### PR TITLE
fix: correct stale docstrings, defensive-copy cached flop weights, cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - importing `counted_float` no longer monkey-patches the `math` module; patches now apply only while a `FlopCountingContext` is active
 
 ### Bug Fixes
-- built-in flop-weight getters return defensive copies, so mutating a returned object can no longer corrupt shared state
+- flop-weight getters (built-in & configured) return deep defensive copies, so mutating a returned object can no longer corrupt shared state
 
 ### Internal
 - remove undocumented `CountedFloat.get_global_flop_counts()` (read counts through a `FlopCountingContext` instead)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@
 - importing `counted_float` no longer monkey-patches the `math` module; patches now apply only while a `FlopCountingContext` is active
 
 ### Bug Fixes
-/
+- built-in flop-weight getters return defensive copies, so mutating a returned object can no longer corrupt shared state
 
 ### Internal
-/
+- remove undocumented `CountedFloat.get_global_flop_counts()` (read counts through a `FlopCountingContext` instead)
 
 <!------------------------------------------------------------------------------------------------->
 > ## v1.0.5

--- a/counted_float/_core/benchmarking/counted_float/_counted_float_benchmark.py
+++ b/counted_float/_core/benchmarking/counted_float/_counted_float_benchmark.py
@@ -42,6 +42,8 @@ class BenchmarkFloat(MicroBenchmark):
             # using standard float() arithmetic
             a = -1e50
             b = 1e50
+            # NOTE: fa/fb are never read (the loop re-evaluates fmid instead); they are kept
+            #       on purpose so the kernel mimics a realistic bisection workload
             fa = _zero_function(a)
             fb = _zero_function(b)
             while b - a > 1e-15:
@@ -70,6 +72,8 @@ class BenchmarkCountedFloat(MicroBenchmark):
             # which will make sure all the remaining operations are also executed using CountedFloat arithmetic
             a = CountedFloat(-1e50)
             b = CountedFloat(1e50)
+            # NOTE: fa/fb are never read (the loop re-evaluates fmid instead); they are kept
+            #       on purpose so the kernel mimics a realistic bisection workload
             fa = _zero_function(a)
             fb = _zero_function(b)
             while b - a > 1e-15:

--- a/counted_float/_core/counting/_builtin_data.py
+++ b/counted_float/_core/counting/_builtin_data.py
@@ -40,7 +40,7 @@ class BuiltInData:
             raise ValueError(f"No built-in flop weights found for key_filter='{key_filter}'")
         else:
             nested_flop_weights_dict = _flat_to_nested_dict(flat_flop_weights_dict)
-            return _computed_nested_average_flop_weights(nested_flop_weights_dict)
+            return _compute_nested_average_flop_weights(nested_flop_weights_dict)
 
     @classmethod
     def get_flop_weights_dict(cls, key_filter: str = "") -> dict[str, FlopWeights]:
@@ -86,11 +86,11 @@ class BuiltInData:
 # =================================================================================================
 #  Utilities
 # =================================================================================================
-def _computed_nested_average_flop_weights(nested_flop_weights_dict: dict[str, dict | FlopWeights]) -> FlopWeights:
+def _compute_nested_average_flop_weights(nested_flop_weights_dict: dict[str, dict | FlopWeights]) -> FlopWeights:
     # make sure all values of the dict are FlopWeights instances
     for key, value in nested_flop_weights_dict.items():
         if isinstance(value, dict):
-            nested_flop_weights_dict[key] = _computed_nested_average_flop_weights(value)
+            nested_flop_weights_dict[key] = _compute_nested_average_flop_weights(value)
 
     # now we can average all FlopWeights instances
     return FlopWeights.as_geo_mean(list(nested_flop_weights_dict.values()))
