### PR TITLE
fix: cap benchmark n_executions to prevent int64 overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `run_flops_benchmark()` no longer crashes with `OverflowError` on modern numba versions
+
 ### Security
 
 ## 1.2.1 (2026-07-06)

--- a/counted_float/_core/benchmarking/micro/_micro_benchmark.py
+++ b/counted_float/_core/benchmarking/micro/_micro_benchmark.py
@@ -28,6 +28,8 @@ class MicroBenchmark(ABC):
     """
 
     MAX_N_EXECUTIONS_FACTOR = 10  # never adjust n_executions by more than this factor (up or down)
+    MAX_N_EXECUTIONS = 10**12  # absolute cap; unbounded growth (e.g. when a jit-compiled kernel is
+    #                            dead-code-eliminated and runtime stays flat) would overflow int64
 
     def __init__(self, name: str, single_execution: str = "execution") -> None:
         self.name = name
@@ -72,7 +74,7 @@ class MicroBenchmark(ABC):
 
             # --- adjust n_ops ---
             n_ops_min = max(1, int(n_executions / self.MAX_N_EXECUTIONS_FACTOR))
-            n_ops_max = int(n_executions * self.MAX_N_EXECUTIONS_FACTOR)
+            n_ops_max = min(int(n_executions * self.MAX_N_EXECUTIONS_FACTOR), self.MAX_N_EXECUTIONS)
             n_executions = max(n_ops_min, min(n_ops_max, int(n_executions * n_seconds_per_run_target / t_tot_seconds)))
 
         # final results

--- a/tests/benchmarking/micro/test_micro_benchmark.py
+++ b/tests/benchmarking/micro/test_micro_benchmark.py
@@ -75,3 +75,31 @@ def test_micro_benchmark(n_runs_total: int, n_runs_warmup: int, n_seconds_per_ru
     assert results.summary_stats_nsecs_per_exec().q75 > 0.9 * nsec_per_exec, (
         "estimated time range should approx. enclose actual time"
     )
+
+
+class FlatRuntimeMicroBenchmark(MicroBenchmark):
+    """Benchmark whose runtime does not scale with n_executions, mimicking a dead-code-eliminated kernel."""
+
+    def __init__(self):
+        super().__init__(name="flat")
+        self.max_n_executions_seen = 0
+
+    def _prepare_benchmark(self, n_executions: int):
+        self.max_n_executions_seen = max(self.max_n_executions_seen, n_executions)
+
+    def _run_benchmark(self):
+        pass
+
+
+def test_micro_benchmark_flat_runtime_respects_cap():
+    # --- arrange -----------------------------------------
+    benchmark = FlatRuntimeMicroBenchmark()
+
+    # --- act ---------------------------------------------
+    # default-like parameters; a flat runtime makes the adaptive sizing grow n_executions
+    # by MAX_N_EXECUTIONS_FACTOR every run, which must stop at MAX_N_EXECUTIONS
+    results = benchmark.run_many(n_runs_total=40, n_runs_warmup=15, n_seconds_per_run_target=0.1)
+
+    # --- assert ------------------------------------------
+    assert isinstance(results, MicroBenchmarkResult)
+    assert benchmark.max_n_executions_seen == MicroBenchmark.MAX_N_EXECUTIONS


### PR DESCRIPTION
Newer numba/llvmlite (≥ 0.66 / 0.48) dead-code-eliminates the baseline kernel's outer repetition loop, making its runtime flat in `n_executions`; the adaptive sizing in `MicroBenchmark.run_many` then grew `n_executions` tenfold per run without bound until it overflowed numba's int64 argument, crashing `run_flops_benchmark()` with `OverflowError` on modern environments.

An absolute cap of 10^12 stops the growth well below the overflow point while staying far above any realistic sizing need. The baseline kernel's own timings are informational only (all latency estimates are kernel-pair differences), so the cap is the complete fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)