### PR TITLE
feat: add --output option to the benchmark command for JSON persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `counted_float benchmark` can write results to a JSON file via `--output`
+
 ### Changed
 
 ### Deprecated

--- a/src/counted_float/_core/_cli.py
+++ b/src/counted_float/_core/_cli.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import click
 
 from counted_float import BuiltInData
@@ -13,9 +15,18 @@ def cli() -> None:
 
 
 @cli.command(short_help="run flop benchmarks")
-def benchmark() -> None:
+@click.option(
+    "--output",
+    type=click.Path(dir_okay=False, writable=True, path_type=Path),
+    default=None,
+    help="Optional file path to write results to as JSON, in the same schema as the built-in data files.",
+)
+def benchmark(output: Path | None) -> None:
     result = run_flops_benchmark()
     result.show()
+    if output is not None:
+        output.write_text(result.model_dump_json(indent=4) + "\n", encoding="utf-8")
+        click.echo(f"Results written to '{output}'.")
 
 
 @cli.command(short_help="show all built-in data")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,6 +1,11 @@
+from pathlib import Path
+
 from click.testing import CliRunner
 
-from counted_float._core._cli import benchmark_counted_float, show_data
+from counted_float import BuiltInData
+from counted_float._core import _cli
+from counted_float._core._cli import benchmark, benchmark_counted_float, show_data
+from counted_float._core.models import FlopsBenchmarkResults
 
 
 def test_show_data():
@@ -11,3 +16,21 @@ def test_show_data():
 def test_benchmark_counted_float():
     runner = CliRunner()
     runner.invoke(benchmark_counted_float)
+
+
+def test_benchmark_output_round_trip(tmp_path: Path, monkeypatch):
+    """`benchmark --output` writes JSON that loads back through the built-in-data path unchanged."""
+
+    # --- arrange -----------------------------------------
+    # patch out the actual benchmark run (slow) with a realistic built-in result
+    results = list(BuiltInData.benchmarks().values()).pop()
+    monkeypatch.setattr(_cli, "run_flops_benchmark", lambda: results)
+    output_path = tmp_path / "benchmark_results.json"
+
+    # --- act ---------------------------------------------
+    result = CliRunner().invoke(benchmark, ["--output", str(output_path)])
+
+    # --- assert ------------------------------------------
+    assert result.exit_code == 0
+    round_tripped = FlopsBenchmarkResults.model_validate_json(output_path.read_text(encoding="utf-8"))
+    assert round_tripped == results


### PR DESCRIPTION
`counted_float benchmark` gains an `--output <path>` option that writes the full results model to a JSON file, using the same schema as the built-in data files. A round-trip test loads the written file back through the built-in-data path to prove the formats match; smoke-tested end-to-end with a real benchmark run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)