@@ -120,10 +120,6 @@ def _load_json_files_as_dict(resource_root) -> dict[str, str]:
     Example keys: 'benchmarks.arm.apple_m4_pro'
                   'specs.x86.intel_core_i9_13900k'
     """
-
-    # allow both plain & recursive calls
-    # if resource_root is None:
-    #     resource_root = files("counted_float._core.data")
 
     # crawl entire folder structure
     result = {}
@@ -211,6 +207,7 @@ class FlopWeightsTreeView:
                         child.lst_is_leaf,
                         child.lst_tree_str,
                         child.lst_flop_weights,
+                        strict=True,
                     )
                 ):
                     self.lst_indent.append(1 + indent)
@@ -238,7 +235,6 @@ class FlopWeightsTreeView:
         tree_width = 5 + max([len(line) for line in self.lst_tree_str])
         col_width = 10
         sorted_flop_types = self.lst_flop_weights[0].get_sorted_flop_types()
-        max_indent = max(self.lst_indent)
 
         n_cols_per_block = max(1, int((console_width - tree_width) / col_width))
         flop_types_per_block = [
@@ -260,6 +256,7 @@ class FlopWeightsTreeView:
                 self.lst_is_leaf,
                 self.lst_tree_str,
                 self.lst_flop_weights,
+                strict=True,
             ):
                 line = tree_str.ljust(tree_width)
                 for flop_type in flop_types:

--- a/counted_float/_core/counting/_context_managers.py
+++ b/counted_float/_core/counting/_context_managers.py
@@ -16,10 +16,6 @@ class FlopCountingContext:
     Context manager that can be used to count FLOP operations in a block of code.  Only floating-point
     operations of CountedFloat objects are counted.  So make sure all math uses this type.
 
-    Flops need to be registered by either of the following:
-      - calls to register_flops(...)
-      - using CountedFloat() objects in the computations
-
     LIMITATIONS:
         - this context manager is not thread-safe
         - not _all_ floating-point operations are counted, see the docs for more details.

--- a/counted_float/_core/counting/_counted_float.py
+++ b/counted_float/_core/counting/_counted_float.py
@@ -1,21 +1,9 @@
 from __future__ import annotations
 
-from counted_float._core.models import FlopCounts
-
 from ._global_counter import GLOBAL_COUNTER
 
 
 class CountedFloat(float):
-    # -------------------------------------------------------------------------
-    #  FLOP COUNTING
-    # -------------------------------------------------------------------------
-    @classmethod
-    def get_global_flop_counts(cls) -> FlopCounts:
-        """
-        Returns the global FLOP counts for all CountedFloat instances.
-        """
-        return GLOBAL_COUNTER.flop_counts()
-
     # -------------------------------------------------------------------------
     #  CONSTRUCTOR
     # -------------------------------------------------------------------------

--- a/counted_float/_core/counting/config/_config.py
+++ b/counted_float/_core/counting/config/_config.py
@@ -32,8 +32,9 @@ class Config:
     def get_flop_weights(cls) -> FlopWeights:
         """
         Get the currently configured flop weights.
+        Returns a fresh deep copy; mutating it does not affect the configured weights.
         """
-        return cls.__weights.model_copy()
+        return cls.__weights.model_copy(deep=True)
 
 
 # =================================================================================================

--- a/counted_float/_core/counting/config/_defaults.py
+++ b/counted_float/_core/counting/config/_defaults.py
@@ -5,16 +5,15 @@ from counted_float._core.counting._builtin_data import BuiltInData
 from counted_float._core.models import FlopWeights
 
 
-@cache
 def get_default_consensus_flop_weights(rounding_mode: None | Literal["nearest_int", "10%"] = "10%") -> FlopWeights:
     """
     Get the default CONSENSUS flop weights.
     Computed as the geo-mean of the unrounded empirical and theoretical weights, rounded to the nearest integer.
+    Returns a fresh copy; mutating it does not affect later calls.
     """
     return get_builtin_flop_weights(key_filter="", rounding_mode=rounding_mode)
 
 
-@cache
 def get_builtin_flop_weights(
     key_filter: str = "",
     rounding_mode: None | Literal["nearest_int", "10%"] = "10%",
@@ -27,8 +26,17 @@ def get_builtin_flop_weights(
                        x86-related flop weights.
     :param rounding_mode: (str, default="10%") rounding mode (None, "nearest_int", "10%").
     :return: A FlopWeights instance computed as the (hierarchical) geo-mean of all matching built-in data.
+             A fresh copy on every call; mutating it does not corrupt the underlying cache.
     :raises ValueError: If no built-in data matches the given key_filter.
     """
+    return _get_builtin_flop_weights_cached(key_filter, rounding_mode).model_copy(deep=True)
+
+
+@cache
+def _get_builtin_flop_weights_cached(
+    key_filter: str,
+    rounding_mode: None | Literal["nearest_int", "10%"],
+) -> FlopWeights:
     weights = BuiltInData.get_flop_weights(key_filter=key_filter)
     if rounding_mode is not None:
         return weights.round(mode=rounding_mode)

--- a/counted_float/_core/models/_flop_weights.py
+++ b/counted_float/_core/models/_flop_weights.py
@@ -42,7 +42,7 @@ class FlopWeights(MyBaseModel):
 
     def get_sorted_flop_types(self) -> list[FlopType]:
         """Return flop types sorted in ascending order of corresponding weights."""
-        sorted_flop_weights_and_types = sorted(zip(self.weights.values(), self.weights.keys()))
+        sorted_flop_weights_and_types = sorted(zip(self.weights.values(), self.weights.keys(), strict=True))
         return [flop_type for _, flop_type in sorted_flop_weights_and_types]
 
     # -------------------------------------------------------------------------
