### PR TITLE
chore: attest SLSA build provenance and create GitHub Releases

### DIFF
--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -46,8 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: prod
     permissions:
-      # IMPORTANT: this permission is mandatory for Trusted Publishing
-      id-token: write
+      contents: read       # job-level perms replace the top-level block, so re-list read for checkout
+      id-token: write      # mandatory for Trusted Publishing; also signs the keyless provenance
+      attestations: write  # store SLSA build provenance for the wheel + sdist
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -64,9 +65,69 @@ jobs:
         shell: bash
         run: uv build
 
+      # SLSA build provenance over the exact artifacts we publish. Complements
+      # (does not replace) the PEP 740 attestations gh-action-pypi-publish emits
+      # on PyPI: this one is verifiable from the GitHub side via
+      # `gh attestation verify <artifact> --repo bertpl/counted-float`, and its
+      # bundle is attached to the GitHub Release by the github-release job below.
+      - name: Attest SLSA build provenance for the wheel + sdist
+        id: attest
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          # List the artifact patterns explicitly rather than `dist/*`: uv build
+          # drops a `dist/.gitignore` into the output dir, which a glob would
+          # otherwise sweep into the provenance as a spurious subject.
+          subject-path: |
+            dist/*.whl
+            dist/*.tar.gz
+      # Extension is `.intoto.jsonl`, not `.sigstore.jsonl`: OpenSSF Scorecard's
+      # Signed-Releases check credits provenance purely by this filename suffix
+      # (it never opens the file). Do not "correct" it — the suffix is what scores.
+      - name: Stage the provenance bundle under a stable name
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}  # via env, not inline — keep it out of the run: template
+        run: cp "$BUNDLE_PATH" provenance.intoto.jsonl
+      - name: Hand the provenance bundle to the release job
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: provenance-bundle
+          path: provenance.intoto.jsonl
+          if-no-files-found: error
+
       - name: Publish package distributions to PyPI   [---PROD---]
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://upload.pypi.org/legacy/
+
+  github-release:
+    needs: publish-to-prod
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create the GitHub Release (implies the read the checkout needs)
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          version: ${{ vars.UV_VERSION }}
+          enable-cache: false
+      - name: Download the provenance bundle from the publish job
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: provenance-bundle
+      - name: Extract release notes from CHANGELOG.md
+        run: uv run python scripts/extract_changelog.py > release_notes.md
+      - name: Create GitHub Release with the provenance bundle attached
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file release_notes.md \
+            provenance.intoto.jsonl
   # No bump-version job: release.py owns versioning (it bumps pyproject and opens
   # the next Unreleased section as part of the local release, before the tag push).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- release artifacts now ship with SLSA build provenance and a GitHub Release; provenance is verifiable with `gh attestation verify`
+
 ## 1.1.3 (2026-07-06)
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,8 @@ exclude_also = [
 
 [tool.codespell]
 # `sme`: "SME" (ARM's Scalable Matrix Extension) appears in the analysis docs.
-ignore-words-list = "sme"
+# `intoto`: the in-toto attestation format (`provenance.intoto.jsonl`).
+ignore-words-list = "sme,intoto"
 
 [tool.pytest.ini_options]
 addopts = "-n auto --dist worksteal"

--- a/scripts/extract_changelog.py
+++ b/scripts/extract_changelog.py
@@ -1,0 +1,54 @@
+"""Extract a single version's section from CHANGELOG.md and print to stdout.
+
+Used by release_tag.yml to populate the GitHub Release notes from the
+just-released section in CHANGELOG.md.  The version is taken from the
+git tag of the current commit (e.g. v0.1.0 -> 0.1.0).  If no tag is
+present, exits non-zero with a clear error.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+CHANGELOG = Path(__file__).resolve().parent.parent / "CHANGELOG.md"
+
+
+def current_tag_version() -> str:
+    """Read the version string from the git tag on HEAD."""
+    result = subprocess.run(
+        ["git", "describe", "--exact-match", "--tags", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.exit("error: HEAD is not at a tag")
+    tag = result.stdout.strip()
+    if not tag.startswith("v"):
+        sys.exit(f"error: tag {tag!r} does not start with 'v'")
+    return tag[1:]
+
+
+def extract_section(text: str, version: str) -> str:
+    """Extract the changelog body for a specific version."""
+    pattern = re.compile(
+        rf"^## {re.escape(version)}\b.*?$(.*?)(?=^## |\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        sys.exit(f"error: no '## {version}' section in CHANGELOG.md")
+    return match.group(1).strip() + "\n"
+
+
+def main() -> None:
+    """Entry point."""
+    version = current_tag_version()
+    sys.stdout.write(extract_section(CHANGELOG.read_text(), version))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
On a release tag, the publish job now attests SLSA build provenance over the exact wheel and sdist it publishes, and a new job creates a GitHub Release carrying that release's changelog section plus the provenance bundle. Provenance is verifiable from the GitHub side with `gh attestation verify <artifact> --repo bertpl/counted-float`.

Adds a small `extract_changelog.py` to pull the release notes from CHANGELOG.md. The release workflow runs only on tag push, so it is exercised at the next actual release, not by this PR. Stacked on the CodeQL branch.

Changelog: Security — signed/attested releases (user-visible on PyPI and GitHub Releases).