### PR TITLE
test: retry wall-clock-dependent tests on CI runner load flakes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
     "pre-commit>=4.0",
     "pytest>=8.0",
     "pytest-cov>=6.0",
+    "pytest-rerunfailures>=15.0",
     "pytest-xdist>=3.5.0",
     # exact tool versions are pinned by the tracked uv.lock (used by pre-commit,
     # `make lint`, and CI); these ranges just set the floor.

--- a/tests/benchmarking/micro/test_micro_benchmark.py
+++ b/tests/benchmarking/micro/test_micro_benchmark.py
@@ -33,6 +33,7 @@ class DummyMicroBenchmark(MicroBenchmark):
             pass
 
 
+@pytest.mark.flaky(reruns=5)  # wall-clock assertions can drift on a loaded CI runner
 @pytest.mark.parametrize(
     ("n_runs_total", "n_runs_warmup", "n_seconds_per_run_target"),
     [

--- a/tests/utils/test_timer.py
+++ b/tests/utils/test_timer.py
@@ -5,6 +5,7 @@ import pytest
 from counted_float._core.utils import Timer
 
 
+@pytest.mark.flaky(reruns=5)  # wall-clock assertions can drift on a loaded CI runner
 def test_timer():
     # --- arrange -----------------------------------------
     timer = Timer()

--- a/uv.lock
+++ b/uv.lock
@@ -219,6 +219,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
@@ -256,6 +257,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=6.0" },
+    { name = "pytest-rerunfailures", specifier = ">=15.0" },
     { name = "pytest-xdist", specifier = ">=3.5.0" },
     { name = "ruff", specifier = ">=0.15.11" },
     { name = "ty", specifier = ">=0.0.56" },
@@ -1197,6 +1199,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/60/a90ca1cc6cffcb97b4260ed0ad2b7934b999d7c48abe4ea0840344862a3b/pytest_rerunfailures-16.4.tar.gz", hash = "sha256:8222d17c37eb7b9e4d6fc96a3c724ff4e1a5c97a5cc7cbb2c19e9282cfd21a11", size = 36635, upload-time = "2026-07-01T06:30:56.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/93/3cdcc4033444e822e01b573414b03fd37fd5533070c750477b8f5fa5224b/pytest_rerunfailures-16.4-py3-none-any.whl", hash = "sha256:f69b5beb39622c90d1e44bd945d826eff6db545dcf0b68f52b7e4ad15eaf6d6c", size = 16955, upload-time = "2026-07-01T06:30:55.333Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Two tests assert on real elapsed time (`test_micro_benchmark`, `test_timer`) and can fail when a shared CI runner stalls — as happened on main after #163. This adds `pytest-rerunfailures` (dev group) and marks just those two tests `flaky(reruns=5)`, so transient load flakes retry instead of reddening the matrix while regressions elsewhere still fail on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)