### PR TITLE
chore: gate CI and releases on a blind install of the built package

### DIFF
--- a/.github/workflows/_package_check.yml
+++ b/.github/workflows/_package_check.yml
@@ -1,0 +1,84 @@
+# Reusable package-integrity check: build the distribution once, verify the
+# wheel statically, then blind-install it into a bare environment and run the
+# test suite against it. Guards the packaging layer (empty wheel, missing data
+# files, broken entry point) that editable-install test runs can never see.
+# Called from the PR pipeline (behind ci-gate) and from the release pipeline
+# (before publish, which reuses the exact artifact tested here).
+name: Package check
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          version: ${{ vars.UV_VERSION }}
+
+      - name: Build sdist + wheel
+        run: uv build
+
+      # Static gate: catches structurally broken wheels (empty, missing the
+      # declared import package, ...) before the install job spins up.
+      - name: Check wheel contents
+        run: uv run --frozen check-wheel-contents dist/*.whl
+
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  install-test:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          version: ${{ vars.UV_VERSION }}
+
+      - name: Download distribution artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist
+
+      # Blind environment: test deps come lockfile-pinned from the dev group
+      # (--no-emit-project keeps the project itself out), and counted_float can
+      # only come from the built wheel — never an editable/source install.
+      - name: Install the built wheel into a bare environment
+        run: |
+          uv export --frozen --no-emit-project --only-group dev -o requirements.txt
+          uv venv blind-venv
+          uv pip install --python blind-venv/bin/python -r requirements.txt
+          WHEEL=(dist/*.whl)
+          uv pip install --python blind-venv/bin/python "counted-float[numba,cli] @ file://$PWD/${WHEEL[0]}"
+
+      - name: Assert the environment is blind
+        run: |
+          blind-venv/bin/python -c "
+          import counted_float
+          path = counted_float.__file__
+          assert 'site-packages' in path, f'counted_float resolves outside site-packages: {path}'
+          print(f'OK: counted_float imported from {path}')
+          "
+
+      - name: Run the test suite against the installed wheel
+        run: blind-venv/bin/python -m pytest tests/
+
+      - name: Smoke-test the CLI entry point
+        run: blind-venv/bin/counted_float --help

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -75,6 +75,13 @@ jobs:
     needs: [preflight]
     uses: ./.github/workflows/_unit_tests.yml
 
+  # Package-integrity gate: build once, verify the wheel statically, then
+  # blind-install the artifact and test against it — catches packaging holes
+  # (empty wheel, missing data files) that editable-install runs cannot see.
+  package:
+    needs: [preflight]
+    uses: ./.github/workflows/_package_check.yml
+
   # Synchronous dependency-CVE gate: audits the locked runtime dependencies
   # against the advisory DB at PR time — the blocking complement to the async,
   # repo-level Dependabot alerts. Hard-fails on any advisory; accepted ones go
@@ -107,7 +114,7 @@ jobs:
     # `always()` is load-bearing — without it the gate is skipped when an
     # upstream job fails, and GitHub treats a skipped required check as passing.
     if: always()
-    needs: [preflight, pre-commit, test, pip-audit]
+    needs: [preflight, pre-commit, test, package, pip-audit]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job did not succeed

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -41,8 +41,14 @@ jobs:
             echo "✓ Tag name matches package version"
           fi
 
-  publish-to-prod:
+  # Build + blind-install gate: the same package check PRs run behind ci-gate.
+  # Publishing below reuses the exact artifact this job built and tested.
+  package-check:
     needs: validate-tag-version
+    uses: ./.github/workflows/_package_check.yml
+
+  publish-to-prod:
+    needs: package-check
     runs-on: ubuntu-latest
     environment: prod
     permissions:
@@ -50,20 +56,11 @@ jobs:
       id-token: write      # mandatory for Trusted Publishing; also signs the keyless provenance
       attestations: write  # store SLSA build provenance for the wheel + sdist
     steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Download the tested distribution artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          persist-credentials: false
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
-        with:
-          version: ${{ vars.UV_VERSION }}
-          enable-cache: false
-
-      - name: Build package with uv
-        shell: bash
-        run: uv build
+          name: dist
+          path: dist
 
       # SLSA build provenance over the exact artifacts we publish. Complements
       # (does not replace) the PEP 740 attestations gh-action-pypi-publish emits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ cli = [
 
 [dependency-groups]
 dev = [
+    "check-wheel-contents>=0.6.2",
     "genbadge[all]>=1.1.2",
     "pre-commit>=4.0",
     "pytest>=8.0",

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -147,6 +156,22 @@ wheels = [
 ]
 
 [[package]]
+name = "check-wheel-contents"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "click" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "wheel-filename" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/37/2b9e0d38c2f668791ffe8b97711185c364d91c027e47f189c371c2348d18/check_wheel_contents-0.6.3.tar.gz", hash = "sha256:10e6939e2fe4e6ce1edf2ff6ec6157808677e80782e78021ae139dd88473a442", size = 586023, upload-time = "2025-08-02T14:01:45.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/05/f39fde9f31ef80b285ef5822fad4ddabf73fec62a1f02c5beb4b2f328972/check_wheel_contents-0.6.3-py3-none-any.whl", hash = "sha256:5ae39c8c434b972f0740d04610759168590713175aab584b012b1b84f6771874", size = 27541, upload-time = "2025-08-02T14:01:43.968Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -189,6 +214,7 @@ numba = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "check-wheel-contents" },
     { name = "genbadge", extra = ["all"] },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -225,6 +251,7 @@ provides-extras = ["numba", "cli"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "check-wheel-contents", specifier = ">=0.6.2" },
     { name = "genbadge", extras = ["all"], specifier = ">=1.1.2" },
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=8.0" },
@@ -1497,4 +1524,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wheel-filename"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/be/726dab762b770d0417e505c58e26d661aac1ec0c831e483cda4817ca2417/wheel_filename-1.4.2.tar.gz", hash = "sha256:87891c465dcbb40b40394a906f01a93214bdd51aa5d25e3a9a59cae62bc298fd", size = 7911, upload-time = "2024-12-01T13:03:16.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/0f/6e97a3bc38cdde32e3ec49f8c0903fe3559ec9ec9db181782f0bb4417717/wheel_filename-1.4.2-py3-none-any.whl", hash = "sha256:3fa599046443d4ca830d06e3d180cd0a675d5871af0a68daa5623318bb4d17e3", size = 6195, upload-time = "2024-12-01T13:03:00.536Z" },
 ]


### PR DESCRIPTION
Adds a reusable `_package_check.yml` workflow with two jobs:

- **build** — `uv build`, then `check-wheel-contents` as a fast static gate (catches empty/structurally broken wheels), then uploads `dist/` as an artifact.
- **install-test** — downloads the artifact into a bare environment: test dependencies come lockfile-pinned via `uv export --frozen --no-emit-project --only-group dev` (the project itself deliberately excluded), `counted_float[numba,cli]` is installed from the built wheel only, an assertion verifies the package resolves from site-packages (the src layout makes this guarantee possible), and then the full test suite (743 tests — the `BuiltInData` tests fail on missing data files) plus a `counted_float --help` smoke test run against it.

Wired into the PR pipeline behind `ci-gate`, and into the release pipeline **before** publish — `publish-to-prod` now downloads and publishes the exact artifact the gate tested (and attests provenance over those same bytes) instead of rebuilding.

Rationale: editable-install test runs can never see packaging holes; a broken wheel previously would have surfaced only on PyPI. `check-wheel-contents` is pinned via the dev dependency group like every other tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)