### PR TITLE
chore: add Dependabot config and auto-merge for patch/minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # "/" scans .github/workflows; each composite action under .github/actions
+    # needs its own entry for the `uses:` pins inside it to be tracked.
+    directories:
+      - "/"
+      - "/.github/actions/unit_test"
+      - "/.github/actions/pre_commit"
+      - "/.github/actions/benchmark"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:  # one batched PR for all action bumps
+        patterns: ["*"]
+    # Let releases age before PRs open: auto-merged patch/minor bumps then sit
+    # long enough for upstream compromises to surface before they can land.
+    cooldown:
+      default-days: 7  # zizmor's dependabot-cooldown floor; ~no-op at weekly cadence anyway
+      semver-major-days: 14
+
+  - package-ecosystem: "uv"
+    # Bumps uv.lock (and pyproject pins) for the runtime + dev/lint/type tooling
+    # the lockfile deliberately pins — those rot without automated updates.
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python:  # one batched PR for all Python-dependency bumps
+        patterns: ["*"]
+    cooldown:
+      default-days: 7  # zizmor's dependabot-cooldown floor; ~no-op at weekly cadence anyway
+      semver-major-days: 14

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,0 +1,32 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # PR author, not github.actor: the actor is whoever triggered the event
+    # (e.g. a human re-running checks), so it can grant or drop the exemption
+    # incorrectly; the author is the property the gate actually means.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write       # to merge
+      pull-requests: write  # to approve + enable auto-merge
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      # Approve and queue native auto-merge for patch/minor only; majors get a PR
+      # that waits for a human. The `CI gate` check still gates the actual merge.
+      - name: Approve and enable auto-merge for patch & minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,7 @@ repos:
     rev: 0.37.2
     hooks:
       - id: check-github-workflows
+      - id: check-dependabot
 
   # ----------------------------------------------------------------------------
   #  Commit-msg stage: enforce the <prefix>: subject convention


### PR DESCRIPTION
Weekly grouped Dependabot updates for GitHub Actions (workflows + each composite action) and uv dependencies, with release cooldowns so bumps age before landing. An auto-merge workflow approves and queues patch/minor updates behind the CI gate; major bumps open a PR that waits for a human.

Also adds the `check-dependabot` pre-commit hook. Note: Dependabot has no pre-commit ecosystem, so managed hook revisions are not auto-bumped by it. Stacked on the Scorecard branch. No user-facing change.