### PR TITLE
chore: annotate the library and add the ty type checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,15 @@ repos:
         types: [python]
         files: ^(counted_float|tests)/
         pass_filenames: true
+      - id: ty
+        name: ty check
+        entry: uv run ty check
+        language: system
+        types: [python]
+        # ty is a whole-program checker: a staged-files-only run would miss
+        # cross-module breakage, so it runs the project as configured by
+        # [tool.ty] (not the staged subset) whenever any Python file changes.
+        pass_filenames: false
 
   # ----------------------------------------------------------------------------
   #  Managed: file hygiene

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - add pre-commit hooks (ruff, file hygiene, codespell, actionlint, conventional commit messages) + `make lint`
 - expand ruff rule set from isort-only to the full lint family set
 - enable pydocstyle (Google convention) and clean up all docstrings
+- fully type-annotate the library and add the ty type checker to pre-commit
 
 <!------------------------------------------------------------------------------------------------->
 > ## v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@
 <!------------------------------------------------------------------------------------------------->
 > ## v1.1.1
 > *(unreleased)*
-> > Internal quality-tooling release: pre-commit hooks, expanded ruff rule set, ty type checker.
+> > Quality-tooling release: pre-commit hooks, expanded ruff rule set, ty type checker; package now ships type information.
 <!------------------------------------------------------------------------------------------------->
 
 ### What's New
 /
 
 ### Improvements
-/
+- package now ships inline type information (fully annotated API + PEP 561 `py.typed` marker)
 
 ### Bug Fixes
 /
@@ -19,7 +19,7 @@
 - add pre-commit hooks (ruff, file hygiene, codespell, actionlint, conventional commit messages) + `make lint`
 - expand ruff rule set from isort-only to the full lint family set
 - enable pydocstyle (Google convention) and clean up all docstrings
-- fully type-annotate the library and add the ty type checker to pre-commit
+- add the ty type checker to pre-commit
 
 <!------------------------------------------------------------------------------------------------->
 > ## v1.1.0

--- a/counted_float/_core/_cli.py
+++ b/counted_float/_core/_cli.py
@@ -8,23 +8,23 @@ from counted_float._core.benchmarking import run_counted_float_benchmark, run_fl
 #  Commands
 # -------------------------------------------------------------------------
 @click.group()
-def cli():
+def cli() -> None:
     pass
 
 
 @cli.command(short_help="run flop benchmarks")
-def benchmark():
+def benchmark() -> None:
     result = run_flops_benchmark()
     result.show()
 
 
 @cli.command(short_help="show all built-in data")
 @click.option("--key_filter", default="", help="Optional key filter for built-in data")
-def show_data(key_filter: str):
+def show_data(key_filter: str) -> None:
     BuiltInData.show(key_filter=key_filter)
 
 
 @cli.command(short_help="run benchmark of float vs CountedFloat performance")
-def benchmark_counted_float():
+def benchmark_counted_float() -> None:
     result = run_counted_float_benchmark()
     result.show()

--- a/counted_float/_core/benchmarking/counted_float/_counted_float_benchmark.py
+++ b/counted_float/_core/benchmarking/counted_float/_counted_float_benchmark.py
@@ -11,7 +11,7 @@ class CountedFloatBenchmarkResults(MyBaseModel):
     float_time_nsec: float
     counted_float_time_nsec: float
 
-    def show(self):
+    def show(self) -> None:
         print("CountedFloat Benchmark Results:")
         print(f"  Bisection using float        : {format_time_duration(self.float_time_nsec)} / execution")
         print(f"  Bisection using CountedFloat : {format_time_duration(self.counted_float_time_nsec)} / execution")
@@ -29,14 +29,14 @@ def _zero_function(x: float) -> float:
 
 
 class BenchmarkFloat(MicroBenchmark):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(name="float")
         self._n_executions = 1
 
-    def _prepare_benchmark(self, n_executions: int):
+    def _prepare_benchmark(self, n_executions: int) -> None:
         self._n_executions = n_executions
 
-    def _run_benchmark(self):
+    def _run_benchmark(self) -> None:
         for _ in range(self._n_executions):
             # Execute bisection to find root of _zero_function in interval [-1e50,1e50],
             # using standard float() arithmetic
@@ -58,14 +58,14 @@ class BenchmarkFloat(MicroBenchmark):
 
 
 class BenchmarkCountedFloat(MicroBenchmark):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(name="CountedFloat")
         self._n_executions = 1
 
