### PR TITLE
Update github actions to make use of admin PAT token.

### DIFF
--- a/.github/actions/badges_and_splash/action.yml
+++ b/.github/actions/badges_and_splash/action.yml
@@ -8,7 +8,7 @@ inputs:
         description: "Version of UV to be used."
     github_token:
         required: true
-        description: "Github token to be used to upload to github pages."
+        description: "Github token to be used to upload to github pages & push updated readme."
 
 
 runs:
@@ -85,5 +85,6 @@ runs:
         run: |
           git config --local user.name "GitHub Actions"
           git config --local user.email ""          
+          git remote set-url origin https://x-access-token:${{ inputs.github_token }}@github.com/bertpl/counted-float.git
           git diff --quiet || (git add "$GITHUB_WORKSPACE/README.md" && git commit -m "Update README.md image URLs")
           git push

--- a/.github/actions/bump_version/action.yml
+++ b/.github/actions/bump_version/action.yml
@@ -6,6 +6,9 @@ inputs:
     uv_version:
         required: true
         description: "Version of UV to be used."
+    github_token:
+        required: true
+        description: "GitHub token with permissions to push to selected branch (git_ref)."
     git_ref:
         required: false
         description: "git ref (tag/commmit/branch) where to bump version  (default: develop)"
@@ -56,7 +59,9 @@ runs:
                 echo "Bumping version ${ver_before} -> ${ver_after}."
           
                 git config --local user.name "GitHub Actions"
-                git config --local user.email ""
+                git config --local user.email ""          
+                git remote set-url origin https://x-access-token:${{ inputs.github_token }}@github.com/bertpl/counted-float.git
+                
                 git add pyproject.toml
                 git commit -m "Bump package version ${ver_before} -> ${ver_after}"
                 git push origin          

--- a/.github/workflows/pull_request_to_main.yml
+++ b/.github/workflows/pull_request_to_main.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: ./.github/actions/badges_and_splash
         with:
           uv_version: ${{ vars.UV_VERSION }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GIT_ADMIN_TOKEN }}
 
 
   publish-to-dev:

--- a/.github/workflows/push_to_develop.yml
+++ b/.github/workflows/push_to_develop.yml
@@ -39,4 +39,4 @@ jobs:
       - uses: ./.github/actions/badges_and_splash
         with:
           uv_version: ${{ vars.UV_VERSION }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GIT_ADMIN_TOKEN }}

--- a/.github/workflows/push_to_main.yml
+++ b/.github/workflows/push_to_main.yml
@@ -98,6 +98,7 @@ jobs:
       - uses: ./.github/actions/bump_version
         with:
           uv_version: ${{ vars.UV_VERSION }}
+          github_token: ${{ secrets.GIT_ADMIN_TOKEN }}
           git_ref: 'develop'
           bump_type: 'patch'
           only_if_equal_to_version: ${{ env.CURRENT_PACKAGE_VERSION }}
@@ -105,4 +106,4 @@ jobs:
       - uses: ./.github/actions/badges_and_splash
         with:
           uv_version: ${{ vars.UV_VERSION }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GIT_ADMIN_TOKEN }}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,7 +16,7 @@
 
 ### Internal
 - CI/CD - Allow manual test deployments
-
+- CI/CD - Use custom PAT for git actions to allow improved rulesets
 
 <!------------------------------------------------------------------------------------------------->
 ## v0.8.3


### PR DESCRIPTION
- this allows github actions to bypass develop rulesets that apply to humans (e.g. allows push to develop without PR).
- this in turn allows us to set the develop ruleset stricter to only allow certain merge types in PRs (squash)