### PR TITLE
fix: delegate mixed-type operations like float and count only successful ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `run_flops_benchmark()` no longer crashes with `OverflowError` on modern numba versions
 - corrected documentation errors (FLOP-type counting rules, configuration function names, default rounding mode, CPU coverage tables)
 - nested or pre-paused `PauseFlopCounting` no longer resumes counting too early
+- `CountedFloat` arithmetic and comparisons now delegate to the other operand like `float` does (e.g. `Fraction` interop no longer raises), and failed operations no longer pollute counts
 
 ### Security
 

--- a/counted_float/_core/counting/_counted_float.py
+++ b/counted_float/_core/counting/_counted_float.py
@@ -38,45 +38,63 @@ class CountedFloat(float):
 
     def __eq__(self, other: object) -> bool:
         """x==other or other==x."""
+        result = super().__eq__(other)
+        if result is NotImplemented:
+            return NotImplemented  # let Python try the reflected operation; nothing was computed, so nothing counts
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
-        return super().__eq__(other)
+        return result
 
     def __ne__(self, other: object) -> bool:
         """x!=other or other!=x."""
+        result = super().__ne__(other)
+        if result is NotImplemented:
+            return NotImplemented
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
-        return super().__ne__(other)
+        return result
 
     def __lt__(self, other: float) -> bool:
         """x<other."""
+        result = super().__lt__(other)
+        if result is NotImplemented:
+            return NotImplemented
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
-        return super().__lt__(other)
+        return result
 
     def __le__(self, other: float) -> bool:
         """x<=other."""
+        result = super().__le__(other)
+        if result is NotImplemented:
+            return NotImplemented
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
-        return super().__le__(other)
+        return result
 
     def __gt__(self, other: float) -> bool:
         """x>other."""
+        result = super().__gt__(other)
+        if result is NotImplemented:
+            return NotImplemented
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
-        return super().__gt__(other)
+        return result
 
     def __ge__(self, other: float) -> bool:
         """x>=other."""
