### PR TITLE
chore: version-pin PyPI README links via hatch-fancy-pypi-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/bertpl/counted-float/blob/main/LICENSE)
 [![code style: ruff](https://img.shields.io/badge/code%20style-ruff-261230)](https://github.com/astral-sh/ruff)
 
-![counted_float logo](https://raw.githubusercontent.com/bertpl/counted-float/main/images/splash/splash.webp)
+![counted_float logo](images/splash/splash.webp)
 
 # counted-float
 
@@ -176,7 +176,7 @@ counts.total_count()         # 2
 The `counted_float` package contains a set of default, built-in FLOP weights, based on both empirical measurements
 and theoretical estimates of the relative cost of different floating point operations.
 
-See [fpu_data_sources.md](https://github.com/bertpl/counted-float/tree/develop/docs/analysis_methodology.md) for
+See [analysis_methodology.md](docs/analysis_methodology.md) for
 rationale behind choice of data sources and methodology.
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,9 @@
 name = "counted-float"
 version = "1.1.2"
 description = "Count floating-point operations in Python code & benchmark relative flop costs."
-readme = "README.md"
+# readme is dynamic: hatch-fancy-pypi-readme builds the PyPI long-description from
+# README.md, rewriting relative links to tag-pinned absolute URLs (config below).
+dynamic = ["readme"]
 requires-python = ">=3.11"
 dependencies = [
     # Per-Python floors: each compiled dep's floor is the earliest version shipping a
@@ -71,8 +73,24 @@ dev = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-fancy-pypi-readme"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+# image embeds (splash, ...): relative -> tag-pinned raw URL for PyPI
+pattern = '\]\((images/[^)]+)\)'
+replacement = '](https://raw.githubusercontent.com/bertpl/counted-float/v$HFPR_VERSION/\1)'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+# docs/*.md references: relative -> tag-pinned blob URL for PyPI
+pattern = '\]\((docs/[^)]+)\)'
+replacement = '](https://github.com/bertpl/counted-float/blob/v$HFPR_VERSION/\1)'
 
 [tool.hatch.build.targets.sdist]
 # configs below also make sure the .whl file contains the data files, because wheels are built from the sdist


### PR DESCRIPTION
Adopts **`hatch-fancy-pypi-readme`** — a hatchling build hook (`dynamic = ["readme"]`, not a CI step). The committed README keeps **relative** links (correct on GitHub); at build time the hook rewrites them to **absolute, tag-pinned** URLs (`.../v$HFPR_VERSION/...`) for the PyPI long-description.

Applied to:
- **the splash** — static today, but version-pinning is ~free and sets up a future version-dependent splash;
- **the `docs/*.md` reference** — which also fixes three real bugs in the old link: wrong link text (`fpu_data_sources.md` vs. the `analysis_methodology.md` target), a stale `develop` branch pin, and `/tree/` used for a file (now `/blob/`).

Substitutions match relative paths only, so the already-absolute shields.io/live badges are never touched. **Verified against the built wheel's METADATA**: splash → `raw.githubusercontent.com/.../v1.1.2/images/splash/splash.webp`, docs → `.../blob/v1.1.2/docs/analysis_methodology.md`, badges unchanged. (The version is 1.1.2 on the branch; release.py stamps the real version at build time.)

After this merges, **v1.1.3 is released with `make release VERSION=1.1.3`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
