### PR TITLE
chore: fix dependabot config and let its PRs pass preflight

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,21 +10,32 @@ updates:
       - "/.github/actions/benchmark"
     schedule:
       interval: "weekly"
+    # `chore` prefix makes the PR title (and thus the squash commit on main)
+    # follow the repo's `<type>: <summary>` convention, so the preflight
+    # title check needs no Dependabot exemption.
+    commit-message:
+      prefix: "chore"
     groups:
       actions:  # one batched PR for all action bumps
         patterns: ["*"]
     # Let releases age before PRs open: auto-merged patch/minor bumps then sit
     # long enough for upstream compromises to surface before they can land.
+    # (semver-specific cooldowns are not supported for github-actions.)
     cooldown:
       default-days: 7  # zizmor's dependabot-cooldown floor; ~no-op at weekly cadence anyway
-      semver-major-days: 14
 
   - package-ecosystem: "uv"
-    # Bumps uv.lock (and pyproject pins) for the runtime + dev/lint/type tooling
-    # the lockfile deliberately pins — those rot without automated updates.
+    # Refreshes uv.lock for the runtime + dev/lint/type tooling the lockfile
+    # deliberately pins — those rot without automated updates.
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+    # Lockfile only: pyproject's dependency floors are deliberate lower bounds
+    # (the lowest-direct CI leg resolves to them) and must never be auto-bumped;
+    # the lockfile is the thing that's pinned for reproducible dev/CI.
+    versioning-strategy: lockfile-only
     groups:
       python:  # one batched PR for all Python-dependency bumps
         patterns: ["*"]

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,14 @@ jobs:
   preflight:
     runs-on: ubuntu-latest
     steps:
+      # Dependabot's `dependabot/...` branch prefix is not configurable, so it
+      # gets an actor-based exemption — branch names are ephemeral (deleted on
+      # squash-merge, never reaching main), unlike PR titles, which become the
+      # commit subject and so are enforced below. `pull_request.user.login` (the
+      # PR author), not `github.actor`, so a human re-running checks on a
+      # Dependabot PR can't un-exempt it.
       - name: Check branch name
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           BRANCH: ${{ github.head_ref }}
         run: |


### PR DESCRIPTION
Converges the dependabot setup with the sibling owned repos, in four parts:

- **`uv` lockfile-only** — `versioning-strategy: lockfile-only` so bumps touch only `uv.lock`, never the deliberate `pyproject.toml` floors.
- **Drop inert cooldown** — `semver-major-days` isn't supported for the `github-actions` ecosystem, so it's removed there (kept for `uv`).
- **`chore` title prefix** — dependabot PR titles become `chore: ...`, satisfying the preflight title check (which becomes the squash-commit subject on main).
- **Branch-name exemption** — dependabot's `dependabot/...` prefix isn't configurable and is ephemeral (deleted on merge), so the preflight branch-name check skips it; PR titles, which persist, stay enforced.

Together the last two let dependabot PRs pass preflight, which the auto-merge workflow assumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)