+        result = super().__ge__(other)
+        if result is NotImplemented:
+            return NotImplemented
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
-        return super().__ge__(other)
+        return result
 
     def __round__(  # ty: ignore[invalid-method-override] -- float's stub narrows return per overload; this is the union
         self, n: SupportsIndex | None = None
@@ -116,59 +134,83 @@ class CountedFloat(float):
 
     def __add__(self, other: float) -> CountedFloat:
         """x+other."""
+        result = super().__add__(other)
+        if result is NotImplemented:
+            return NotImplemented
         GLOBAL_COUNTER.incr_add()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
-        return CountedFloat(super().__add__(other))
+        return CountedFloat(result)
 
     def __radd__(self, other: float) -> CountedFloat:
         """other+x."""
+        result = super().__radd__(other)
+        if result is NotImplemented:
+            return NotImplemented
         GLOBAL_COUNTER.incr_add()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
-        return CountedFloat(super().__radd__(other))
+        return CountedFloat(result)
 
     def __sub__(self, other: float) -> CountedFloat:
         """x-other."""
+        result = super().__sub__(other)
+        if result is NotImplemented:
+            return NotImplemented
         GLOBAL_COUNTER.incr_sub()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
-        return CountedFloat(super().__sub__(other))
+        return CountedFloat(result)
 
     def __rsub__(self, other: float) -> CountedFloat:
         """other-x."""
+        result = super().__rsub__(other)
+        if result is NotImplemented:
+            return NotImplemented
         GLOBAL_COUNTER.incr_sub()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
-        return CountedFloat(super().__rsub__(other))
+        return CountedFloat(result)
 
     def __mul__(self, other: float) -> CountedFloat:
         """x*other or other*x."""
+        result = super().__mul__(other)
+        if result is NotImplemented:
+            return NotImplemented
         GLOBAL_COUNTER.incr_mul()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
-        return CountedFloat(super().__mul__(other))
+        return CountedFloat(result)
 
     def __rmul__(self, other: float) -> CountedFloat:
         """other*x."""
+        result = super().__rmul__(other)
+        if result is NotImplemented:
+            return NotImplemented
         GLOBAL_COUNTER.incr_mul()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
-        return CountedFloat(super().__rmul__(other))
+        return CountedFloat(result)
 
     def __truediv__(self, other: float) -> CountedFloat:
         """x/other."""
+        result = super().__truediv__(other)
+        if result is NotImplemented:
+            return NotImplemented
         GLOBAL_COUNTER.incr_div()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
-        return CountedFloat(super().__truediv__(other))
+        return CountedFloat(result)
 
     def __rtruediv__(self, other: float) -> CountedFloat:
         """other/x."""
+        result = super().__rtruediv__(other)
+        if result is NotImplemented:
+            return NotImplemented
         GLOBAL_COUNTER.incr_div()
         if isinstance(other, int):
             GLOBAL_COUNTER.incr_i2f()
-        return CountedFloat(super().__rtruediv__(other))
+        return CountedFloat(result)
 
     def __pow__(self, other: float) -> CountedFloat:  # ty: ignore[invalid-method-override] -- no `mod` param; float.__pow__'s mod is None-only and unused here
         """x**other.
@@ -178,14 +220,23 @@ class CountedFloat(float):
         the strength reduction (x*x) a compiled port would apply. A float operand may just as well
         be a runtime variable that happens to hold that value, where a port would compile a
         generic pow, so `x**2.0` counts as POW.
+
+        A negative base with a fractional exponent yields a complex result (as for plain float);
+        complex values fall outside the counting model, so nothing is counted and the result is
+        returned unwrapped.
         """
+        result = super().__pow__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        if not isinstance(result, float):
+            return result
         if isinstance(other, int) and other == 2:
             GLOBAL_COUNTER.incr_mul()  # x^2 = x*x
         else:
             if isinstance(other, int):
                 GLOBAL_COUNTER.incr_i2f()
             GLOBAL_COUNTER.incr_pow()
-        return CountedFloat(super().__pow__(other))
+        return CountedFloat(result)
 
     def __rpow__(self, other: float) -> CountedFloat:  # ty: ignore[invalid-method-override] -- no `mod` param; float.__rpow__'s mod is None-only and unused here
         """other**x.
@@ -194,7 +245,16 @@ class CountedFloat(float):
         is taken as a hardcoded constant, counting as EXP2 / EXP10 (the strength reduction a
         compiled port would apply); a float base may be a runtime variable, so it counts as
         generic POW.
+
+        A negative base with a fractional exponent yields a complex result (as for plain float);
+        complex values fall outside the counting model, so nothing is counted and the result is
+        returned unwrapped.
         """
+        result = super().__rpow__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        if not isinstance(result, float):
+            return result
         if isinstance(other, int) and other == 2:
             GLOBAL_COUNTER.incr_exp2()
         elif isinstance(other, int) and other == 10:
@@ -203,4 +263,4 @@ class CountedFloat(float):
             if isinstance(other, int):
                 GLOBAL_COUNTER.incr_i2f()
             GLOBAL_COUNTER.incr_pow()
-        return CountedFloat(super().__rpow__(other))
+        return CountedFloat(result)

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -4,6 +4,12 @@
   `numpy`)
 - not all Python built-in math operations are counted (e.g. hyperbolic
   functions)
+- mixed operations with non-float numeric types are outside the counting
+  model: `CountedFloat` delegates to the other operand exactly like `float`
+  does, so e.g. a `fractions.Fraction` operand generally yields a correct but
+  plain — and uncounted — `float` result (downstream counting stops), while a
+  `decimal.Decimal` operand raises `TypeError` just as with plain `float`.
+  Numerical algorithms should use `float`/`CountedFloat` values throughout.
 - flop weights should be taken with a grain of salt and should only provide
   relative ballpark estimates w.r.t. computational complexity. Production
   implementations in a compiled language could have vastly differing

