### PR TITLE
9 improve deployment ci/cd

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,15 +1,37 @@
 name: Deploy to test.pypi.org
 on:
-  workflow_dispatch:  # manually triggered
-    inputs:
-      devVersionNumber:
-        description: 'Development version number'
-        required: false
-        type: string
+  pull_request:
+    branches:
+      - main    # test-deploy on PRs to main branch (which represent a new release)
 
 jobs:
 
+  check_version_tag_does_not_exist:
+    name: check version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Full checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # fetch all history and tags
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ vars.UV_VERSION }}
+
+      - name: Create tag
+        run: |
+          TAG="v$( uv version --short )"  
+          if git show-ref --tags --verify --quiet "refs/tags/${TAG}"; then
+            echo "Tag ${TAG} already exists --> UNSAFE to merge to main"
+            exit -1
+          else
+            echo "Tag ${TAG} does not exist --> safe to merge to main"
+          fi
+
   unit_test:
+    name: full unit test matrix
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -48,7 +70,7 @@ jobs:
             fi
 
   deploy:
-    name: build & upload release to test.pypi.org (DEV)
+    name: deploy to test.pypi.org (DEV)
     needs: unit_test
     runs-on: ubuntu-latest
     environment: dev
@@ -66,7 +88,7 @@ jobs:
 
       - name: Update version in pyproject.toml
         run: |
-          ver_dev="$(uv version --short).dev${{ github.event.inputs.devVersionNumber || github.run_number }}"
+          ver_dev="$(uv version --short).dev${{ github.run_number }}"
           echo "Updating version to ${ver_dev}"
           uv version "${ver_dev}"
 

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: ${{ vars.UV_VERSION }}
 
       - name: Set up venv, Python ${{ matrix.python-version }} & dependencies
         run:  |
@@ -62,7 +62,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: ${{ vars.UV_VERSION }}
 
       - name: Update version in pyproject.toml
         run: |

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: ${{ vars.UV_VERSION }}
 
       - name: Set up venv, Python ${{ matrix.python-version }} & dependencies
         run:  |
@@ -59,7 +59,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: ${{ vars.UV_VERSION }}
 
       - name: Build package with uv
         run: uv build

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -1,12 +1,40 @@
 name: Deploy to pypi.org
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*.*.*"  # Match version tags like v1.2.3   (as set by the tag_release workflow)
 
 jobs:
 
+  check_tag_version_correct:
+    name: check tag correctness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Full checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # fetch all history and tags
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ vars.UV_VERSION }}
+
+      - name: Check tag
+        run: |
+          EXPECTED_TAG="v$( uv version --short )"  
+          if [ "${GITHUB_REF}" != "refs/tags/${EXPECTED_TAG}" ]; then
+            echo "This workflow was triggered by tag ${GITHUB_REF}, but expected tag is refs/tags/${EXPECTED_TAG}"
+            echo "This means that the tag does not match the current version in pyproject.toml"
+            echo "Please fix this before deploying to production"
+            exit -1
+          else
+            echo "Tag matches the current version in pyproject.toml"
+          fi      
+
   unit_test:
+    name: full unit test matrix
+    needs: check_tag_version_correct
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -45,7 +73,7 @@ jobs:
             fi
 
   deploy:
-    name: build & upload release to pypi.org (PROD)
+    name: deploy to pypi.org (PROD)
     needs: unit_test
     runs-on: ubuntu-latest
     environment: prod

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,33 @@
+name: Tag commit as v<version> if it does not exist
+on:
+  push:
+    branches:
+      - main    # on each push to the main branch, check if this version already has a tag
+
+
+jobs:
+
+  tag_as_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Full checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # fetch all history and tags
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ vars.UV_VERSION }}
+
+      - name: Create tag
+        run: |
+          TAG="v$( uv version --short )"  
+          if git show-ref --tags --verify --quiet "refs/tags/${TAG}"; then
+            echo "Tag ${TAG} already exists --> do not create & fail this step"
+            exit -1
+          else
+            echo "Tag ${TAG} does not exist --> create it now"
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi

--- a/.github/workflows/unit_tests_full.yml
+++ b/.github/workflows/unit_tests_full.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: ${{ vars.UV_VERSION }}
 
       - name: Set up venv, Python ${{ matrix.python-version }} & dependencies
         run:  |

--- a/.github/workflows/unit_tests_full.yml
+++ b/.github/workflows/unit_tests_full.yml
@@ -1,6 +1,7 @@
 name: Unit Tests - Full Matrix
 on:
   pull_request:
+    branches-ignore: ['main']
   workflow_dispatch:
   push:
     branches: ["fix/*"]

--- a/.github/workflows/unit_tests_reduced.yml
+++ b/.github/workflows/unit_tests_reduced.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: ${{ vars.UV_VERSION }}
 
       - name: Set up venv, Python ${{ matrix.python-version }} & dependencies
         run:  |

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.4"
+          version: ${{ vars.UV_VERSION }}
       - name: Update Badge - Tests & Coverage
         run: |
           uv venv


### PR DESCRIPTION
- make deployment to prod be triggered by creating an appropriate tag
  - check if tag corresponds to pyproject.toml version
- auto-tag version upon push to main
- extend checks in PRs to main
  - check if test-deploying works
  - check if version does not have a tag yet