### PR TITLE
fix: add blank lines before lists in methodology docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- bullet lists in the methodology pages of the documentation site now render correctly
+
 ### Security
 
 ## 1.2.0 (2026-07-06)

--- a/docs/analysis_methodology.md
+++ b/docs/analysis_methodology.md
@@ -16,6 +16,7 @@ Intel Itanium, Transmeta, IBM Power... chips can be considered either obsolete o
 Given the nature of algorithms we intend to analyze, the type of math code typically consists of a mix of instructions,
 forming dependent chains of operations, that lead to choices (strategy, terminate, ...) made in each iteration.  This
 type of code does not lend itself to being easily vectorized, hence we ignore vector instructions:
+
 - **x86**: SSE2/3/4 vector instructions, AVX<n>, ...
 - **arm**: SVE, SME, NEON, ...
 
@@ -30,6 +31,7 @@ For ARM processors, we should focus on arm v8-A or higher (AARCH64/ARM64).
 ## 1.4. Latency types
 
 For most processors, two instruction latency figures can typically be obtained (*naming varies*):
+
 - **execution latency**: time needed for end-to-end execution until a new instruction can start using the end result
 - **(reciprocal) throughput**: time needed per instruction with maximal throughput for independent similar operations
 
@@ -47,6 +49,7 @@ to work with a maximum of 4K double precision values.
 # 2. Sources
 
 We will focus on 3 types of sources for FPU instruction 'cost':
+
 * **benchmarks**: these are the benchmarks implemented in this package; these can be run on each CPU architecture that is
   supported by numba and can analyze each type of math operation, even those that have no hardware support in some or all cpu architectures.
 * **external - analyses**: CPU latency numbers obtained by 3rd parties by running tailored benchmarks / analyses; limited to what can be publicly found.
@@ -87,6 +90,7 @@ x87 instructions are provided fyi; for x86 CPUs only SSE2/3/4.1 scalar instructi
 | cos(x)                 | FCOS + ?                      | /             | /              |
 
 **NOTES**
+
 - ***(1)*** These instructions don't have Scalar versions (only Packed versions)
 - ***(2)*** Different comparison instructions in SSE2
      - CMPSD   : executes a specific comparison based on a 'predicate' (=instruction which comparison to perform) and outputs to a register all 0s or all 1s

--- a/docs/cpu_architectures_scope.md
+++ b/docs/cpu_architectures_scope.md
@@ -1,6 +1,7 @@
 # 1. Introduction
 
 As mentioned [here](./analysis_methodology.md), we will focus on the following classes of CPUs:
+
 - x86 & arm  (dominant architectures in laptops, desktops & cloud computing)
 - 64-bit architectures only
 - CPUs released in the last 5-10yr, with higher emphasis on more recent models
@@ -32,6 +33,7 @@ In general, we focus on those micro-architectures that are _not_ mobile-only and
 | 2024     | [Lion Cove](https://en.wikipedia.org/wiki/Lion_Cove)                                                                                                                         | Core 2 Ultra: [Arrow Lake](https://en.wikipedia.org/wiki/Arrow_Lake_(microprocessor)) & [Lunar Lake](https://en.wikipedia.org/wiki/Lunar_Lake) (P cores)                                 | / ***(2)***                                                                                    |           |
 
 **Notes:**
+
 - ***(1)*** but with improvements to FPU multiplication latencies
 - ***(2)*** no server variants announced at the time of writing.
 
@@ -78,6 +80,7 @@ in the last ±10 years, we will focus on **ARM v8.2-A or higher**, as this ISA w
 | 2024-10   |           | ARMv9.6-A ***(1)*** |
 
 Notes:
+
 - ***(1)*** at the time of writing no chips have been released with support for these ISA levels.
 
 Finally, since the ARM microarchitecture is used over a wide range of devices from low-power embedded chips to high-performance
@@ -85,6 +88,7 @@ HPC servers, we will restrict ourselves to ARM cores that are classified as eith
 consider **'efficiency' and similar** cores as **out-of-scope**.
 
 More background:
+
 - https://en.wikipedia.org/wiki/Comparison_of_ARM_processors
 - https://en.wikipedia.org/wiki/AArch64
 


### PR DESCRIPTION
python-markdown (unlike GitHub's renderer) requires a blank line before a list starts; the two methodology documents predate the docs site and rendered their bullet lists as run-on prose there. Eight blank-line insertions fix all affected lists; GitHub rendering is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)