### PR TITLE
chore: add CONTRIBUTING.md and SECURITY.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- added a security policy (`SECURITY.md`) with a private vulnerability reporting channel
+
 ## 1.1.4 (2026-07-06)
 
 ### Security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing to counted-float
+
+Thanks for your interest in contributing.
+
+## Security
+
+Found a vulnerability? Please report it privately — see
+[`SECURITY.md`](SECURITY.md). Do not open a public issue for it.
+
+## Dev setup
+
+One-time setup on a fresh clone:
+
+```bash
+uv sync --all-extras
+uv run pre-commit install
+```
+
+This syncs dev dependencies (including the optional extras) via `uv` and
+installs pre-commit hooks.
+
+## Common commands
+
+```bash
+make test     # Run the test suite (pytest)
+make lint     # Run all pre-commit checks (format, ruff, ty, hygiene)
+make format   # Format and auto-fix with ruff
+```
+
+## Development workflow
+
+- **External contributors** -- fork the repository, create your branch in the
+  fork, and open a pull request against the upstream `main`.
+- **Core maintainers** (write access) -- branch directly on the upstream repo,
+  and may use an internal or composite numbering scheme (e.g. a per-version PR
+  sequence) in place of an issue number.
+
+## Branching
+
+Branch names follow the pattern:
+
+```
+<prefix>/<issue-number>-<short-slug>
+```
+
+- **Prefix** -- one of `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`,
+  `test/`. CI rejects anything else.
+- **Issue number** -- the GitHub issue the change addresses. If none exists
+  yet, open one first, so every change traces back to a tracked discussion.
+  Core maintainers may instead use an internal or composite numbering scheme
+  in place of an issue number (see *Development workflow* above).
+- **Slug** -- short kebab-case description: lowercase letters, digits, and
+  hyphens only.
+
+Examples: `feat/42-new-input-format`, `fix/57-crash-on-empty-input`.
+
+## Pull requests
+
+PRs are merged into `main` via **squash merge only** (repo settings disable
+merge commits and rebase merges). Each PR therefore produces exactly one commit
+on `main`. The squash commit subject is the PR title and the body is the PR
+body, so write both with care -- they become the permanent history. The feature
+branch is deleted automatically on merge.
+
+## Commit messages
+
+Subject line uses the same short-form prefixes as branches:
+
+```
+<prefix>: <imperative summary>
+```
+
+- **Prefix** -- `feat`, `fix`, `chore`, `docs`, `refactor`, `test` (matching
+  the branch prefix is the common case but not required).
+- **Summary** -- imperative mood, lowercase, no trailing period, ideally under
+  72 characters.
+
+The body (optional) explains *why*, not *what*. Wrap at ~72 characters.
+
+## Changelog
+
+Add an entry under the appropriate category in the `## Unreleased` section of
+[`CHANGELOG.md`](CHANGELOG.md) as part of your PR.
+
+Changelog entries are **user-facing** — write them for someone deciding whether
+to upgrade, not for someone reviewing the implementation.
+
+**Keep each entry to a single line.** Omit internal details (class names,
+wiring, behavior-neutral refactors). Expand to a second line only when one line
+genuinely can't convey the change.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes land in a new release on top of the latest published version;
+older versions are not patched in place.
+
+| Version          | Supported          |
+| ---------------- | ------------------ |
+| latest release   | :white_check_mark: |
+| any earlier      | :x:                |
+
+Always upgrade to the most recent release on
+[PyPI](https://pypi.org/project/counted-float/) to receive security fixes.
+
+## Reporting a vulnerability
+
+Please report security issues **privately** — do not open a public issue,
+discussion, or pull request for a suspected vulnerability.
+
+Use GitHub's [Private Vulnerability Reporting](https://github.com/bertpl/counted-float/security/advisories/new)
+to open a confidential advisory. This is the only supported reporting channel;
+the project publishes no maintainer email address.
+
+When reporting, please include:
+
+- the counted-float version and Python version,
+- a description of the issue and its impact,
+- a minimal input or set of steps that reproduces it.
+
+## What to expect
+
+This is a solo-maintained project, so responses are best-effort:
+
+- **Acknowledgment** within 7 days.
+- **Initial assessment** (confirmed / needs-more-info / not-a-vulnerability)
+  within 14 days.
+- A fix released as soon as practical once an issue is confirmed, with the
+  advisory published alongside it.
+
+Please allow a reasonable window for a fix before any public disclosure.
+Coordinated disclosure is appreciated, and reporters are credited in the
+published advisory unless they prefer to remain anonymous.


### PR DESCRIPTION
Adds a contribution guide (fork-based flow for external contributors, direct branches for core maintainers, branch/commit/changelog conventions) and a security policy: latest-release-only support, with GitHub private vulnerability reporting as the sole reporting channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)