### PR TITLE
Fix off-by-1000x error in cpu frequency on some platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 /
 
 ### Bug Fixes
-- make determining cpu frequency robust to environment that do not provide this info (e.g. some CI/CD runners)
+- make determining cpu frequency robust to environment that do not provide this info (e.g. some CI/CD runners) or in different units (MHz vs GHz)
 
 ### Internal
 /

--- a/counted_float/_core/benchmarking/micro/_micro_benchmark.py
+++ b/counted_float/_core/benchmarking/micro/_micro_benchmark.py
@@ -1,8 +1,13 @@
 from abc import ABC, abstractmethod
 
 from counted_float._core.models import MicroBenchmarkResult, SingleRunResult
-from counted_float._core.utils import Timer, convert_nsecs_to_cycles, format_latency, format_time_duration
-from counted_float._core.utils._cpu_freq import get_cpu_frequency_current
+from counted_float._core.utils import (
+    Timer,
+    convert_nsecs_to_cycles,
+    format_latency,
+    format_time_duration,
+    get_cpu_frequency_mhz_current,
+)
 
 
 # =================================================================================================
@@ -100,7 +105,7 @@ class MicroBenchmark(ABC):
         return SingleRunResult(
             n_executions=n_executions,
             t_nsecs=t.t_elapsed_nsec(),
-            t_cycles=convert_nsecs_to_cycles(nsec=t.t_elapsed_nsec(), cpu_freq_mhz=get_cpu_frequency_current()),
+            t_cycles=convert_nsecs_to_cycles(nsec=t.t_elapsed_nsec(), cpu_freq_mhz=get_cpu_frequency_mhz_current()),
         )
 
     @abstractmethod

--- a/counted_float/_core/models/_flops_benchmark_meta_data.py
+++ b/counted_float/_core/models/_flops_benchmark_meta_data.py
@@ -6,7 +6,7 @@ from importlib.metadata import PackageNotFoundError, version
 import cpuinfo
 import psutil
 
-from counted_float._core.utils._cpu_freq import get_cpu_frequency_min_max
+from counted_float._core.utils import get_cpu_frequency_mhz_max, get_cpu_frequency_mhz_min
 
 from ._base import MyBaseModel
 
@@ -69,8 +69,8 @@ class ProcessorInfo(MyBaseModel):
             ),
             n_logical_core_count=psutil.cpu_count(logical=True),
             n_physical_core_count=psutil.cpu_count(logical=False),
-            min_freq_mhz=int(get_cpu_frequency_min_max()[0]),
-            max_freq_mhz=int(get_cpu_frequency_min_max()[1]),
+            min_freq_mhz=int(get_cpu_frequency_mhz_min()),
+            max_freq_mhz=int(get_cpu_frequency_mhz_max()),
         )
 
 

--- a/counted_float/_core/utils/__init__.py
+++ b/counted_float/_core/utils/__init__.py
@@ -1,3 +1,4 @@
+from ._cpu_freq import get_cpu_frequency_mhz_current, get_cpu_frequency_mhz_max, get_cpu_frequency_mhz_min
 from ._formatting import format_latency, format_time_duration
 from ._geo_mean import geo_mean
 from ._latency import convert_nsecs_to_cycles

--- a/counted_float/_core/utils/_cpu_freq.py
+++ b/counted_float/_core/utils/_cpu_freq.py
@@ -1,17 +1,43 @@
+import math
+
 import psutil
 
 
-def get_cpu_frequency_current() -> float:
-    """Use psutil - with some fallbacks - to determine current CPU frequency in MHz."""
-    try:
-        return psutil.cpu_freq().current
-    except AttributeError:
-        return 1000.0  # fallback to 1000 MHz if psutil cannot provide the info
+# =================================================================================================
+#  Get Min, Max, Current CPU frequency in MHz
+# =================================================================================================
+def get_cpu_frequency_mhz_min() -> float:
+    """Use psutil - with some fallbacks - to determine MIN CPU frequency in MHz."""
+    return _get_psutil_cpu_freq_attribute_mhz("min", fallback=1000.0)
 
 
-def get_cpu_frequency_min_max() -> tuple[float, float]:
-    """Use psutil - with some fallbacks - to determine min, max CPU frequency in MHz."""
+def get_cpu_frequency_mhz_max() -> float:
+    """Use psutil - with some fallbacks - to determine MAX CPU frequency in MHz."""
+    return _get_psutil_cpu_freq_attribute_mhz("max", fallback=1000.0)
+
+
+def get_cpu_frequency_mhz_current() -> float:
+    """Use psutil - with some fallbacks - to determine CURRENT CPU frequency in MHz."""
+    return _get_psutil_cpu_freq_attribute_mhz("current", fallback=1000.0)
+
+
+# =================================================================================================
+#  Internal helper
+# =================================================================================================
+def _get_psutil_cpu_freq_attribute_mhz(att_name: str, fallback: float) -> float:
+    """Helper to get an attribute from psutil.cpu_freq(), with a fallback value & heuristics to distinguish Mhz & GHz"""
     try:
-        return psutil.cpu_freq().min, psutil.cpu_freq().max
+        value = getattr(psutil.cpu_freq(), att_name)
     except AttributeError:
-        return 0.0, 1000.0  # fallback to (0 - 1000) MHz if psutil cannot provide the info
+        value = 0.0
+
+    if (value is None) or (value <= 0.0):
+        return fallback
+    else:
+        valid_range_min_mhz = 2000 / math.sqrt(1000)  # ~ 63 MHz
+        valid_range_max_mhz = 2000 * math.sqrt(1000)  # ~ 63 GHz
+        while value < valid_range_min_mhz:
+            value *= 1000.0
+        while value > valid_range_max_mhz:
+            value /= 1000.0
+        return value


### PR DESCRIPTION
- Addresses #109 
- This happens on Apple M4 & above, where cpu freq. is reported by `psutil` in GHz instead of MHz due to underlying platform changes
