### PR TITLE
chore: pin CI actions to SHAs and harden workflow permissions

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -15,29 +15,31 @@ runs:
     using: "composite"
     steps:
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
           version: ${{ inputs.uv_version }}
 
       - name: Determine Python version
         shell: bash
-        run: |
-            if [ -n "${{ inputs.python_version }}" ]; then
-                echo "PYTHON_EFFECTIVE_VERSION=${{ inputs.python_version }}" >> $GITHUB_ENV
+        run: |  # zizmor: ignore[github-env] value is a workflow-controlled Python version, not user input
+            if [ -n "${INPUTS_PYTHON_VERSION}" ]; then
+                echo "PYTHON_EFFECTIVE_VERSION=${INPUTS_PYTHON_VERSION}" >> $GITHUB_ENV
             else
                 PYTHON_VERSION=$(cat .python-version)
                 echo "PYTHON_EFFECTIVE_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
             fi
-            echo "Using PYTHON ${{ env.PYTHON_EFFECTIVE_VERSION }}."
+            echo "Using PYTHON ${PYTHON_EFFECTIVE_VERSION}."
+        env:
+          INPUTS_PYTHON_VERSION: ${{ inputs.python_version }}
 
       - name: Set up venv, Python ${{ env.PYTHON_EFFECTIVE_VERSION }} & dependencies
         shell: bash
         run:  |
-            uv python install ${{ env.PYTHON_EFFECTIVE_VERSION }}
-            uv venv --python ${{ env.PYTHON_EFFECTIVE_VERSION }}
+            uv python install ${PYTHON_EFFECTIVE_VERSION}
+            uv venv --python ${PYTHON_EFFECTIVE_VERSION}
             uv sync --all-extras --dev
 
       - name: Run benchmarks
         shell: bash
         run:  |
-            uv run --all-extras --python ${{ env.PYTHON_EFFECTIVE_VERSION }} counted_float benchmark
+            uv run --all-extras --python ${PYTHON_EFFECTIVE_VERSION} counted_float benchmark

--- a/.github/actions/pre_commit/action.yml
+++ b/.github/actions/pre_commit/action.yml
@@ -11,13 +11,13 @@ runs:
     using: composite
     steps:
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.3.0
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
           version: ${{ inputs.uv_version }}
           enable-cache: true
 
       - name: Cache pre-commit hook environments
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/actions/unit_test/action.yml
+++ b/.github/actions/unit_test/action.yml
@@ -27,7 +27,7 @@ runs:
     using: composite
     steps:
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.3.0
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
           version: ${{ inputs.uv_version }}
           # Distinct cache key per combo so parallel legs don't race to save one shared key.
@@ -37,7 +37,7 @@ runs:
         shell: bash
         env:
           REQUESTED: ${{ inputs.python_version }}
-        run: |
+        run: |  # zizmor: ignore[github-env] value is a workflow-controlled Python version, not user input
           PY="${REQUESTED:-$(cat .python-version)}"
           echo "PYTHON_EFFECTIVE_VERSION=$PY" >> "$GITHUB_ENV"
           echo "Using Python $PY."
@@ -81,7 +81,7 @@ runs:
 
       - name: Upload coverage + node-id data
         if: inputs.coverage == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-data-${{ inputs.python_version }}-${{ inputs.dependency_resolution }}-extras-${{ inputs.include_all_extra_deps }}
           path: |

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -28,7 +28,9 @@ jobs:
           - { python: "3.11", resolution: highest,       all_extras: "false" }  # numba-absent shim
           - { python: "3.14", resolution: highest,       all_extras: "false" }  # numba-absent shim
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/unit_test
         with:
           uv_version: ${{ vars.UV_VERSION }}
@@ -53,12 +55,14 @@ jobs:
         run: |
           echo "::error::test matrix did not fully succeed (core result: ${{ needs.core.result }})"
           exit 1
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.3.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
           version: ${{ vars.UV_VERSION }}
       - name: Download coverage data from all matrix combos
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-data-*
           merge-multiple: true