--- a/tests/counting/test_numeric_protocol.py
+++ b/tests/counting/test_numeric_protocol.py
@@ -1,0 +1,179 @@
+"""Tests for CountedFloat's numeric-protocol behavior with non-float operand types.
+
+CountedFloat must delegate to the other operand exactly like plain float does (returning
+NotImplemented so Python can try the reflected operation), must raise float's TypeError for
+genuinely unsupported operands, and must count an operation only when the float layer actually
+performed it.
+"""
+
+import operator
+from collections.abc import Callable
+from decimal import Decimal
+from fractions import Fraction
+
+import pytest
+
+from counted_float._core.counting._counted_float import CountedFloat
+from counted_float._core.counting._global_counter import GlobalFlopCounter
+
+ARITHMETIC_OPERATORS = [operator.add, operator.sub, operator.mul, operator.truediv, operator.pow]
+COMPARISON_OPERATORS = [operator.eq, operator.ne, operator.lt, operator.le, operator.gt, operator.ge]
+
+
+class ReflectedOps:
+    """Minimal foreign type implementing only reflected operators, as a stand-in for third-party numerics."""
+
+    def __radd__(self, other: float) -> str:
+        return "radd"
+
+    def __rsub__(self, other: float) -> str:
+        return "rsub"
+
+    def __rmul__(self, other: float) -> str:
+        return "rmul"
+
+    def __rtruediv__(self, other: float) -> str:
+        return "rtruediv"
+
+    def __rpow__(self, other: float) -> str:
+        return "rpow"
+
+    def __gt__(self, other: float) -> str:
+        return "gt"  # reflected counterpart of CountedFloat.__lt__
+
+
+# =================================================================================================
+#  Delegation to the other operand
+# =================================================================================================
+@pytest.mark.parametrize("op", [operator.add, operator.sub, operator.mul, operator.truediv])
+def test_arithmetic_with_fraction_matches_float(op: Callable, global_counter: GlobalFlopCounter):
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(1.5)
+    frac = Fraction(1, 2)
+
+    # --- act ---------------------------------------------
+    result = op(cf, frac)
+
+    # --- assert ------------------------------------------
+    # value & type parity with plain float; the delegated operation is deliberately NOT counted
+    # and the result demotes to plain float (documented known limitation)
+    assert result == op(1.5, frac)
+    assert type(result) is float
+    assert global_counter.total_count() == 0
+
+
+def test_pow_with_fraction_stays_counted(global_counter: GlobalFlopCounter):
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(1.5)
+
+    # --- act ---------------------------------------------
+    result = cf ** Fraction(1, 2)
+
+    # --- assert ------------------------------------------
+    # unlike the other operators, Fraction.__rpow__ computes base ** float(exponent) without
+    # stripping the subclass, so the operation lands back in CountedFloat.__pow__: the result
+    # stays contagious and is counted
+    assert result == 1.5 ** Fraction(1, 2)
+    assert isinstance(result, CountedFloat)
+    assert global_counter.POW == 1
+
+
+@pytest.mark.parametrize("op", COMPARISON_OPERATORS)
+def test_comparison_with_fraction_matches_float(op: Callable, global_counter: GlobalFlopCounter):
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(1.5)
+    frac = Fraction(1, 2)
+
+    # --- act ---------------------------------------------
+    result = op(cf, frac)
+
+    # --- assert ------------------------------------------
+    assert result == op(1.5, frac)
+    assert global_counter.total_count() == 0
+
+
+def test_reflected_operators_of_foreign_type_win(global_counter: GlobalFlopCounter):
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(1.5)
+    foreign = ReflectedOps()
+
+    # --- act & assert ------------------------------------
+    assert cf + foreign == "radd"
+    assert cf - foreign == "rsub"
+    assert cf * foreign == "rmul"
+    assert cf / foreign == "rtruediv"
+    assert cf**foreign == "rpow"
+    assert (cf < foreign) == "gt"
+    assert global_counter.total_count() == 0
+
+
+# =================================================================================================
+#  Unsupported operands raise float's TypeError
+# =================================================================================================
+@pytest.mark.parametrize("op", ARITHMETIC_OPERATORS)
+@pytest.mark.parametrize("other", ["abc", Decimal("0.5"), None])
+def test_arithmetic_with_unsupported_operand_raises(
+    op: Callable, other: object, global_counter: GlobalFlopCounter
+):
+    # --- act & assert ------------------------------------
+    # error parity with plain float (the exact message varies: str.__rmul__ raises its own
+    # "can't multiply sequence" TypeError, exactly as for plain float)
+    with pytest.raises(TypeError):
+        op(1.5, other)
+    with pytest.raises(TypeError):
+        op(CountedFloat(1.5), other)
+    assert global_counter.total_count() == 0
+
+
+def test_ordering_with_unsupported_operand_raises(global_counter: GlobalFlopCounter):
+    # --- act & assert ------------------------------------
+    with pytest.raises(TypeError):
+        _ = CountedFloat(1.5) < "abc"
+    assert global_counter.total_count() == 0
+
+
+def test_equality_with_unsupported_operand_is_uncounted(global_counter: GlobalFlopCounter):
+    # --- act ---------------------------------------------
+    result = CountedFloat(1.5) == "abc"  # resolves via identity fallback, not a float comparison
+
+    # --- assert ------------------------------------------
+    assert result is False
+    assert global_counter.total_count() == 0
+
+
+# =================================================================================================
+#  Failed operations do not count
+# =================================================================================================
+def test_failed_division_is_uncounted(global_counter: GlobalFlopCounter):
+    # --- act ---------------------------------------------
+    with pytest.raises(ZeroDivisionError):
+        _ = CountedFloat(1.5) / CountedFloat(0.0)
+    with pytest.raises(ZeroDivisionError):
+        _ = 1.5 / CountedFloat(0.0)  # via __rtruediv__
+
+    # --- assert ------------------------------------------
+    assert global_counter.total_count() == 0
+
+
+def test_failed_pow_is_uncounted(global_counter: GlobalFlopCounter):
+    # --- act ---------------------------------------------
+    with pytest.raises(OverflowError):
+        _ = CountedFloat(2.0) ** 1e6
+
+    # --- assert ------------------------------------------
+    assert global_counter.total_count() == 0
+
+
+def test_complex_pow_result_matches_float_and_is_uncounted(global_counter: GlobalFlopCounter):
+    # --- act ---------------------------------------------
+    result_pow = CountedFloat(-8.0) ** 0.333
+    result_rpow = (-8.0) ** CountedFloat(0.333)
+
+    # --- assert ------------------------------------------
+    # a negative base with fractional exponent yields complex, exactly like plain float;
+    # complex results fall outside the counting model
+    assert result_pow == (-8.0) ** 0.333
+    assert result_rpow == (-8.0) ** 0.333
+    assert isinstance(result_pow, complex)
+    assert isinstance(result_rpow, complex)
+    assert global_counter.total_count() == 0

