### PR TITLE
chore: add a blocking pip-audit dependency-CVE gate

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -75,6 +75,31 @@ jobs:
     needs: [preflight]
     uses: ./.github/workflows/_unit_tests.yml
 
+  # Synchronous dependency-CVE gate: audits the locked runtime dependencies
+  # against the advisory DB at PR time — the blocking complement to the async,
+  # repo-level Dependabot alerts. Hard-fails on any advisory; accepted ones go
+  # in `ignore-vulns` below with a justification.
+  pip-audit:
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          version: ${{ vars.UV_VERSION }}
+      - name: Export the locked runtime dependencies
+        run: uv export --frozen --no-emit-project --no-dev --no-hashes --format requirements-txt -o requirements.txt
+      - uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266 # v1.1.0
+        with:
+          inputs: requirements.txt
+          no-deps: "true"  # requirements.txt is already the full pinned closure
+          # Accepted/unfixable advisories go here (one id per line) with a reason:
+          # ignore-vulns: |
+          #   GHSA-xxxx-xxxx-xxxx  # why accepted
+
   ci-gate:
     name: CI gate
     # The single stable required check on main: branch protection requires only
@@ -82,7 +107,7 @@ jobs:
     # `always()` is load-bearing — without it the gate is skipped when an
     # upstream job fails, and GitHub treats a skipped required check as passing.
     if: always()
-    needs: [preflight, pre-commit, test]
+    needs: [preflight, pre-commit, test, pip-audit]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job did not succeed


### PR DESCRIPTION
Export the locked runtime dependency closure and audit it against the advisory DB on every PR, hard-failing on any advisory — the synchronous, blocking complement to Dependabot's asynchronous alerts. Wired into the CI gate. Accepted or unfixable advisories go in a documented `ignore-vulns` list (empty today). Stacked on the Dependabot branch. No user-facing change.