@@ -69,7 +73,7 @@ jobs:
       - name: Compute release metrics (coverage % + test count)
         run: uv run --group dev python .github/scripts/ci_compute_metrics.py metrics.json
       - name: Upload release metrics
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-metrics
           path: metrics.json

--- a/.github/workflows/benchmark_linux_arm.yml
+++ b/.github/workflows/benchmark_linux_arm.yml
@@ -2,12 +2,17 @@ name: benchmark_linux_arm.yml
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run_benchmark:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark
         with:

--- a/.github/workflows/benchmark_linux_x86.yml
+++ b/.github/workflows/benchmark_linux_x86.yml
@@ -2,12 +2,17 @@ name: benchmark_linux_x86.yml
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run_benchmark:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark
         with:

--- a/.github/workflows/benchmark_macos_arm.yml
+++ b/.github/workflows/benchmark_macos_arm.yml
@@ -2,12 +2,17 @@ name: benchmark_macos_arm.yml
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run_benchmark:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark
         with:

--- a/.github/workflows/benchmark_macos_x86.yml
+++ b/.github/workflows/benchmark_macos_x86.yml
@@ -2,12 +2,17 @@ name: benchmark_macos_x86.yml
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run_benchmark:
     runs-on: macos-15-intel
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark
         with:

--- a/.github/workflows/benchmark_windows_x86.yml
+++ b/.github/workflows/benchmark_windows_x86.yml
@@ -2,12 +2,17 @@ name: benchmark_windows_x86.yml
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run_benchmark:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,9 +40,10 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check changelog updated for feat/ and fix/ branches
         env:
           BRANCH: ${{ github.head_ref }}
@@ -63,7 +64,9 @@ jobs:
     needs: [preflight]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/pre_commit
         with:
           uv_version: ${{ vars.UV_VERSION }}

--- a/.github/workflows/push_to_branch.yml
+++ b/.github/workflows/push_to_branch.yml
@@ -36,7 +36,9 @@ jobs:
     if: needs.check-open-pr.outputs.has_pr == 'false'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/pre_commit
         with:
           uv_version: ${{ vars.UV_VERSION }}
@@ -46,7 +48,9 @@ jobs:
     if: needs.check-open-pr.outputs.has_pr == 'false'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/unit_test
         with:
           uv_version: ${{ vars.UV_VERSION }}

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -3,23 +3,29 @@ on:
   push:
     tags: ["v*"]
 
+permissions:
+  contents: read
+
 jobs:
   validate-tag-version:
     name: Validate tag name matches package version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
           version: ${{ vars.UV_VERSION }}
+          enable-cache: false
 
       - name: Validate tag and version match
         run: |
           PACKAGE_VERSION=$(uv version --short)
-          TAG_NAME="${{ github.ref_name }}"
+          TAG_NAME="${GITHUB_REF_NAME}"
           EXPECTED_TAG="v${PACKAGE_VERSION}"
 
           echo "Package version: ${PACKAGE_VERSION}"
@@ -44,19 +50,22 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
           version: ${{ vars.UV_VERSION }}
+          enable-cache: false
 
       - name: Build package with uv
         shell: bash
         run: uv build
 
       - name: Publish package distributions to PyPI   [---PROD---]
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://upload.pypi.org/legacy/
   # No bump-version job: release.py owns versioning (it bumps pyproject and opens

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,11 @@ repos:
     hooks:
       - id: actionlint
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.25.2
+    hooks:
+      - id: zizmor  # security linter for workflows — complements actionlint (correctness)
+
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.37.2
     hooks:


### PR DESCRIPTION
Pin every external action reference to a commit SHA — normalizing each to its latest release, with the version in a trailing comment — so the CI supply chain no longer floats on mutable tags. Alongside the pins: least-privilege `permissions:` on every workflow and `persist-credentials: false` on every checkout, plus a zizmor pre-commit hook that keeps the workflow set hardened going forward.

Two `github-env` findings are suppressed with an inline justification: the value written is a workflow-controlled Python version, not user input.

No user-facing change.