### PR TITLE
fix: restore prior counting state when exiting PauseFlopCounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `run_flops_benchmark()` no longer crashes with `OverflowError` on modern numba versions
 - corrected documentation errors (FLOP-type counting rules, configuration function names, default rounding mode, CPU coverage tables)
+- nested or pre-paused `PauseFlopCounting` no longer resumes counting too early
 
 ### Security
 

--- a/counted_float/_core/counting/_context_managers.py
+++ b/counted_float/_core/counting/_context_managers.py
@@ -92,10 +92,16 @@ class FlopCountingContext:
 class PauseFlopCounting:
     """Context manager that pauses flop counting for the enclosed code block.
 
-    This acts globally, across all active FlopCountingContext instances.
+    This acts globally, across all active FlopCountingContext instances.  On exit the counter's
+    prior state is restored (rather than counting being resumed unconditionally), so these blocks
+    can be nested and can sit inside code that already paused counting.
     """
 
+    def __init__(self) -> None:
+        self.__was_active: bool = False
+
     def __enter__(self) -> Self:
+        self.__was_active = GLOBAL_COUNTER.is_active()
         GLOBAL_COUNTER.pause()
         return self
 
@@ -105,4 +111,5 @@ class PauseFlopCounting:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        GLOBAL_COUNTER.resume()
+        if self.__was_active:
+            GLOBAL_COUNTER.resume()

--- a/tests/counting/test_context_managers.py
+++ b/tests/counting/test_context_managers.py
@@ -1,5 +1,6 @@
 from counted_float._core.counting._context_managers import FlopCountingContext, PauseFlopCounting
 from counted_float._core.counting._counted_float import CountedFloat
+from counted_float._core.counting._global_counter import GLOBAL_COUNTER
 
 
 # =================================================================================================
@@ -189,3 +190,43 @@ def test_pause_flop_counting():
     assert flop_counts_1.total_count() == 1
     assert flop_counts_2.total_count() == 1
     assert flop_counts_3.total_count() == 0
+
+
+def test_pause_flop_counting_nested():
+    # --- arrange -----------------------------------------
+    cf1 = CountedFloat(1.0)
+    cf2 = CountedFloat(2.0)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext() as fcc:
+        with PauseFlopCounting():
+            with PauseFlopCounting():
+                _ = cf1 + cf2  # should not be counted (doubly paused)
+            _ = cf1 * cf2  # should not be counted (still inside outer pause)
+        _ = cf1 / cf2  # should be counted (both pauses exited)
+
+    # --- assert ------------------------------------------
+    flop_counts = fcc.flop_counts()
+    assert flop_counts.ADD == 0
+    assert flop_counts.MUL == 0
+    assert flop_counts.DIV == 1
+
+
+def test_pause_flop_counting_restores_paused_state():
+    # --- arrange -----------------------------------------
+    cf1 = CountedFloat(1.0)
+    cf2 = CountedFloat(2.0)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext() as fcc:
+        GLOBAL_COUNTER.pause()
+        with PauseFlopCounting():
+            pass
+        _ = cf1 + cf2  # should not be counted: counter was already paused before the with-block
+        GLOBAL_COUNTER.resume()
+        _ = cf1 * cf2  # should be counted
+
+    # --- assert ------------------------------------------
+    flop_counts = fcc.flop_counts()
+    assert flop_counts.ADD == 0
+    assert flop_counts.MUL == 1


### PR DESCRIPTION
Exiting a `PauseFlopCounting` block unconditionally resumed global counting, with two consequences: an inner block re-enabled counting inside an outer paused region (nested pauses), and a counter that was already paused before entry was force-resumed on exit.

The context manager now snapshots the counter's active state on enter and restores it on exit, making pause blocks safely nestable and composable with code that already paused counting. Regression tests cover both scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)