### PR TITLE
chore: expand ruff rule set from isort-only to the full lint family set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Internal
 - add pre-commit hooks (ruff, file hygiene, codespell, actionlint, conventional commit messages) + `make lint`
+- expand ruff rule set from isort-only to the full lint family set
 
 <!------------------------------------------------------------------------------------------------->
 > ## v1.1.0

--- a/counted_float/__init__.py
+++ b/counted_float/__init__.py
@@ -5,8 +5,6 @@ from ._core.counting import BuiltInData, CountedFloat, FlopCountingContext, Paus
 from ._core.models import FlopCounts, FlopType, FlopWeights, Quantiles, SystemInfo
 
 __all__ = [
-    "benchmarking",
-    "config",
     "CountedFloat",
     "FlopCountingContext",
     "FlopCounts",
@@ -15,4 +13,6 @@ __all__ = [
     "PauseFlopCounting",
     "Quantiles",
     "SystemInfo",
+    "benchmarking",
+    "config",
 ]

--- a/counted_float/_core/benchmarking/counted_float/_counted_float_benchmark.py
+++ b/counted_float/_core/benchmarking/counted_float/_counted_float_benchmark.py
@@ -51,10 +51,10 @@ class BenchmarkFloat(MicroBenchmark):
                 fmid = _zero_function(mid)
                 if fmid < 0:
                     a = mid
-                    fa = fmid
+                    fa = fmid  # noqa: F841
                 else:
                     b = mid
-                    fb = fmid
+                    fb = fmid  # noqa: F841
 
 
 class BenchmarkCountedFloat(MicroBenchmark):
@@ -81,7 +81,7 @@ class BenchmarkCountedFloat(MicroBenchmark):
                 fmid = _zero_function(mid)
                 if fmid < 0:
                     a = mid
-                    fa = fmid
+                    fa = fmid  # noqa: F841
                 else:
                     b = mid
-                    fb = fmid
+                    fb = fmid  # noqa: F841

--- a/counted_float/_core/benchmarking/flops/_array_generator.py
+++ b/counted_float/_core/benchmarking/flops/_array_generator.py
@@ -66,10 +66,10 @@ def _random_balanced_values(size: int) -> np.ndarray:
     """
     cumsum = 0.0
     lst = []
-    for i in range(size - 1):
+    for _i in range(size - 1):
         next_min_value = max(-1.0, -1.0 - cumsum)
         next_max_value = min(1.0, 1.0 - cumsum)
-        next_value = random.uniform(next_min_value, next_max_value)
+        next_value = random.uniform(next_min_value, next_max_value)  # noqa: S311 -- benchmark data, not crypto
         lst.append(next_value)
         cumsum += next_value
     lst.append(-cumsum)

--- a/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
+++ b/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
@@ -44,7 +44,9 @@ class FlopsBenchmarkSuite:
         print()
         print(f"Running FLOPS benchmarks using counted-float {version('counted-float')} ...")
         print(
-            f"(Expected duration: ~{(n_runs_total - n_runs_warmup / 2) * n_seconds_per_run_target * len(FlopsBenchmarkType):.1f} seconds)"
+            f"(Expected duration: "
+            f"~{(n_runs_total - n_runs_warmup / 2) * n_seconds_per_run_target * len(FlopsBenchmarkType):.1f}"
+            f" seconds)"
         )
         print()
 
@@ -111,7 +113,7 @@ class FlopsBenchmarkSuite:
     #  Static methods
     # -------------------------------------------------------------------------
     @staticmethod
-    def get_flops_benchmarking_suite(size: int) -> dict[FlopsBenchmarkType, FlopsMicroBenchmark]:
+    def get_flops_benchmarking_suite(size: int) -> dict[FlopsBenchmarkType, FlopsMicroBenchmark]:  # noqa: C901 -- flat registry of per-flop-type jit kernels
         """
         Returns a benchmark for each FlopsBenchmarkType, of requested array size.
         """
@@ -334,7 +336,7 @@ class FlopsBenchmarkSuite:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
-                    if tmp >= in_f[i]:
+                    if tmp >= in_f[i]:  # noqa: SIM108 -- timed kernel: keep the branchy shape being measured
                         tmp = tmp - in_f[i]
                     else:
                         tmp = tmp + in_f[i]

--- a/counted_float/_core/benchmarking/flops/_flops_micro_benchmark.py
+++ b/counted_float/_core/benchmarking/flops/_flops_micro_benchmark.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 
@@ -24,7 +24,8 @@ class FlopsMicroBenchmark(MicroBenchmark):
          - the function should be implemented such that it does not use vectorized operations, we want to avoid
              using vectorized CPU instructions (AVX, etc...): we want to measure the speed of the regular, scalar
              operations
-         - the function should be implemented such that the floating point operations form dependent chains of operations,
+         - the function should be implemented such that the floating point operations form dependent chains
+           of operations,
             to avoid the out-of-order superscalar nature of most modern CPUs to manage to run certain operations
             (partially or fully) in parallel.
          - we numba.jit the function, to make sure it is compiled to machine code, to avoid Python overhead to dominate

--- a/counted_float/_core/benchmarking/micro/_micro_benchmark.py
+++ b/counted_float/_core/benchmarking/micro/_micro_benchmark.py
@@ -42,7 +42,8 @@ class MicroBenchmark(ABC):
         :param n_runs_total: (int, default=20) total number of benchmark_runs runs
         :param n_runs_warmup: (int, default=5) number of warmup_runs runs
                                              - the first n_runs_warmup of n_runs_total are not included in timing stats
-                                             - warmup_runs runs serve to initialize n_executions & get processor, cache, ...
+                                             - warmup_runs runs serve to initialize n_executions & get processor,
+                                               cache, ...
                                                  in a stable, representative state
         :param n_seconds_per_run_target: (float, default=0.5) target time (sec) per benchmark_runs run (prepare + run).
                                              n_executions will be iteratively adjusted to achieve this target time.
@@ -92,7 +93,8 @@ class MicroBenchmark(ABC):
         return benchmark_result
 
     def run_once(self, n_executions: int) -> SingleRunResult:
-        """Runs benchmark_runs once for a given # of executions and returns time in nanoseconds & cpu cycles per execution"""
+        """Runs benchmark_runs once for a given # of executions and returns time in nanoseconds & cpu cycles
+        per execution."""
 
         # prepare
         self._prepare_benchmark(n_executions)
@@ -111,7 +113,8 @@ class MicroBenchmark(ABC):
     @abstractmethod
     def _prepare_benchmark(self, n_executions: int):
         """
-        Prepare benchmark_runs (e.g. set up data) based on requested number of executions.  This argument is adjusted each
+        Prepare benchmark_runs (e.g. set up data) based on requested number of executions.  This argument is
+        adjusted each
           run by the MicroBenchmarkRunner class to ensure that the benchmark_runs runs for a reasonable amount of time
             (e.g. 1 second per run).
         """

--- a/counted_float/_core/compatibility/_numba.py
+++ b/counted_float/_core/compatibility/_numba.py
@@ -11,12 +11,12 @@ except ImportError:
         if len(args) == 1 and isinstance(args[0], Callable):
             # decorator used without arguments
             return args[0]
-        else:
-            # decorator used with arguments
-            def decorator(func):
-                return func
 
-            return decorator
+        # decorator used with arguments
+        def decorator(func):
+            return func
+
+        return decorator
 
     # create a dummy numba object with numba.jit and numba.njit dummy decorators
     class Numba:

--- a/counted_float/_core/counting/_builtin_data.py
+++ b/counted_float/_core/counting/_builtin_data.py
@@ -38,9 +38,8 @@ class BuiltInData:
         flat_flop_weights_dict = cls.get_flop_weights_dict(key_filter)
         if len(flat_flop_weights_dict) == 0:
             raise ValueError(f"No built-in flop weights found for key_filter='{key_filter}'")
-        else:
-            nested_flop_weights_dict = _flat_to_nested_dict(flat_flop_weights_dict)
-            return _compute_nested_average_flop_weights(nested_flop_weights_dict)
+        nested_flop_weights_dict = _flat_to_nested_dict(flat_flop_weights_dict)
+        return _compute_nested_average_flop_weights(nested_flop_weights_dict)
 
     @classmethod
     def get_flop_weights_dict(cls, key_filter: str = "") -> dict[str, FlopWeights]:
@@ -106,7 +105,7 @@ def _flat_to_nested_dict(flat_dict: dict) -> dict:
         keys = flat_key.split(".")
         d = nested_dict
         for key in keys[:-1]:
-            d = d.setdefault(key, dict())
+            d = d.setdefault(key, {})
         d[keys[-1]] = value
     return nested_dict
 
@@ -156,8 +155,7 @@ def _deserialize_as_any_pydantic_class(json_str: str, pydantic_classes: list[typ
     # try all supported classes
     for pydantic_cls in pydantic_classes:
         try:
-            obj = pydantic_cls.model_validate_json(json_str)
-            return obj
+            return pydantic_cls.model_validate_json(json_str)
         except ValidationError:
             continue
 

--- a/counted_float/_core/counting/_context_managers.py
+++ b/counted_float/_core/counting/_context_managers.py
@@ -46,8 +46,7 @@ class FlopCountingContext:
         """Returns current total flop count for this context manager.  See constructor comments for details."""
         if self.__active:
             return GLOBAL_COUNTER.flop_counts() - self.__cnt_start_snapshot
-        else:
-            return self.__cnt_subtotal.copy()
+        return self.__cnt_subtotal.copy()
 
     # -------------------------------------------------------------------------
     #  Pause/Resume

--- a/counted_float/_core/counting/_counted_float.py
+++ b/counted_float/_core/counting/_counted_float.py
@@ -10,8 +10,7 @@ class CountedFloat(float):
     def __new__(cls, value: float | int):
         if isinstance(value, int):
             GLOBAL_COUNTER.incr_i2f()
-        self = super().__new__(cls, float(value))
-        return self
+        return super().__new__(cls, float(value))
 
     def __str__(self):
         return self.__repr__()

--- a/counted_float/_core/counting/_global_counter.py
+++ b/counted_float/_core/counting/_global_counter.py
@@ -42,8 +42,7 @@ class GlobalFlopCounter:
         # provide shorthand access to the counts
         if item in FlopCounts.field_names():
             return getattr(self.__counts, item)
-        else:
-            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{item}'")
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{item}'")
 
     # -------------------------------------------------------------------------
     #  Incrementing counts

--- a/counted_float/_core/counting/_math_patching.py
+++ b/counted_float/_core/counting/_math_patching.py
@@ -55,19 +55,17 @@ def math_sqrt(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
         GLOBAL_COUNTER.incr_sqrt()
         return CountedFloat(original_math_sqrt(x))
-    else:
-        return original_math_sqrt(x)
+    return original_math_sqrt(x)
 
 
 def math_cbrt(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
         GLOBAL_COUNTER.incr_cbrt()
         return CountedFloat(original_math_cbrt(x))
-    else:
-        return original_math_cbrt(x)
+    return original_math_cbrt(x)
 
 
-def math_log(x: float, base=_NO_BASE) -> float | CountedFloat:
+def math_log(x: float, base=_NO_BASE) -> float | CountedFloat:  # noqa: C901 -- branches mirror the per-log-variant counting rules
     """
     Patched math.log: stdlib contract (optional base), with flop classification for the base
     following the same constant-detection heuristic as CountedFloat.__pow__ / __rpow__
@@ -85,64 +83,57 @@ def math_log(x: float, base=_NO_BASE) -> float | CountedFloat:
         if isinstance(x, CountedFloat):
             GLOBAL_COUNTER.incr_log()
             return CountedFloat(original_math_log(x))
-        else:
-            return original_math_log(x)
+        return original_math_log(x)
+    # computed first: raises per stdlib contract before anything is counted
+    result = original_math_log(x, base)
+    if isinstance(base, int) and base == 2:
+        if isinstance(x, CountedFloat):
+            GLOBAL_COUNTER.incr_log2()
+    elif isinstance(base, int) and base == 10:
+        if isinstance(x, CountedFloat):
+            GLOBAL_COUNTER.incr_log10()
+    elif isinstance(base, int):
+        if isinstance(x, CountedFloat):
+            GLOBAL_COUNTER.incr_log()
+            GLOBAL_COUNTER.incr_mul()
     else:
-        # computed first: raises per stdlib contract before anything is counted
-        result = original_math_log(x, base)
-        if isinstance(base, int) and base == 2:
-            if isinstance(x, CountedFloat):
-                GLOBAL_COUNTER.incr_log2()
-        elif isinstance(base, int) and base == 10:
-            if isinstance(x, CountedFloat):
-                GLOBAL_COUNTER.incr_log10()
-        elif isinstance(base, int):
-            if isinstance(x, CountedFloat):
-                GLOBAL_COUNTER.incr_log()
-                GLOBAL_COUNTER.incr_mul()
-        else:
-            if isinstance(x, CountedFloat):
-                GLOBAL_COUNTER.incr_log()
-            if isinstance(base, CountedFloat):
-                GLOBAL_COUNTER.incr_log()
-            if isinstance(x, CountedFloat) or isinstance(base, CountedFloat):
-                GLOBAL_COUNTER.incr_div()
+        if isinstance(x, CountedFloat):
+            GLOBAL_COUNTER.incr_log()
+        if isinstance(base, CountedFloat):
+            GLOBAL_COUNTER.incr_log()
         if isinstance(x, CountedFloat) or isinstance(base, CountedFloat):
-            return CountedFloat(result)
-        else:
-            return result
+            GLOBAL_COUNTER.incr_div()
+    if isinstance(x, CountedFloat) or isinstance(base, CountedFloat):
+        return CountedFloat(result)
+    return result
 
 
 def math_log2(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
         GLOBAL_COUNTER.incr_log2()
         return CountedFloat(original_math_log2(x))
-    else:
-        return original_math_log2(x)
+    return original_math_log2(x)
 
 
 def math_log10(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
         GLOBAL_COUNTER.incr_log10()
         return CountedFloat(original_math_log10(x))
-    else:
-        return original_math_log10(x)
+    return original_math_log10(x)
 
 
 def math_exp(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
         GLOBAL_COUNTER.incr_exp()
         return CountedFloat(original_math_exp(x))
-    else:
-        return original_math_exp(x)
+    return original_math_exp(x)
 
 
 def math_exp2(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
         GLOBAL_COUNTER.incr_exp2()
         return CountedFloat(original_math_exp2(x))
-    else:
-        return original_math_exp2(x)
+    return original_math_exp2(x)
 
 
 def math_pow(x: float, y: float) -> float | CountedFloat:
@@ -172,32 +163,28 @@ def math_pow(x: float, y: float) -> float | CountedFloat:
                     GLOBAL_COUNTER.incr_i2f()
                 GLOBAL_COUNTER.incr_pow()
         return CountedFloat(result)
-    else:
-        return original_math_pow(x, y)
+    return original_math_pow(x, y)
 
 
 def math_sin(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
         GLOBAL_COUNTER.incr_sin()
         return CountedFloat(original_math_sin(x))
-    else:
-        return original_math_sin(x)
+    return original_math_sin(x)
 
 
 def math_cos(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
         GLOBAL_COUNTER.incr_cos()
         return CountedFloat(original_math_cos(x))
-    else:
-        return original_math_cos(x)
+    return original_math_cos(x)
 
 
 def math_tan(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
         GLOBAL_COUNTER.incr_tan()
         return CountedFloat(original_math_tan(x))
-    else:
-        return original_math_tan(x)
+    return original_math_tan(x)
 
 
 # -------------------------------------------------------------------------

--- a/counted_float/_core/counting/config/_defaults.py
+++ b/counted_float/_core/counting/config/_defaults.py
@@ -40,5 +40,4 @@ def _get_builtin_flop_weights_cached(
     weights = BuiltInData.get_flop_weights(key_filter=key_filter)
     if rounding_mode is not None:
         return weights.round(mode=rounding_mode)
-    else:
-        return weights
+    return weights

--- a/counted_float/_core/models/_flop_counts.py
+++ b/counted_float/_core/models/_flop_counts.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import dataclasses
+from typing import TYPE_CHECKING
 
 from ._flop_type import FlopType
-from ._flop_weights import FlopWeights
+
+if TYPE_CHECKING:
+    from ._flop_weights import FlopWeights
 
 
 @dataclasses.dataclass(slots=True)

--- a/counted_float/_core/models/_flop_weights.py
+++ b/counted_float/_core/models/_flop_weights.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Iterable, Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from pydantic import field_serializer, field_validator
@@ -10,6 +10,9 @@ from counted_float._core.utils import geo_mean, impute_missing_data, round_numbe
 
 from ._base import MyBaseModel
 from ._flop_type import FlopType
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class FlopWeights(MyBaseModel):
@@ -29,12 +32,9 @@ class FlopWeights(MyBaseModel):
             return FlopWeights(
                 weights={k: math.nan if math.isnan(v) else max(1, round(v)) for k, v in self.weights.items()},
             )
-        else:
-            return FlopWeights(
-                weights={
-                    k: math.nan if math.isnan(v) else round_number(v, mode="10%") for k, v in self.weights.items()
-                },
-            )
+        return FlopWeights(
+            weights={k: math.nan if math.isnan(v) else round_number(v, mode="10%") for k, v in self.weights.items()},
+        )
 
     def has_missing_data(self) -> bool:
         """Check if any flop type has missing data (i.e. weight is NaN)."""
@@ -91,11 +91,7 @@ class FlopWeights(MyBaseModel):
                 w[i_row, i_col] = fw.weights[flop_type]
 
         # --- fill missing data ---------------------------
-        if (
-            fill_missing_data
-            and (len(all_flop_weights) > 1)
-            and any([fw.has_missing_data() for fw in all_flop_weights])
-        ):
+        if fill_missing_data and (len(all_flop_weights) > 1) and any(fw.has_missing_data() for fw in all_flop_weights):
             w = impute_missing_data(w)
 
         # --- compute geo_mean ----------------------------
@@ -115,7 +111,8 @@ class FlopWeights(MyBaseModel):
         As a reference duration, we take the cost of the ADD operation.
         """
 
-        # step 1) compute reference duration based on 1 simple flop type (SUB, MUL and a few others are usually very close)
+        # step 1) compute reference duration based on 1 simple flop type
+        #         (SUB, MUL and a few others are usually very close)
         ref_cost = flop_costs[FlopType.ADD]
 
         # step 2) normalize and construct FlopWeights object

--- a/counted_float/_core/models/_instruction_latencies.py
+++ b/counted_float/_core/models/_instruction_latencies.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import math
-from typing import Annotated, Literal, Union
+from typing import Annotated, Literal
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from ._base import MyBaseModel
 from ._flop_type import FlopType
@@ -37,7 +37,7 @@ class Latency(MyBaseModel):
 # =================================================================================================
 #  InstructionLatencies - SSE2
 # =================================================================================================
-class InstructionLatencies_SSE2(MyBaseModel):
+class InstructionLatencies_SSE2(MyBaseModel):  # noqa: N801 -- established public API name
     # SEE: https://github.com/bertpl/counted-float/tree/develop/counted_float/data/fpu_data_sources.md
 
     # --- primary fields ----------------------------------
@@ -79,7 +79,7 @@ class InstructionLatencies_SSE2(MyBaseModel):
 # =================================================================================================
 #  InstructionLatencies - ARM
 # =================================================================================================
-class InstructionLatencies_ARM(MyBaseModel):
+class InstructionLatencies_ARM(MyBaseModel):  # noqa: N801 -- established public API name
     # SEE: https://github.com/bertpl/counted-float/tree/develop/counted_float/data/fpu_data_sources.md
 
     # --- primary fields ----------------------------------
@@ -122,12 +122,9 @@ class InstructionLatencies_ARM(MyBaseModel):
 #  Union Class
 # =================================================================================================
 class InstructionLatencies(MyBaseModel):
-    notes: list[str] | None = [""]
+    notes: list[str] | None = [""]  # noqa: RUF012 -- pydantic deep-copies field defaults per instance
     latencies: Annotated[
-        Union[
-            InstructionLatencies_SSE2,
-            InstructionLatencies_ARM,
-        ],
+        InstructionLatencies_SSE2 | InstructionLatencies_ARM,
         Field(discriminator="architecture"),
     ]
 

--- a/counted_float/_core/utils/_cpu_freq.py
+++ b/counted_float/_core/utils/_cpu_freq.py
@@ -36,11 +36,10 @@ def _get_psutil_cpu_freq_attribute_mhz(att_name: str) -> float | None:
 
     if (value is None) or (value <= 0.0):
         return None
-    else:
-        valid_range_min_mhz = 2000 / math.sqrt(1000)  # ~ 63 MHz
-        valid_range_max_mhz = 2000 * math.sqrt(1000)  # ~ 63 GHz
-        while value < valid_range_min_mhz:
-            value *= 1000.0
-        while value > valid_range_max_mhz:
-            value /= 1000.0
-        return value
+    valid_range_min_mhz = 2000 / math.sqrt(1000)  # ~ 63 MHz
+    valid_range_max_mhz = 2000 * math.sqrt(1000)  # ~ 63 GHz
+    while value < valid_range_min_mhz:
+        value *= 1000.0
+    while value > valid_range_max_mhz:
+        value /= 1000.0
+    return value

--- a/counted_float/_core/utils/_formatting.py
+++ b/counted_float/_core/utils/_formatting.py
@@ -4,12 +4,11 @@
 def format_time_duration(nsec: float) -> str:
     if nsec < 1e3:
         return _format_nsec_as_ns(nsec)
-    elif nsec < 1e6:
+    if nsec < 1e6:
         return _format_nsec_as_us(nsec)
-    elif nsec < 1e9:
+    if nsec < 1e9:
         return _format_nsec_as_ms(nsec)
-    else:
-        return _format_nsec_as_s(nsec) + " "  # add trailing whitespace to right-align well with other cases
+    return _format_nsec_as_s(nsec) + " "  # add trailing whitespace to right-align well with other cases
 
 
 def _format_nsec_as_ns(nsec: float) -> str:
@@ -34,15 +33,14 @@ def _format_nsec_as_s(nsec: float) -> str:
 def format_latency(n_cycles: float) -> str:
     if round(n_cycles, 2) < 10:
         return f" {n_cycles:4.2f} cpu cycles"
-    elif round(n_cycles, 1) < 100:
+    if round(n_cycles, 1) < 100:
         return f" {n_cycles:4.1f} cpu cycles"
-    elif round(n_cycles, 0) < 1_000:
+    if round(n_cycles, 0) < 1_000:
         return f" {n_cycles:4.0f} cpu cycles"
-    elif round(n_cycles, -1) < 10_000:
+    if round(n_cycles, -1) < 10_000:
         return f"{n_cycles / 1e3:4.2f}K cpu cycles"
-    elif round(n_cycles, -2) < 100_000:
+    if round(n_cycles, -2) < 100_000:
         return f"{n_cycles / 1e3:4.1f}K cpu cycles"
-    elif round(n_cycles, -3) < 1_000_000:
+    if round(n_cycles, -3) < 1_000_000:
         return f"{n_cycles / 1e3:4.0f}K cpu cycles"
-    else:
-        return f"{n_cycles / 1e6:4.2f}M cpu cycles"
+    return f"{n_cycles / 1e6:4.2f}M cpu cycles"

--- a/counted_float/_core/utils/_geo_mean.py
+++ b/counted_float/_core/utils/_geo_mean.py
@@ -2,8 +2,8 @@ import math
 
 
 def geo_mean(values: list[float | int]) -> float:
-    """Take geometric mean of list of values, returning 0.0 for an empty list; nan values propagate (nan in -> nan out)."""
+    """Take geometric mean of list of values, returning 0.0 for an empty list; nan values propagate
+    (nan in -> nan out)."""
     if len(values) == 0:
         return 0.0
-    else:
-        return pow(math.prod(values), 1 / len(values))
+    return pow(math.prod(values), 1 / len(values))

--- a/counted_float/_core/utils/_missing_data.py
+++ b/counted_float/_core/utils/_missing_data.py
@@ -23,7 +23,7 @@ def impute_missing_data(data: np.ndarray) -> np.ndarray:
 
     e_step = 0.75  # exponent to apply to correction coefficients  (keep <1.0 for stability)
 
-    for i in range(100):
+    for _i in range(100):
         # compute correction factors for c_rows
         c_row_correct = np.zeros(n_rows)
         for i_row in range(n_rows):

--- a/counted_float/_core/utils/_rounding.py
+++ b/counted_float/_core/utils/_rounding.py
@@ -49,13 +49,12 @@ def round_number(value: float, mode: None | Literal["nearest_int", "10%"]) -> fl
         case "10%":
             if value == 0:
                 return 0
-            elif value < 0:
+            if value < 0:
                 return -round_number(-value, mode)
-            elif 1.0 <= value <= 10.0:
+            if 1.0 <= value <= 10.0:
                 return _round_to_log_nearest(value, __ALLOWED_10PERC_ROUNDING_VALUES)
-            else:
-                scale = 10 ** math.floor(math.log10(value))
-                return scale * round_number(value / scale, mode)
+            scale = 10 ** math.floor(math.log10(value))
+            return scale * round_number(value / scale, mode)
         case _:
             return value
 

--- a/counted_float/_core/utils/_timer.py
+++ b/counted_float/_core/utils/_timer.py
@@ -27,9 +27,8 @@ class Timer:
         if self._end is None:
             # timer still running
             return time.perf_counter_ns() - self._start
-        else:
-            # timer finished
-            return self._end - self._start
+        # timer finished
+        return self._end - self._start
 
     def t_elapsed_sec(self) -> float:
         return self.t_elapsed_nsec() / 1e9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,49 @@ line-length = 120
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["I"]
+select = [
+    "F",       # pyflakes
+    "E", "W",  # pycodestyle (incl. E501 line-too-long)
+    "I",       # isort
+    "UP",      # pyupgrade
+    "B",       # flake8-bugbear
+    "C4",      # flake8-comprehensions
+    "PIE",     # flake8-pie
+    "SIM",     # flake8-simplify
+    "RET",     # flake8-return
+    "N",       # pep8-naming
+    "PTH",     # flake8-use-pathlib
+    "PT",      # flake8-pytest-style
+    "TC",      # flake8-type-checking
+    "RUF",     # ruff-native
+    "C901",    # mccabe complexity gate (threshold below)
+    "PLE", "PLW",  # pylint errors + warnings (PLC/PLR excluded — noisy on this domain)
+    "PGH",     # pygrep-hooks: no blanket `noqa` / `type: ignore`
+    "BLE",     # flake8-blind-except
+    "A",       # flake8-builtins: shadowing
+    "RSE",     # flake8-raise: no needless parens on `raise`
+    "FLY",     # flynt: static str-join → f-string
+    "SLF",     # flake8-self: private-member access
+    "INP",     # flake8-no-pep420: every package dir has an __init__.py
+    "S",       # flake8-bandit: security lint
+]
+ignore = [
+    "RUF001", "RUF002", "RUF003",  # intentional typography, not "ambiguous"
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.flake8-type-checking]
+# Keep pydantic field types importable at runtime (pydantic evaluates
+# annotations to build validators); don't move them under TYPE_CHECKING.
+runtime-evaluated-base-classes = ["pydantic.BaseModel", "counted_float._core.models._base.MyBaseModel"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["SLF001", "S101", "S311"]  # AAA tests: asserts, private-member access, non-crypto random data
+"__init__.py" = ["F401"]                 # re-export modules: naked imports, no `as` alias
+# module-level mutable patching state (original-function snapshots + context refcount) is the design
+"counted_float/_core/counting/_math_patching.py" = ["PLW0603"]
 
 [tool.coverage.run]
 source = ["counted_float"]

--- a/tests/benchmarking/flops/test_array_generator.py
+++ b/tests/benchmarking/flops/test_array_generator.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -11,7 +11,7 @@ from counted_float._core.benchmarking.flops._array_generator import (
 
 
 @pytest.mark.parametrize(
-    "factory_method, expected_cls",
+    ("factory_method", "expected_cls"),
     [
         (ArrayGenerator.lin_range, ArrayGeneratorLinear),
         (ArrayGenerator.log_range, ArrayGeneratorLog),
@@ -29,7 +29,7 @@ def test_array_generator_factory_methods(factory_method: Callable, expected_cls)
 
 
 @pytest.mark.parametrize(
-    "min_value, max_value",
+    ("min_value", "max_value"),
     [
         (0.0, 1.0),
         (-2.0, 10.0),
@@ -44,7 +44,7 @@ def test_array_generator_linear(min_value: float, max_value: float):
     arr = generator.new_array(size=1000)
 
     # --- assert ------------------------------------------
-    assert all([min_value <= v <= max_value for v in arr])
+    assert all(min_value <= v <= max_value for v in arr)
     assert len(set(arr)) == 1000
     assert min_value < np.mean(arr) < max_value
     assert np.mean(arr) == pytest.approx(0.5 * (min_value + max_value))
@@ -52,7 +52,7 @@ def test_array_generator_linear(min_value: float, max_value: float):
 
 
 @pytest.mark.parametrize(
-    "min_value, max_value",
+    ("min_value", "max_value"),
     [
         (0.1, 1.0),
         (2.0, 10.0),
@@ -67,7 +67,7 @@ def test_array_generator_log(min_value: float, max_value: float):
     arr = generator.new_array(size=1000)
 
     # --- assert ------------------------------------------
-    assert all([min_value <= v <= max_value for v in arr])
+    assert all(min_value <= v <= max_value for v in arr)
     assert len(set(arr)) == 1000
     assert min_value < np.mean(arr) < max_value
     assert np.mean(np.log(arr)) == pytest.approx(0.5 * (np.log(min_value) + np.log(max_value)))

--- a/tests/benchmarking/flops/test_flops_benchmark_suite.py
+++ b/tests/benchmarking/flops/test_flops_benchmark_suite.py
@@ -10,9 +10,9 @@ def test_flops_benchmarking_suite_get():
     benchmarks = suite.get_flops_benchmarking_suite(size=12345)
 
     # --- assert ------------------------------------------
-    assert all([fbt in benchmarks.keys() for fbt in FlopsBenchmarkType])
-    assert all([isinstance(v, FlopsMicroBenchmark) for v in benchmarks.values()])
-    assert all([v.size == 12345 for v in benchmarks.values()])
+    assert all(fbt in benchmarks for fbt in FlopsBenchmarkType)
+    assert all(isinstance(v, FlopsMicroBenchmark) for v in benchmarks.values())
+    assert all(v.size == 12345 for v in benchmarks.values())
 
 
 def test_flops_benchmarking_suite_run():

--- a/tests/benchmarking/flops/test_flops_micro_benchmark.py
+++ b/tests/benchmarking/flops/test_flops_micro_benchmark.py
@@ -1,5 +1,3 @@
-import pytest
-
 from counted_float._core.benchmarking.flops import ArrayGenerator, FlopsMicroBenchmark
 from counted_float._core.models import MicroBenchmarkResult, SingleRunResult
 

--- a/tests/benchmarking/micro/test_micro_benchmark.py
+++ b/tests/benchmarking/micro/test_micro_benchmark.py
@@ -34,7 +34,7 @@ class DummyMicroBenchmark(MicroBenchmark):
 
 
 @pytest.mark.parametrize(
-    "n_runs_total, n_runs_warmup, n_seconds_per_run_target",
+    ("n_runs_total", "n_runs_warmup", "n_seconds_per_run_target"),
     [
         (20, 10, 0.01),
         (20, 5, 0.01),

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,13 +1,13 @@
 from click.testing import CliRunner
 
-from counted_float._core._cli import benchmark_counted_float, cli, show_data
+from counted_float._core._cli import benchmark_counted_float, show_data
 
 
 def test_show_data():
     runner = CliRunner()
-    result = runner.invoke(show_data)
+    runner.invoke(show_data)
 
 
 def test_benchmark_counted_float():
     runner = CliRunner()
-    result = runner.invoke(benchmark_counted_float)
+    runner.invoke(benchmark_counted_float)

--- a/tests/counting/config/test_config.py
+++ b/tests/counting/config/test_config.py
@@ -6,7 +6,7 @@ from counted_float._core.models import FlopType, FlopWeights
 
 
 @pytest.mark.parametrize(
-    "getter, setter",
+    ("getter", "setter"),
     [
         (get_active_flop_weights, set_active_flop_weights),
         (Config.get_flop_weights, Config.set_flop_weights),

--- a/tests/counting/config/test_defaults.py
+++ b/tests/counting/config/test_defaults.py
@@ -13,8 +13,8 @@ def test_default_flop_weights(rounding_mode: None | str):
 
     # --- assert ------------------------------------------
     assert isinstance(flop_weights, FlopWeights)
-    assert all([isinstance(v, int | float) for v in flop_weights.weights.values()])
-    assert not any([math.isnan(v) for v in flop_weights.weights.values()])
+    assert all(isinstance(v, int | float) for v in flop_weights.weights.values())
+    assert not any(math.isnan(v) for v in flop_weights.weights.values())
 
 
 @pytest.mark.parametrize("rounding_mode", ["nearest_int", "10%"])

--- a/tests/counting/test_built_in_data.py
+++ b/tests/counting/test_built_in_data.py
@@ -33,12 +33,12 @@ def test_builtin_data_get_flop_weights_invalid_key():
     key_filter = "my_kitchen_sink"
 
     # --- act / assert ------------------------------------
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="No built-in flop weights found"):
         BuiltInData.get_flop_weights(key_filter=key_filter)
 
 
 @pytest.mark.parametrize(
-    "key_filter, n_expected",
+    ("key_filter", "n_expected"),
     [
         (".", 47),
         ("benchmark", 19),
@@ -57,7 +57,7 @@ def test_builtin_data_get_flop_weights_dict(key_filter: str, n_expected: int):
 
     # --- assert ------------------------------------------
     assert len(results) == n_expected
-    assert all(key in full_dict.keys() for key in results.keys())
+    assert all(key in full_dict for key in results)
 
 
 # =================================================================================================

--- a/tests/counting/test_context_managers.py
+++ b/tests/counting/test_context_managers.py
@@ -1,5 +1,3 @@
-import pytest
-
 from counted_float._core.counting._context_managers import FlopCountingContext, PauseFlopCounting
 from counted_float._core.counting._counted_float import CountedFloat
 
@@ -8,7 +6,7 @@ from counted_float._core.counting._counted_float import CountedFloat
 #  FlopCountingContext
 # =================================================================================================
 def test_flop_counting_context_construction():
-    fcc = FlopCountingContext()
+    FlopCountingContext()
 
 
 def test_flop_counting_context_is_active():
@@ -121,17 +119,16 @@ def test_flop_counting_context_pause_resume_nested():
     cf2 = CountedFloat(2.0)
 
     # --- act ---------------------------------------------
-    with FlopCountingContext() as fcc1:
-        with FlopCountingContext() as fcc2:
-            _ = cf1 + cf2  # should be counted in fcc1 & fcc2
-            fcc2.pause()
-            _ = cf1 * cf2  # should be counted in fcc1, not in fcc2
-            fcc2.resume()
-            _ = cf1**cf2  # should be counted in fcc1 & fcc2
-            fcc1.pause()
-            _ = cf1 - cf2  # should be counted in fcc2, not in fcc1
-            fcc2.pause()
-            _ = cf1 / cf2  # should not be counted in either fcc1 or fcc2
+    with FlopCountingContext() as fcc1, FlopCountingContext() as fcc2:
+        _ = cf1 + cf2  # should be counted in fcc1 & fcc2
+        fcc2.pause()
+        _ = cf1 * cf2  # should be counted in fcc1, not in fcc2
+        fcc2.resume()
+        _ = cf1**cf2  # should be counted in fcc1 & fcc2
+        fcc1.pause()
+        _ = cf1 - cf2  # should be counted in fcc2, not in fcc1
+        fcc2.pause()
+        _ = cf1 / cf2  # should not be counted in either fcc1 or fcc2
 
     flop_counts_1 = fcc1.flop_counts()
     flop_counts_2 = fcc2.flop_counts()
@@ -177,13 +174,12 @@ def test_pause_flop_counting():
     cf2 = CountedFloat(2.0)
 
     # --- act ---------------------------------------------
-    with FlopCountingContext() as fcc1:
-        with FlopCountingContext() as fcc2:
-            _ = cf1 + cf2  # should be counted in fcc1 & fcc2
-            with PauseFlopCounting():
-                _ = cf1 / cf2  # should be counted anywhere
-                with FlopCountingContext() as fcc3:
-                    _ = cf1 * cf2  # should be counted anywhere
+    with FlopCountingContext() as fcc1, FlopCountingContext() as fcc2:
+        _ = cf1 + cf2  # should be counted in fcc1 & fcc2
+        with PauseFlopCounting():
+            _ = cf1 / cf2  # should be counted anywhere
+            with FlopCountingContext() as fcc3:
+                _ = cf1 * cf2  # should be counted anywhere
 
     flop_counts_1 = fcc1.flop_counts()
     flop_counts_2 = fcc2.flop_counts()

--- a/tests/counting/test_counted_float.py
+++ b/tests/counting/test_counted_float.py
@@ -1,5 +1,5 @@
 import math
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 
@@ -53,8 +53,8 @@ def test_counted_float_str_repr(f: float):
     cf_repr = repr(cf)
 
     # --- assert ------------------------------------------
-    assert cf_str == f"CountedFloat({str(f)})", "String representation of CountedFloat is incorrect."
-    assert cf_repr == f"CountedFloat({repr(f)})", "Repr representation of CountedFloat is incorrect."
+    assert cf_str == f"CountedFloat({f!s})", "String representation of CountedFloat is incorrect."
+    assert cf_repr == f"CountedFloat({f!r})", "Repr representation of CountedFloat is incorrect."
 
 
 # =================================================================================================
@@ -325,18 +325,12 @@ def test_counted_float_math_ceil(f: float):
 
 @pytest.mark.parametrize("f1", [-1.0, 0.0, -math.pi, math.e])
 @pytest.mark.parametrize("f2", [-1.0, 0.0, -math.pi, math.e])
-@pytest.mark.parametrize("cf_left, cf_right", [(False, True), (True, False), (True, True)])
+@pytest.mark.parametrize(("cf_left", "cf_right"), [(False, True), (True, False), (True, True)])
 def test_counted_float_math_add(f1: float, f2: float, cf_left: bool, cf_right: bool):
     # --- arrange -----------------------------------------
-    if cf_left:
-        left = CountedFloat(f1)
-    else:
-        left = f1
+    left = CountedFloat(f1) if cf_left else f1
 
-    if cf_right:
-        right = CountedFloat(f2)
-    else:
-        right = f2
+    right = CountedFloat(f2) if cf_right else f2
 
     # --- act ---------------------------------------------
     f_sum = f1 + f2
@@ -349,18 +343,12 @@ def test_counted_float_math_add(f1: float, f2: float, cf_left: bool, cf_right: b
 
 @pytest.mark.parametrize("f1", [-1.0, 0.0, -math.pi, math.e])
 @pytest.mark.parametrize("f2", [-1.0, 0.0, -math.pi, math.e])
-@pytest.mark.parametrize("cf_left, cf_right", [(False, True), (True, False), (True, True)])
+@pytest.mark.parametrize(("cf_left", "cf_right"), [(False, True), (True, False), (True, True)])
 def test_counted_float_math_sub(f1: float, f2: float, cf_left: bool, cf_right: bool):
     # --- arrange -----------------------------------------
-    if cf_left:
-        left = CountedFloat(f1)
-    else:
-        left = f1
+    left = CountedFloat(f1) if cf_left else f1
 
-    if cf_right:
-        right = CountedFloat(f2)
-    else:
-        right = f2
+    right = CountedFloat(f2) if cf_right else f2
 
     # --- act ---------------------------------------------
     f_diff = f1 - f2
@@ -373,18 +361,12 @@ def test_counted_float_math_sub(f1: float, f2: float, cf_left: bool, cf_right: b
 
 @pytest.mark.parametrize("f1", [-1.0, 0.0, -math.pi, math.e])
 @pytest.mark.parametrize("f2", [-1.0, 0.0, -math.pi, math.e])
-@pytest.mark.parametrize("cf_left, cf_right", [(False, True), (True, False), (True, True)])
+@pytest.mark.parametrize(("cf_left", "cf_right"), [(False, True), (True, False), (True, True)])
 def test_counted_float_math_mul(f1: float, f2: float, cf_left: bool, cf_right: bool):
     # --- arrange -----------------------------------------
-    if cf_left:
-        left = CountedFloat(f1)
-    else:
-        left = f1
+    left = CountedFloat(f1) if cf_left else f1
 
-    if cf_right:
-        right = CountedFloat(f2)
-    else:
-        right = f2
+    right = CountedFloat(f2) if cf_right else f2
 
     # --- act ---------------------------------------------
     f_prod = f1 * f2
@@ -397,18 +379,12 @@ def test_counted_float_math_mul(f1: float, f2: float, cf_left: bool, cf_right: b
 
 @pytest.mark.parametrize("f1", [-1.0, 0.0, -math.pi, math.e])
 @pytest.mark.parametrize("f2", [-1.0, -math.pi, math.e])
-@pytest.mark.parametrize("cf_left, cf_right", [(False, True), (True, False), (True, True)])
+@pytest.mark.parametrize(("cf_left", "cf_right"), [(False, True), (True, False), (True, True)])
 def test_counted_float_math_div(f1: float, f2: float, cf_left: bool, cf_right: bool):
     # --- arrange -----------------------------------------
-    if cf_left:
-        left = CountedFloat(f1)
-    else:
-        left = f1
+    left = CountedFloat(f1) if cf_left else f1
 
-    if cf_right:
-        right = CountedFloat(f2)
-    else:
-        right = f2
+    right = CountedFloat(f2) if cf_right else f2
 
     # --- act ---------------------------------------------
     f_ratio = f1 / f2
@@ -421,18 +397,12 @@ def test_counted_float_math_div(f1: float, f2: float, cf_left: bool, cf_right: b
 
 @pytest.mark.parametrize("f1", [0.0, 1.0, 2, math.e])
 @pytest.mark.parametrize("f2", [0.0, 1.0, 2, math.pi])
-@pytest.mark.parametrize("cf_left, cf_right", [(False, True), (True, False), (True, True)])
+@pytest.mark.parametrize(("cf_left", "cf_right"), [(False, True), (True, False), (True, True)])
 def test_counted_float_math_pow(f1: float, f2: float, cf_left: bool, cf_right: bool):
     # --- arrange -----------------------------------------
-    if cf_left:
-        left = CountedFloat(f1)
-    else:
-        left = f1
+    left = CountedFloat(f1) if cf_left else f1
 
-    if cf_right:
-        right = CountedFloat(f2)
-    else:
-        right = f2
+    right = CountedFloat(f2) if cf_right else f2
 
     # --- act ---------------------------------------------
     f_pow = f1**f2
@@ -475,7 +445,7 @@ def test_counted_float_math_log2(global_counter, f: float):
 #  CountedFloat - Correct integration with GLOBAL_COUNTER
 # =================================================================================================
 @pytest.mark.parametrize(
-    "value, expected_n_i2f",
+    ("value", "expected_n_i2f"),
     [
         (0, 1),
         (1, 1),
@@ -488,11 +458,11 @@ def test_counted_float_math_log2(global_counter, f: float):
 )
 def test_counted_float_construction(value: float | int, expected_n_i2f: int, global_counter):
     # --- act ---------------------------------------------
-    cf = CountedFloat(value)
+    CountedFloat(value)
 
     # --- assert ------------------------------------------
     assert global_counter.total_count() == expected_n_i2f
-    assert global_counter.I2F == expected_n_i2f
+    assert expected_n_i2f == global_counter.I2F
 
 
 def test_counted_float_counts_abs(global_counter):
@@ -605,22 +575,19 @@ def test_counted_float_counts_gt(global_counter):
 
 
 @pytest.mark.parametrize("min_max_fun", [min, max])
-@pytest.mark.parametrize("f1, f2", [(1.2345, 0.1234), (0.345, 0.222), (2.468, 2.468), (2.468, 2), (3, 2.478), (2, 3)])
-@pytest.mark.parametrize("cf_left, cf_right", [(False, True), (True, False), (True, True)])
+@pytest.mark.parametrize(
+    ("f1", "f2"),
+    [(1.2345, 0.1234), (0.345, 0.222), (2.468, 2.468), (2.468, 2), (3, 2.478), (2, 3)],
+)
+@pytest.mark.parametrize(("cf_left", "cf_right"), [(False, True), (True, False), (True, True)])
 def test_counted_float_counts_min_max(
     min_max_fun: Callable, f1: float, f2: float, cf_left: bool, cf_right: bool, global_counter
 ):
     # --- arrange -----------------------------------------
     n_integers = int(isinstance(f1, int)) + int(isinstance(f2, int))
-    if cf_left:
-        left = CountedFloat(f1)
-    else:
-        left = f1
+    left = CountedFloat(f1) if cf_left else f1
 
-    if cf_right:
-        right = CountedFloat(f2)
-    else:
-        right = f2
+    right = CountedFloat(f2) if cf_right else f2
 
     # --- act ---------------------------------------------
     f_min_max = min_max_fun(f1, f2)
@@ -628,7 +595,7 @@ def test_counted_float_counts_min_max(
 
     # --- assert ------------------------------------------
     assert global_counter.COMP == 1
-    assert global_counter.I2F == n_integers
+    assert n_integers == global_counter.I2F
     assert f_min_max == cf_min_max
 
 
@@ -650,7 +617,7 @@ def test_counted_float_counts_ge(global_counter):
 
 
 @pytest.mark.parametrize(
-    "ndigits, expected_n_rnd, expected_n_f2i",
+    ("ndigits", "expected_n_rnd", "expected_n_f2i"),
     [
         (None, 0, 1),  # round to int -> F2I
         (0, 1, 0),  # round to float -> RND
@@ -666,8 +633,8 @@ def test_counted_float_counts_round(global_counter, ndigits, expected_n_rnd: int
 
     # --- assert ------------------------------------------
     assert global_counter.total_count() == 1
-    assert global_counter.RND == expected_n_rnd
-    assert global_counter.F2I == expected_n_f2i
+    assert expected_n_rnd == global_counter.RND
+    assert expected_n_f2i == global_counter.F2I
 
 
 def test_counted_float_counts_floor(global_counter):

--- a/tests/counting/test_math_patching.py
+++ b/tests/counting/test_math_patching.py
@@ -23,7 +23,7 @@ def test_import_does_not_patch_math():
         "import math; before = math.sqrt; import counted_float; "
         "assert math.sqrt is before, 'math.sqrt was patched at import time'"
     )
-    subprocess.run([sys.executable, "-c", code], check=True)
+    subprocess.run([sys.executable, "-c", code], check=True)  # noqa: S603 -- fixed interpreter, literal code
 
 
 @pytest.mark.parametrize("fname", PATCHED_FUNCTION_NAMES)
@@ -50,7 +50,7 @@ def test_math_module_patched_inside_context_only(fname):
 #  Patched math functions - stdlib contract for plain floats
 # =================================================================================================
 @pytest.mark.parametrize(
-    "fname, args",
+    ("fname", "args"),
     [
         ("sqrt", (2.0,)),
         ("cbrt", (2.0,)),
@@ -96,7 +96,7 @@ def test_math_log_supports_two_arg_form(global_counter):
 def test_math_pow_raises_domain_error_for_negative_base(global_counter):
     # regression test: patched math.pow used to return a complex number instead of raising
     # --- act & assert ------------------------------------
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="math domain error"):
         math.pow(-8.0, 1 / 3)
 
 
@@ -214,7 +214,7 @@ def test_math_log_domain_error_counts_nothing(global_counter):
     cf = CountedFloat(-8.0)
 
     # --- act & assert ------------------------------------
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="math domain error"):
         math.log(cf, 2)
     assert global_counter.total_count() == 0
 
@@ -224,7 +224,7 @@ def test_math_pow_domain_error_counts_nothing(global_counter):
     cf = CountedFloat(-8.0)
 
     # --- act & assert ------------------------------------
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="math domain error"):
         math.pow(cf, 1 / 3)
     assert global_counter.total_count() == 0
 

--- a/tests/models/test_flop_counts.py
+++ b/tests/models/test_flop_counts.py
@@ -54,7 +54,7 @@ def test_flop_counts_construction():
 
     # --- assert ------------------------------------------
     for k, values_lst in expected_values.items():
-        for i, (fc, value) in enumerate(zip([fc_0, fc_1, fc_2], values_lst)):
+        for i, (fc, value) in enumerate(zip([fc_0, fc_1, fc_2], values_lst, strict=False)):
             assert getattr(fc, k) == value, f"fc_{i}.{k} should be {value} but is {getattr(fc, k)}"
 
 
@@ -130,7 +130,7 @@ def test_flop_counts_copy():
     fc_copy = fc_orig.copy()
 
     # --- assert ------------------------------------------
-    assert not fc_copy is fc_orig, "Copy should not be the same object as the original."
+    assert fc_copy is not fc_orig, "Copy should not be the same object as the original."
     for attr in FlopCounts.field_names():
         assert getattr(fc_orig, attr) == getattr(fc_copy, attr), f"Attribute {attr} does not match in copy."
 

--- a/tests/models/test_flop_weights.py
+++ b/tests/models/test_flop_weights.py
@@ -22,10 +22,7 @@ def test_flop_weights_construction(
     sample_flop_weights_dict_by_enum, sample_flop_weights_dict_by_str, use_dict_by_str: bool
 ) -> None:
     # --- arrange -----------------------------------------
-    if use_dict_by_str:
-        weights_dict = sample_flop_weights_dict_by_str
-    else:
-        weights_dict = sample_flop_weights_dict_by_enum
+    weights_dict = sample_flop_weights_dict_by_str if use_dict_by_str else sample_flop_weights_dict_by_enum
 
     # --- act ---------------------------------------------
     flop_weights = FlopWeights(weights=weights_dict)
@@ -33,7 +30,7 @@ def test_flop_weights_construction(
     # --- assert ------------------------------------------
 
     # check if result is correct
-    assert all([isinstance(k, FlopType) for k in flop_weights.weights.keys()])
+    assert all(isinstance(k, FlopType) for k in flop_weights.weights)
     assert set(FlopType) == set(flop_weights.weights.keys())
 
 
@@ -61,8 +58,8 @@ def test_flop_weights_serialization(sample_flop_weights_dict_by_str):
     result = flop_weights.model_dump()
 
     # --- assert ------------------------------------------
-    assert result == dict(weights=sample_flop_weights_dict_by_str)
-    assert not any([isinstance(k, FlopType) for k in result["weights"].keys()]), "keys should be pure strings"
+    assert result == {"weights": sample_flop_weights_dict_by_str}
+    assert not any(isinstance(k, FlopType) for k in result["weights"]), "keys should be pure strings"
 
 
 @pytest.mark.parametrize("use_dict_by_str", [True, False])
@@ -70,10 +67,7 @@ def test_flop_weights_missing_flop_types(
     sample_flop_weights_dict_by_enum, sample_flop_weights_dict_by_str, use_dict_by_str: bool
 ) -> None:
     # --- arrange -----------------------------------------
-    if use_dict_by_str:
-        weights_dict = sample_flop_weights_dict_by_str
-    else:
-        weights_dict = sample_flop_weights_dict_by_enum
+    weights_dict = sample_flop_weights_dict_by_str if use_dict_by_str else sample_flop_weights_dict_by_enum
 
     # remove 1 key to trigger ValueError
     del weights_dict[FlopType.ABS]
@@ -83,7 +77,7 @@ def test_flop_weights_missing_flop_types(
     assert math.isnan(flop_weights.weights[FlopType.ABS])
 
 
-def test_flop_weights_show(sample_flop_weights_dict_by_str):
+def test_flop_weights_show_smoke(sample_flop_weights_dict_by_str):
     """Very minimal test to check if MyBaseModel.print() at least does not raise exceptions."""
     # --- arrange -----------------------------------------
     flop_weights = FlopWeights(weights=sample_flop_weights_dict_by_str)

--- a/tests/models/test_flops_benchmark_results.py
+++ b/tests/models/test_flops_benchmark_results.py
@@ -1,5 +1,9 @@
+from typing import TYPE_CHECKING
+
 from counted_float import BuiltInData
-from counted_float._core.models import FlopsBenchmarkResults
+
+if TYPE_CHECKING:
+    from counted_float._core.models import FlopsBenchmarkResults
 
 
 def test_flops_benchmark_results_show():
@@ -9,6 +13,6 @@ def test_flops_benchmark_results_show():
     flops_benchmark_results: FlopsBenchmarkResults = list(BuiltInData.benchmarks().values()).pop()
 
     # --- act ---------------------------------------------
-    s_str = str(flops_benchmark_results)
-    s_repr = repr(flops_benchmark_results)
+    str(flops_benchmark_results)
+    repr(flops_benchmark_results)
     flops_benchmark_results.show()

--- a/tests/models/test_instruction_latencies.py
+++ b/tests/models/test_instruction_latencies.py
@@ -14,7 +14,7 @@ from counted_float._core.models._instruction_latencies import (
 #  Latency
 # =================================================================================================
 @pytest.mark.parametrize(
-    "min_cycles, max_cycles, expected_consensus",
+    ("min_cycles", "max_cycles", "expected_consensus"),
     [
         (1.0, 4.0, 4.0),
         (0.0, 3.0, 3.0),

--- a/tests/shared/test_imports.py
+++ b/tests/shared/test_imports.py
@@ -3,23 +3,23 @@ import importlib
 
 def test_import_all_counted_float():
     """Check if importing all elements of __all__ from counted_float always works."""
-    from counted_float import __all__ as ALL
+    from counted_float import __all__ as public_names
 
-    for item in ALL:
+    for item in public_names:
         _ = getattr(importlib.import_module("counted_float"), item)
 
 
 def test_import_all_counted_float_config():
     """Check if importing all elements of __all__ from counted_float.config always works."""
-    from counted_float.config import __all__ as ALL
+    from counted_float.config import __all__ as public_names
 
-    for item in ALL:
+    for item in public_names:
         _ = getattr(importlib.import_module("counted_float.config"), item)
 
 
 def test_import_all_counted_float_benchmarking():
     """Check if importing all elements of __all__ from counted_float.benchmarking always works."""
-    from counted_float.benchmarking import __all__ as ALL
+    from counted_float.benchmarking import __all__ as public_names
 
-    for item in ALL:
+    for item in public_names:
         _ = getattr(importlib.import_module("counted_float.benchmarking"), item)

--- a/tests/utils/test_formatting.py
+++ b/tests/utils/test_formatting.py
@@ -14,7 +14,7 @@ from counted_float._core.utils._formatting import (
 #  Time durations
 # =================================================================================================
 @pytest.mark.parametrize(
-    "nsec, expected_result",
+    ("nsec", "expected_result"),
     [
         (6.55003, "   6.55 ns"),
         (12.33002, "  12.33 ns"),
@@ -27,7 +27,7 @@ def test_format_nsec_as_ns(nsec: float, expected_result: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "nsec, expected_result",
+    ("nsec", "expected_result"),
     [
         (1e3 * 6.55003, "   6.55 µs"),
         (1e3 * 12.33002, "  12.33 µs"),
@@ -40,7 +40,7 @@ def test_format_nsec_as_us(nsec: float, expected_result: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "nsec, expected_result",
+    ("nsec", "expected_result"),
     [
         (1e6 * 6.55003, "   6.55 ms"),
         (1e6 * 12.33002, "  12.33 ms"),
@@ -53,7 +53,7 @@ def test_format_nsec_as_ms(nsec: float, expected_result: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "nsec, expected_result",
+    ("nsec", "expected_result"),
     [
         (1e9 * 6.55003, "   6.55 s"),
         (1e9 * 12.33002, "  12.33 s"),
@@ -66,7 +66,7 @@ def test_format_nsec_as_s(nsec: float, expected_result: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "nsec, expected_result",
+    ("nsec", "expected_result"),
     [
         (0.0010000000000, "   0.00 ns"),
         (0.0100000000000, "   0.01 ns"),
@@ -93,7 +93,7 @@ def test_format_time_duration(nsec: float, expected_result: str) -> None:
 #  Format latencies
 # =================================================================================================
 @pytest.mark.parametrize(
-    "n_cycles, expected_result",
+    ("n_cycles", "expected_result"),
     [
         (0.0012300000000, " 0.00 cpu cycles"),
         (0.0123000000000, " 0.01 cpu cycles"),

--- a/tests/utils/test_geo_mean.py
+++ b/tests/utils/test_geo_mean.py
@@ -4,7 +4,7 @@ from counted_float._core.utils import geo_mean
 
 
 @pytest.mark.parametrize(
-    "values, expected_result",
+    ("values", "expected_result"),
     [
         ([0, 1, 1], 0.0),
         ([1, 1, 1], 1.0),

--- a/tests/utils/test_latency.py
+++ b/tests/utils/test_latency.py
@@ -4,7 +4,7 @@ from counted_float._core.utils import convert_nsecs_to_cycles
 
 
 @pytest.mark.parametrize(
-    "nsec, cpu_freq_mhz, fallback_freq_mhz, expected_result",
+    ("nsec", "cpu_freq_mhz", "fallback_freq_mhz", "expected_result"),
     [
         (1.0, 1000, 1000, 1.0),
         (2.0, 1000, 1000, 2.0),

--- a/tests/utils/test_rounding.py
+++ b/tests/utils/test_rounding.py
@@ -6,7 +6,7 @@ from counted_float._core.utils import round_number
 
 
 @pytest.mark.parametrize(
-    "value,mode,expected_value",
+    ("value", "mode", "expected_value"),
     [
         (1.123, None, 1.123),
         (0.9, "nearest_int", 1.0),

--- a/tests/utils/test_timer.py
+++ b/tests/utils/test_timer.py
@@ -11,7 +11,7 @@ def test_timer():
 
     # --- assert 1 ----------------------------------------
     with pytest.raises(RuntimeError):
-        t = timer.t_elapsed_sec()
+        timer.t_elapsed_sec()
 
     # --- act ---------------------------------------------
     with timer:
@@ -27,7 +27,7 @@ def test_timer_running():
     timer = Timer()
 
     # --- act ---------------------------------------------
-    with timer as t:
+    with timer:
         t_before = timer.t_elapsed_sec()
         time.sleep(0.1)
         t_after = timer.t_elapsed_sec()


### PR DESCRIPTION
Turns on the full rule-family set (all except docstring and annotation rules), with per-file-ignores for tests (asserts, private access, non-crypto random) and `__init__.py` re-exports (F401). Most fixes are mechanical; benchmark kernels keep their deliberate branchy/assignment shape via targeted `noqa` so measurements stay comparable. Notable real find: a duplicate `test_flop_weights_show` name meant one test never ran — now renamed and running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)