@@ -112,7 +112,7 @@ class FlopWeights(MyBaseModel):
     def from_abs_flop_costs(cls, flop_costs: dict[FlopType, float]) -> FlopWeights:
         """
         Computes FlopWeights based on absolute costs (in clock cycles, nanoseconds, ...) of each flop type.
-        As a reference duration, we take the geometric mean of the costs for EQUALS, ADD, SUB, and MUL operations.
+        As a reference duration, we take the cost of the ADD operation.
         """
 
         # step 1) compute reference duration based on 1 simple flop type (SUB, MUL and a few others are usually very close)

--- a/counted_float/_core/utils/_geo_mean.py
+++ b/counted_float/_core/utils/_geo_mean.py
@@ -2,7 +2,7 @@ import math
 
 
 def geo_mean(values: list[float | int]) -> float:
-    """Take geometric mean of list of values, returning None if any value is None or list is empty."""
+    """Take geometric mean of list of values, returning 0.0 for an empty list; nan values propagate (nan in -> nan out)."""
     if len(values) == 0:
         return 0.0
     else:

--- a/tests/counting/config/test_config.py
+++ b/tests/counting/config/test_config.py
@@ -31,3 +31,13 @@ def test_flop_weight_config(getter, setter):
     assert flop_weights_b != flop_weights_c
     assert flop_weights_b == dummy_flop_weights_1
     assert flop_weights_c == dummy_flop_weights_2
+
+
+@pytest.mark.parametrize("getter", [get_active_flop_weights, Config.get_flop_weights])
+def test_flop_weight_getters_return_defensive_copies(getter):
+    # --- act ---------------------------------------------
+    flop_weights = getter()
+    flop_weights.weights[FlopType.ADD] = -12345.0  # mutate the returned object
+
+    # --- assert ------------------------------------------
+    assert getter().weights[FlopType.ADD] != -12345.0

--- a/tests/counting/config/test_defaults.py
+++ b/tests/counting/config/test_defaults.py
@@ -2,8 +2,8 @@ import math
 
 import pytest
 
-from counted_float._core.counting.config._defaults import get_default_consensus_flop_weights
-from counted_float._core.models import FlopWeights
+from counted_float._core.counting.config._defaults import get_builtin_flop_weights, get_default_consensus_flop_weights
+from counted_float._core.models import FlopType, FlopWeights
 
 
 @pytest.mark.parametrize("rounding_mode", [None, "nearest_int", "10%"])
@@ -25,3 +25,13 @@ def test_default_flop_weights_rounding(rounding_mode: str):
 
     # --- assert ------------------------------------------
     assert rounded.weights == unrounded.round(rounding_mode).weights
+
+
+@pytest.mark.parametrize("getter", [get_builtin_flop_weights, get_default_consensus_flop_weights])
+def test_builtin_flop_weight_getters_return_defensive_copies(getter):
+    # --- act ---------------------------------------------
+    flop_weights = getter()
+    flop_weights.weights[FlopType.ADD] = -12345.0  # mutate the returned object
+
+    # --- assert ------------------------------------------
+    assert getter().weights[FlopType.ADD] != -12345.0

--- a/tests/counting/test_counted_float.py
+++ b/tests/counting/test_counted_float.py
@@ -4,7 +4,6 @@ from typing import Callable
 import pytest
 
 from counted_float._core.counting._counted_float import CountedFloat
-from counted_float._core.models import FlopCounts
 
 
 # =================================================================================================
@@ -475,21 +474,6 @@ def test_counted_float_math_log2(global_counter, f: float):
 # =================================================================================================
 #  CountedFloat - Correct integration with GLOBAL_COUNTER
 # =================================================================================================
-def test_counted_float_get_global_flop_counts(global_counter):
-    # --- arrange -----------------------------------------
-    global_counter.incr_add()
-    global_counter.incr_add()
-
-    # --- act ---------------------------------------------
-    global_flop_counts = CountedFloat.get_global_flop_counts()
-    global_counter.incr_add()  # to double-check we get a copy
-
-    # --- assert ------------------------------------------
-    assert isinstance(global_flop_counts, FlopCounts)
-    assert global_flop_counts.total_count() == 2
-    assert global_flop_counts.ADD == 2
-
-
 @pytest.mark.parametrize(
     "value, expected_n_i2f",
     [


### PR DESCRIPTION
Cleanup round from a recent code review:

- `geo_mean` and `from_abs_flop_costs` docstrings described behavior the code doesn't have (None-handling that doesn't exist; a geo-mean reference the code replaced with plain ADD cost) — rewritten to match reality. A `FlopCountingContext` docstring reference to a nonexistent `register_flops(...)` is gone too.
- The `@cache`-d built-in flop-weight getters handed out shared mutable objects: mutating a returned `FlopWeights` corrupted the cache for every later caller. They now return deep copies.
- Removed the undocumented `CountedFloat.get_global_flop_counts()` — counts are read through a `FlopCountingContext`.
- Cosmetics: dead local, commented-out code, internal-name typo, `zip(strict=True)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)