-    def _prepare_benchmark(self, n_executions: int):
+    def _prepare_benchmark(self, n_executions: int) -> None:
         self._n_executions = n_executions
 
-    def _run_benchmark(self):
+    def _run_benchmark(self) -> None:
         for _ in range(self._n_executions):
             # Execute bisection to find root of _zero_function in interval [-1e50,1e50],
             # with identical implementation as BenchmarkFloat, except that we initialize a,b as CountedFloats,

--- a/counted_float/_core/benchmarking/flops/_array_generator.py
+++ b/counted_float/_core/benchmarking/flops/_array_generator.py
@@ -34,7 +34,7 @@ class ArrayGenerator(ABC):
 #  Implementations
 # =================================================================================================
 class ArrayGeneratorLinear(ArrayGenerator):
-    def __init__(self, min_value: float, max_value: float):
+    def __init__(self, min_value: float, max_value: float) -> None:
         """Array generator, where values are in interval [min_value, max_value] with avg. equal to mid-point."""
         self.min_value = min_value
         self.max_value = max_value
@@ -45,7 +45,7 @@ class ArrayGeneratorLinear(ArrayGenerator):
 
 
 class ArrayGeneratorLog(ArrayGenerator):
-    def __init__(self, min_value: float, max_value: float):
+    def __init__(self, min_value: float, max_value: float) -> None:
         """Array generator, where values are in interval [min_value, max_value] with geomean equal to geo-mid."""
         self.min_value = min_value
         self.max_value = max_value

--- a/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
+++ b/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
@@ -115,14 +115,14 @@ class FlopsBenchmarkSuite:
 
         # --- define all test functions -------------------
         @numba.njit(parallel=False)