--- a/tests/counting/test_numeric_protocol.py
+++ b/tests/counting/test_numeric_protocol.py
@@ -112,9 +112,7 @@ def test_reflected_operators_of_foreign_type_win(global_counter: GlobalFlopCount
 # =================================================================================================
 @pytest.mark.parametrize("op", ARITHMETIC_OPERATORS)
 @pytest.mark.parametrize("other", ["abc", Decimal("0.5"), None])
-def test_arithmetic_with_unsupported_operand_raises(
-    op: Callable, other: object, global_counter: GlobalFlopCounter
-):
+def test_arithmetic_with_unsupported_operand_raises(op: Callable, other: object, global_counter: GlobalFlopCounter):
     # --- act & assert ------------------------------------
     # error parity with plain float (the exact message varies: str.__rmul__ raises its own
     # "can't multiply sequence" TypeError, exactly as for plain float)


### PR DESCRIPTION
CountedFloat's arithmetic and comparison dunders counted before attempting the operation, and wrapped float's `NotImplemented` in the constructor. Consequences: interop with types implementing reflected operators (e.g. `Fraction`) raised a confusing `TypeError` instead of delegating, and failed or delegated operations polluted counts.

All sixteen dunders (ten arithmetic, six comparison) now follow one pattern: compute via `super()` first, pass `NotImplemented` through so Python can try the reflected operation, count only on success, wrap last. This also aligns the dunders with the compute-first/count-after convention already documented and tested in the math patches. Complex pow results (negative base, fractional exponent) are returned unwrapped and uncounted, matching plain-float values while staying outside the counting model.

Delegated operations are deliberately uncounted and may demote to plain float (e.g. `Fraction` arithmetic) — documented as a known limitation, with tests locking the intended behavior in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)