-        def f_baseline(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_baseline(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -130,7 +130,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_minus(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_minus(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -138,7 +138,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_abs(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_abs(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -146,7 +146,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_add(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_add(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -155,7 +155,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_sub(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_sub(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -164,7 +164,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_round(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_round(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -172,7 +172,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_sqrt(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_sqrt(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -180,7 +180,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_cbrt(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_cbrt(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -188,7 +188,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_log(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_log(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -196,7 +196,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_log_exp(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_log_exp(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -204,7 +204,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_log2(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_log2(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -212,7 +212,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_log2_exp2(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_log2_exp2(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -220,7 +220,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_log10(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_log10(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -228,7 +228,9 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_log10_exp10(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_log10_exp10(
+            n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray
+        ) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -236,7 +238,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_sin(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_sin(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -244,7 +246,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_cos(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_cos(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -252,7 +254,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_add_tan(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_add_tan(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -260,7 +262,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_pow(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_pow(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -268,7 +270,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_pow_pow(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_pow_pow(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -276,7 +278,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_sub(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_sub(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -284,7 +286,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_sub_sub(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_sub_sub(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -293,7 +295,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_mul(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_mul(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -301,7 +303,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_mul_mul(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_mul_mul(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -310,7 +312,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_div(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_div(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -318,7 +320,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_div_div(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_div_div(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):
@@ -327,7 +329,7 @@ class FlopsBenchmarkSuite:
                     out_f[i] = tmp
 
         @numba.njit(parallel=False)
-        def f_lte_addsub(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray):
+        def f_lte_addsub(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
             for _ in range(n_executions):
                 tmp = math.e
                 for i in range(n):

--- a/counted_float/_core/benchmarking/flops/_flops_micro_benchmark.py
+++ b/counted_float/_core/benchmarking/flops/_flops_micro_benchmark.py
@@ -43,7 +43,7 @@ class FlopsMicroBenchmark(MicroBenchmark):
     operations, so we can make representative estimates of the number of FLOPS executed by instrumented algorithms.
     """
 
-    def __init__(self, name: str, size: int, array_init: ArrayGenerator, f: Callable):
+    def __init__(self, name: str, size: int, array_init: ArrayGenerator, f: Callable) -> None:
         super().__init__(name=name, single_execution=f"{size} iterations")
         self.size = size
         self.array_init = array_init
@@ -55,7 +55,7 @@ class FlopsMicroBenchmark(MicroBenchmark):
         self.out_f: np.ndarray = np.zeros(size, dtype=float)
         self.out_i: np.ndarray = np.zeros(size, dtype=int)
 
-    def _prepare_benchmark(self, n_executions: int):
+    def _prepare_benchmark(self, n_executions: int) -> None:
         self.n_executions = n_executions
         # input array
         self.in_f = self.array_init.new_array(self.size)
@@ -63,6 +63,6 @@ class FlopsMicroBenchmark(MicroBenchmark):
         self.out_f: np.ndarray = np.full(self.size, 0.0, dtype=float)
         self.out_i: np.ndarray = np.full(self.size, 0, dtype=int)
 
-    def _run_benchmark(self):
+    def _run_benchmark(self) -> None:
         # call 'f' with appropriate n_executions & size parameters
         self.f(self.n_executions, self.size, self.in_f, self.out_f, self.out_i)

--- a/counted_float/_core/benchmarking/micro/_micro_benchmark.py
+++ b/counted_float/_core/benchmarking/micro/_micro_benchmark.py
@@ -29,7 +29,7 @@ class MicroBenchmark(ABC):
 
     MAX_N_EXECUTIONS_FACTOR = 10  # never adjust n_executions by more than this factor (up or down)
 
-    def __init__(self, name: str, single_execution: str = "execution"):
+    def __init__(self, name: str, single_execution: str = "execution") -> None:
         self.name = name
         self.single_execution = single_execution
 
@@ -111,7 +111,7 @@ class MicroBenchmark(ABC):
         )
 
     @abstractmethod
-    def _prepare_benchmark(self, n_executions: int):
+    def _prepare_benchmark(self, n_executions: int) -> None:
         """Prepare benchmark_runs (e.g. set up data) based on requested number of executions.
 
         This argument is adjusted each run by the MicroBenchmarkRunner class to ensure that the benchmark_runs
@@ -120,6 +120,6 @@ class MicroBenchmark(ABC):
         ...
 
     @abstractmethod
-    def _run_benchmark(self):
+    def _run_benchmark(self) -> None:
         """Run benchmark_runs.  This method is called multiple times and the time spent here is measured."""
         ...

--- a/counted_float/_core/compatibility/_numba.py
+++ b/counted_float/_core/compatibility/_numba.py
@@ -1,19 +1,19 @@
 from collections.abc import Callable
 
 try:
-    import numba
+    import numba  # ty: ignore[unresolved-import] -- numba is an optional dependency; shimmed below if absent
 
 
 except ImportError:
     # dummy decorator that will replace numba.jit and numba.njit
-    def dummy_decorator(*args, **kwargs):
+    def dummy_decorator(*args: object, **kwargs: object) -> Callable:
         # dummy decorator that does nothing and can be used with or without arguments
         if len(args) == 1 and isinstance(args[0], Callable):
             # decorator used without arguments
             return args[0]
 
         # decorator used with arguments
-        def decorator(func):
+        def decorator(func: Callable) -> Callable:
             return func
 
         return decorator
@@ -24,7 +24,7 @@ except ImportError:
         jit = dummy_decorator
         njit = dummy_decorator
 
-    numba = Numba
+    numba = Numba  # ty: ignore[invalid-assignment] -- module-shaped stand-in for the absent optional module
 
 
 def is_numba_installed() -> bool:

--- a/counted_float/_core/counting/_builtin_data.py
+++ b/counted_float/_core/counting/_builtin_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from importlib.resources import files
+from typing import TYPE_CHECKING, TypeVar
 
 from pydantic import BaseModel, ValidationError
 from rich.console import Console
@@ -11,6 +12,12 @@ from counted_float._core.models import (
     FlopWeights,
     InstructionLatencies,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from importlib.resources.abc import Traversable
+
+PydanticModelT = TypeVar("PydanticModelT", bound=BaseModel)
 
 DATA_PACKAGE = "counted_float.data"
 
@@ -71,7 +78,7 @@ class BuiltInData:
     #  Visualization
     # -------------------------------------------------------------------------
     @classmethod
-    def show(cls, key_filter: str = ""):
+    def show(cls, key_filter: str = "") -> None:
         """Show flow weights of all built-in data, optionally satisfying key_filter."""
         fw_nested_dict = _flat_to_nested_dict(cls.get_flop_weights_dict(key_filter))
         tree_view = FlopWeightsTreeView.from_nested_dict(name="ALL", nested_dict=fw_nested_dict)
@@ -88,7 +95,8 @@ def _compute_nested_average_flop_weights(nested_flop_weights_dict: dict[str, dic
             nested_flop_weights_dict[key] = _compute_nested_average_flop_weights(value)
 
     # now we can average all FlopWeights instances
-    return FlopWeights.as_geo_mean(list(nested_flop_weights_dict.values()))
+    # the loop above collapsed every dict value to FlopWeights; ty cannot track the mutation
+    return FlopWeights.as_geo_mean(list(nested_flop_weights_dict.values()))  # ty: ignore[invalid-argument-type]
 
 
 def _flat_to_nested_dict(flat_dict: dict) -> dict:
@@ -106,7 +114,7 @@ def _flat_to_nested_dict(flat_dict: dict) -> dict:
     return nested_dict
 
 
-def _load_json_files_as_dict(resource_root) -> dict[str, str]:
+def _load_json_files_as_dict(resource_root: Traversable) -> dict[str, str]:
     """Read all .json files recursively from the given resource root and return a dict mapping key -> json_str.
 
     Keys are .-separated values indicating the path + filename of the source data file.
@@ -122,7 +130,7 @@ def _load_json_files_as_dict(resource_root) -> dict[str, str]:
             for key, value in sub_dir_json_dict.items():
                 result[f"{entry.name}.{key}"] = value
         elif entry.is_file() and entry.name.endswith(".json"):
-            result[entry.stem] = entry.read_text(encoding="utf-8")
+            result[entry.stem] = entry.read_text(encoding="utf-8")  # ty: ignore[unresolved-attribute] -- Path-like
     return result
 
 
@@ -145,7 +153,10 @@ def _construct_flop_weights_from_json_str(json_str: str) -> FlopWeights:
     ).flop_weights()
 
 
-def _deserialize_as_any_pydantic_class(json_str: str, pydantic_classes: list[type[BaseModel]]):
+def _deserialize_as_any_pydantic_class(
+    json_str: str,
+    pydantic_classes: Sequence[type[PydanticModelT]],
+) -> PydanticModelT:
     # try all supported classes
     for pydantic_cls in pydantic_classes:
         try:
@@ -161,7 +172,7 @@ class FlopWeightsTreeView:
     # -------------------------------------------------------------------------
     #  Constructor
     # -------------------------------------------------------------------------
-    def __init__(self, name: str, children: FlopWeights | list[FlopWeightsTreeView]):
+    def __init__(self, name: str, children: FlopWeights | list[FlopWeightsTreeView]) -> None:
         # --- init ----------------------------------------
         self.lst_indent: list[int] = []
         self.lst_is_leaf: list[bool] = []
@@ -220,7 +231,7 @@ class FlopWeightsTreeView:
     # -------------------------------------------------------------------------
     #  Visualization
     # -------------------------------------------------------------------------
-    def show(self):
+    def show(self) -> None:
         # --- prep ----------------------------------------
         console = Console()
         console_width = console.width

--- a/counted_float/_core/counting/_context_managers.py
+++ b/counted_float/_core/counting/_context_managers.py
@@ -3,6 +3,9 @@
 Also provides .pause() and .resume() methods to control flop counting.
 """
 
+from types import TracebackType
+from typing import Self
+
 from counted_float._core.counting._global_counter import GLOBAL_COUNTER
 from counted_float._core.counting._math_patching import apply_math_patches, remove_math_patches
 from counted_float._core.models import FlopCounts
@@ -24,7 +27,7 @@ class FlopCountingContext:
     # -------------------------------------------------------------------------
     #  Constructor
     # -------------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         # Active/inactive flag  (toggled by __enter__ and __exit__ + by pause() and resume() methods)
         # When inactive:
         #   - current count == self.__cnt_subtotal
@@ -51,13 +54,13 @@ class FlopCountingContext:
     # -------------------------------------------------------------------------
     #  Pause/Resume
     # -------------------------------------------------------------------------
-    def pause(self):
+    def pause(self) -> None:
         if self.__active:
             self.__cnt_subtotal = self.flop_counts()
             self.__cnt_start_snapshot = FlopCounts()
             self.__active = False
 
-    def resume(self):
+    def resume(self) -> None:
         if not self.__active:
             self.__cnt_start_snapshot = GLOBAL_COUNTER.flop_counts() - self.__cnt_subtotal
             self.__cnt_subtotal = FlopCounts()
@@ -66,14 +69,19 @@ class FlopCountingContext:
     # -------------------------------------------------------------------------
     #  Context manager interface
     # -------------------------------------------------------------------------
-    def __enter__(self):
+    def __enter__(self) -> Self:
         # patching the math module is tied to the with-block lifetime (not to pause()/resume(),
         # which only control whether counts are registered)
         apply_math_patches()
         self.resume()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         self.pause()
         remove_math_patches()
 
@@ -87,9 +95,14 @@ class PauseFlopCounting:
     This acts globally, across all active FlopCountingContext instances.
     """
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         GLOBAL_COUNTER.pause()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         GLOBAL_COUNTER.resume()

--- a/counted_float/_core/counting/_counted_float.py
+++ b/counted_float/_core/counting/_counted_float.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import SupportsIndex
+
 from ._global_counter import GLOBAL_COUNTER
 
 
@@ -7,18 +9,18 @@ class CountedFloat(float):
     # -------------------------------------------------------------------------
     #  CONSTRUCTOR
     # -------------------------------------------------------------------------
-    def __new__(cls, value: float | int):
+    def __new__(cls, value: float | int) -> CountedFloat:
         if isinstance(value, int):
             GLOBAL_COUNTER.incr_i2f()
         return super().__new__(cls, float(value))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__repr__()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"CountedFloat({super().__repr__()})"
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return super().__hash__()
 
     # -------------------------------------------------------------------------
@@ -34,49 +36,51 @@ class CountedFloat(float):
         GLOBAL_COUNTER.incr_minus()
         return CountedFloat(super().__neg__())
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         """x==other or other==x."""
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
         return super().__eq__(other)
 
-    def __ne__(self, other) -> bool:
+    def __ne__(self, other: object) -> bool:
         """x!=other or other!=x."""
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
         return super().__ne__(other)
 
-    def __lt__(self, other):
+    def __lt__(self, other: float) -> bool:
         """x<other."""
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
         return super().__lt__(other)
 
-    def __le__(self, other):
+    def __le__(self, other: float) -> bool:
         """x<=other."""
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
         return super().__le__(other)
 
-    def __gt__(self, other):
+    def __gt__(self, other: float) -> bool:
         """x>other."""
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
         return super().__gt__(other)
 
-    def __ge__(self, other):
+    def __ge__(self, other: float) -> bool:
         """x>=other."""
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
         return super().__ge__(other)
 
-    def __round__(self, n=None) -> int:
+    def __round__(  # ty: ignore[invalid-method-override] -- float's stub narrows return per overload; this is the union
+        self, n: SupportsIndex | None = None
+    ) -> int | float:
         """Round to n decimal places, i.e. round(x, n).
 
         n = None -> round to nearest integer and return int
@@ -110,63 +114,63 @@ class CountedFloat(float):
         GLOBAL_COUNTER.incr_f2i()
         return super().__trunc__()
 
-    def __add__(self, other) -> CountedFloat:
+    def __add__(self, other: float) -> CountedFloat:
         """x+other."""
         GLOBAL_COUNTER.incr_add()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(super().__add__(other))
 
-    def __radd__(self, other) -> CountedFloat:
+    def __radd__(self, other: float) -> CountedFloat:
         """other+x."""
         GLOBAL_COUNTER.incr_add()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(super().__radd__(other))
 
-    def __sub__(self, other) -> CountedFloat:
+    def __sub__(self, other: float) -> CountedFloat:
         """x-other."""
         GLOBAL_COUNTER.incr_sub()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(super().__sub__(other))
 
-    def __rsub__(self, other) -> CountedFloat:
+    def __rsub__(self, other: float) -> CountedFloat:
         """other-x."""
         GLOBAL_COUNTER.incr_sub()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(super().__rsub__(other))
 
-    def __mul__(self, other) -> CountedFloat:
+    def __mul__(self, other: float) -> CountedFloat:
         """x*other or other*x."""
         GLOBAL_COUNTER.incr_mul()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(super().__mul__(other))
 
-    def __rmul__(self, other) -> CountedFloat:
+    def __rmul__(self, other: float) -> CountedFloat:
         """other*x."""
         GLOBAL_COUNTER.incr_mul()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(super().__rmul__(other))
 
-    def __truediv__(self, other) -> CountedFloat:
+    def __truediv__(self, other: float) -> CountedFloat:
         """x/other."""
         GLOBAL_COUNTER.incr_div()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(super().__truediv__(other))
 
-    def __rtruediv__(self, other) -> CountedFloat:
+    def __rtruediv__(self, other: float) -> CountedFloat:
         """other/x."""
         GLOBAL_COUNTER.incr_div()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(super().__rtruediv__(other))
 
-    def __pow__(self, other) -> CountedFloat:
+    def __pow__(self, other: float) -> CountedFloat:  # ty: ignore[invalid-method-override] -- no `mod` param; float.__pow__'s mod is None-only and unused here
         """x**other.
 
         Counting heuristic: an `int` operand is taken as evidence of a hardcoded constant in the
@@ -183,7 +187,7 @@ class CountedFloat(float):
             GLOBAL_COUNTER.incr_pow()
         return CountedFloat(super().__pow__(other))
 
-    def __rpow__(self, other) -> CountedFloat:
+    def __rpow__(self, other: float) -> CountedFloat:  # ty: ignore[invalid-method-override] -- no `mod` param; float.__rpow__'s mod is None-only and unused here
         """other**x.
 
         Same constant-detection heuristic as __pow__, applied to the base: an `int` base 2 or 10

--- a/counted_float/_core/counting/_global_counter.py
+++ b/counted_float/_core/counting/_global_counter.py
@@ -12,20 +12,20 @@ class GlobalFlopCounter:
     # -------------------------------------------------------------------------
     #  Constructor
     # -------------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         self.__counts = FlopCounts()
         self.__incr = 1  # 1 if enabled, 0 if paused
 
     # -------------------------------------------------------------------------
     #  Pause / Resume / Status API
     # -------------------------------------------------------------------------
-    def pause(self):
+    def pause(self) -> None:
         self.__incr = 0
 
-    def resume(self):
+    def resume(self) -> None:
         self.__incr = 1
 
-    def reset(self):
+    def reset(self) -> None:
         self.__counts.reset()
         self.resume()
 
@@ -39,7 +39,7 @@ class GlobalFlopCounter:
         """Shorthand for self.flop_counts().total_count()."""
         return self.__counts.total_count()
 
-    def __getattr__(self, item):
+    def __getattr__(self, item: str) -> int:
         # provide shorthand access to the counts
         if item in FlopCounts.field_names():
             return getattr(self.__counts, item)
@@ -48,70 +48,70 @@ class GlobalFlopCounter:
     # -------------------------------------------------------------------------
     #  Incrementing counts
     # -------------------------------------------------------------------------
-    def incr_abs(self):
+    def incr_abs(self) -> None:
         self.__counts.ABS += self.__incr
 
-    def incr_minus(self):
+    def incr_minus(self) -> None:
         self.__counts.MINUS += self.__incr
 
-    def incr_comp(self):
+    def incr_comp(self) -> None:
         self.__counts.COMP += self.__incr
 
-    def incr_rnd(self):
+    def incr_rnd(self) -> None:
         self.__counts.RND += self.__incr
 
-    def incr_f2i(self):
+    def incr_f2i(self) -> None:
         self.__counts.F2I += self.__incr
 
-    def incr_i2f(self):
+    def incr_i2f(self) -> None:
         self.__counts.I2F += self.__incr
 
-    def incr_add(self):
+    def incr_add(self) -> None:
         self.__counts.ADD += self.__incr
 
-    def incr_sub(self):
+    def incr_sub(self) -> None:
         self.__counts.SUB += self.__incr
 
-    def incr_mul(self):
+    def incr_mul(self) -> None:
         self.__counts.MUL += self.__incr
 
-    def incr_div(self):
+    def incr_div(self) -> None:
         self.__counts.DIV += self.__incr
 
-    def incr_sqrt(self):
+    def incr_sqrt(self) -> None:
         self.__counts.SQRT += self.__incr
 
-    def incr_cbrt(self):
+    def incr_cbrt(self) -> None:
         self.__counts.CBRT += self.__incr
 
-    def incr_exp(self):
+    def incr_exp(self) -> None:
         self.__counts.EXP += self.__incr
 
-    def incr_exp2(self):
+    def incr_exp2(self) -> None:
         self.__counts.EXP2 += self.__incr
 
-    def incr_exp10(self):
+    def incr_exp10(self) -> None:
         self.__counts.EXP10 += self.__incr
 
-    def incr_log(self):
+    def incr_log(self) -> None:
         self.__counts.LOG += self.__incr
 
-    def incr_log2(self):
+    def incr_log2(self) -> None:
         self.__counts.LOG2 += self.__incr
 
-    def incr_log10(self):
+    def incr_log10(self) -> None:
         self.__counts.LOG10 += self.__incr
 
-    def incr_pow(self):
+    def incr_pow(self) -> None:
         self.__counts.POW += self.__incr
 
-    def incr_sin(self):
+    def incr_sin(self) -> None:
         self.__counts.SIN += self.__incr
 
-    def incr_cos(self):
+    def incr_cos(self) -> None:
         self.__counts.COS += self.__incr
 
-    def incr_tan(self):
+    def incr_tan(self) -> None:
         self.__counts.TAN += self.__incr
 
 

--- a/counted_float/_core/counting/_math_patching.py
+++ b/counted_float/_core/counting/_math_patching.py
@@ -64,7 +64,10 @@ def math_cbrt(x: float) -> float | CountedFloat:
     return original_math_cbrt(x)
 
 
-def math_log(x: float, base=_NO_BASE) -> float | CountedFloat:  # noqa: C901 -- branches mirror the per-log-variant counting rules
+def math_log(  # noqa: C901 -- branches mirror the per-log-variant counting rules
+    x: float,
+    base: float = _NO_BASE,  # ty: ignore[invalid-parameter-default] -- sentinel mirrors math.log's omittable base
+) -> float | CountedFloat:
     """Patch math.log: stdlib contract (optional base), with flop classification per log variant.
 
     Flop classification for the base follows the same constant-detection heuristic as
@@ -211,7 +214,7 @@ _saved_originals: dict[str, object] = {}
 _active_context_count = 0
 
 
-def _capture_originals():
+def _capture_originals() -> None:
     """Snapshot the current math functions.
 
     This way the replacements delegate through (and unpatching restores) whatever is current —
@@ -238,7 +241,7 @@ def _capture_originals():
         _saved_originals[name] = getattr(math, name)
 
 
-def apply_math_patches():
+def apply_math_patches() -> None:
     """Apply the counting replacements to the math module (refcounted; see module docstring)."""
     global _active_context_count
     _active_context_count += 1
@@ -248,7 +251,7 @@ def apply_math_patches():
             setattr(math, name, replacement)
 
 
-def remove_math_patches():
+def remove_math_patches() -> None:
     """Undo apply_math_patches; the math module is restored once the last context exits."""
     global _active_context_count
     _active_context_count = max(0, _active_context_count - 1)

--- a/counted_float/_core/counting/config/_config.py
+++ b/counted_float/_core/counting/config/_config.py
@@ -20,7 +20,7 @@ class Config:
     #  Configuration Methods
     # -------------------------------------------------------------------------
     @classmethod
-    def set_flop_weights(cls, weights: FlopWeights):
+    def set_flop_weights(cls, weights: FlopWeights) -> None:
         """Set the weights for the flops used in the package.
 
         These weights will be used in any calculation of weighted flops, going forward.
@@ -40,7 +40,7 @@ class Config:
 # =================================================================================================
 #  Functional accessors
 # =================================================================================================
-def set_active_flop_weights(weights: FlopWeights):
+def set_active_flop_weights(weights: FlopWeights) -> None:
     """Set the weights for the flops used in the package.
 
     These weights will be used in any calculation of weighted flops, going forward.

--- a/counted_float/_core/models/_base.py
+++ b/counted_float/_core/models/_base.py
@@ -2,11 +2,11 @@ from pydantic import BaseModel
 
 
 class MyBaseModel(BaseModel):
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.model_dump_json(indent=4)
 
-    def show(self):
+    def show(self) -> None:
         print(self.model_dump_json(indent=4))

--- a/counted_float/_core/models/_flop_counts.py
+++ b/counted_float/_core/models/_flop_counts.py
@@ -72,7 +72,7 @@ class FlopCounts:
         return sum([getattr(self, flop_type.name) * weights.weights[flop_type] for flop_type in FlopType])
 
     # --- other -------------------------------------------
-    def reset(self):
+    def reset(self) -> None:
         """Reset all counts to 0."""
         for attr in self.field_names():
             setattr(self, attr, 0)

--- a/counted_float/_core/models/_flop_weights.py
+++ b/counted_float/_core/models/_flop_weights.py
@@ -65,7 +65,7 @@ class FlopWeights(MyBaseModel):
     # -------------------------------------------------------------------------
     #  Custom visualization
     # -------------------------------------------------------------------------
-    def show(self):
+    def show(self) -> None:
         print("{")
         for k, v in sorted(self.weights.items(), key=lambda kv: (kv[1], kv[0].long_name())):
             if isinstance(v, float):

--- a/counted_float/_core/models/_instruction_latencies.py
+++ b/counted_float/_core/models/_instruction_latencies.py
@@ -28,11 +28,11 @@ class Latency(MyBaseModel):
             case (None, None):
                 return math.nan
             case (None, _):
-                return max(1.0, self.max_cycles)
+                return max(1.0, self.max_cycles)  # ty: ignore[invalid-argument-type] -- non-None here
             case (_, None):
-                return max(1.0, self.min_cycles)
+                return max(1.0, self.min_cycles)  # ty: ignore[invalid-argument-type] -- non-None per pattern
             case (_, _):
-                return max(1.0, self.min_cycles, self.max_cycles)
+                return max(1.0, self.min_cycles, self.max_cycles)  # ty: ignore[invalid-argument-type] -- non-None
 
 
 # =================================================================================================

--- a/counted_float/_core/utils/_timer.py
+++ b/counted_float/_core/utils/_timer.py
@@ -1,20 +1,27 @@
 import time
+from types import TracebackType
+from typing import Self
 
 
 class Timer:
     """Class acting as a context manager to measure time elapsed.  Elapsed time can be retrieved using t_elapsed()."""
 
     # --- constructor -------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         self._start: float | None = None
         self._end: float | None = None
 
     # --- context manager ---------------------------------
-    def __enter__(self):
+    def __enter__(self) -> Self:
         self._start = time.perf_counter_ns()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         self._end = time.perf_counter_ns()
 
     # --- extract results ---------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,10 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=6.0",
     "pytest-xdist>=3.5.0",
-    # ruff is pinned exactly: uv.lock is untracked, so this pin is what keeps
-    # pre-commit, `make lint`, and CI on the same ruff version.
+    # ruff & ty are pinned exactly: uv.lock is untracked, so these pins are what
+    # keep pre-commit, `make lint`, and CI on the same tool versions.
     "ruff==0.15.11",
+    "ty==0.0.56",
 ]
 
 [build-system]
@@ -55,7 +56,7 @@ packages = ["counted_float"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py313"
+target-version = "py311"  # matches requires-python floor, so ruff fixes never introduce newer syntax
 
 [tool.ruff.lint]
 select = [
@@ -72,6 +73,7 @@ select = [
     "PTH",     # flake8-use-pathlib
     "PT",      # flake8-pytest-style
     "TC",      # flake8-type-checking
+    "ANN",     # flake8-annotations
     "D",       # pydocstyle (Google convention; D401 enforced)
     "RUF",     # ruff-native
     "C901",    # mccabe complexity gate (threshold below)
@@ -101,10 +103,19 @@ convention = "google"
 runtime-evaluated-base-classes = ["pydantic.BaseModel", "counted_float._core.models._base.MyBaseModel"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["SLF001", "S101", "S311", "D"]  # AAA tests: asserts, private access, random data, no docstring duty
+"tests/**" = ["SLF001", "S101", "S311", "D", "ANN"]  # AAA tests: asserts, private access, random data, no docstring/annotation duty
 "__init__.py" = ["F401"]                 # re-export modules: naked imports, no `as` alias
 # module-level mutable patching state (original-function snapshots + context refcount) is the design
 "counted_float/_core/counting/_math_patching.py" = ["PLW0603"]
+
+[tool.ty.src]
+include = ["counted_float"]
+
+[tool.ty.rules]
+# The numba shim needs `ty: ignore`s that are used only when the optional numba
+# extra is absent from the env; flagging them as unused in the other env would
+# make `ty check` results depend on which extras happen to be installed.
+unused-ignore-comment = "ignore"
 
 [tool.coverage.run]
 source = ["counted_float"]


### PR DESCRIPTION
Adds full type annotations across the library (tests exempt via per-file-ignores), ships a PEP 561 `py.typed` marker (verified present in the built wheel) so downstream type checkers consume them, and wires the ty type checker into the dev group and pre-commit, pinned exactly alongside ruff. Also fixes ruff's `target-version` (py313 → py311) to match the `requires-python` floor, and makes the numba compatibility shim typecheck whether or not the optional extra is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)