### PR TITLE
fix: treat int and bool operands as compile-time constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `int`/`bool` operands are now more systematically treated as compile-time constants: arithmetic, comparisons, and `**` with an integer operand no longer add an `I2F` conversion count (wrap a runtime integer in `CountedFloat(...)` to count it)
+
 ### Deprecated
 
 ### Removed

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -55,10 +55,17 @@ The library detects constants through two mechanisms, applying the same rule:
   above.
 - **`int` operands**: evidence of a *hardcoded* constant — ints don't fall out
   of floating-point computations, so an int operand almost certainly appears
-  literally in your source. This enables counting the strength reductions a
-  compiled port would apply: `x**2` counts MUL (i.e. `x*x`), `2**x` counts
-  EXP2, `math.log(x, 10)` counts LOG10 — while `x**2.0`, with a float that
-  *could* be a runtime value, conservatively counts a generic POW.
+  literally in your source. As a constant it is folded to a float literal by a
+  compiled port, so an `int` operand adds **no `I2F` conversion**; it merely
+  enables the strength reductions such a port would apply: `x**2` counts MUL
+  (i.e. `x*x`), `2**x` counts EXP2, `math.log(x, 10)` counts LOG10 — while
+  `x**2.0`, with a float that *could* be a runtime value, conservatively counts
+  a generic POW.
+
+The one place an `I2F` conversion *is* counted is explicit construction from an
+int — `CountedFloat(n)`. That is exactly how you opt a genuine runtime integer
+(a loop index, a computed count) into the counting model: wrap it, and its
+int→float conversion counts like any other FLOP.
 
 The flip side: an unwrapped runtime input is invisible to the counter — that
 is a wrapping error at your algorithm's boundary, not something the library

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -60,11 +60,13 @@ find:
 - Relevant CPU instructions
     - **ARM:** `SCVTF`
     - **x86:** `CVTSI2SD`
-- **Counted Python operations:** Construction of `CountedFloat` from int, any
-  binary operation where one operand is an int and the other a `CountedFloat`
-  (e.g., `x + 3`, `3 * x`, etc.)
-- **Not counted:** `float(n)`, unitary operations (e.g. `math.sqrt` on
-  integers -> convert to `CountedFloat` first)
+- **Counted Python operations:** Construction of `CountedFloat` from an int,
+  e.g. `CountedFloat(3)` — the way to opt a genuine runtime integer into the
+  counting model
+- **Not counted:** `float(n)`; an `int` operand in arithmetic, comparisons, or
+  `**` (e.g. `x + 3`, `3 * x`, `x < 2`, `x**3`) — an `int` operand is a
+  compile-time constant, folded to a float literal by a compiled port, so it
+  adds no conversion (see [Counting FLOPs](counting_flops.md))
 
 ## FlopType.ADD (`x+y`)
 

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -41,8 +41,6 @@ class CountedFloat(float):
         result = super().__eq__(other)
         if result is NotImplemented:
             return NotImplemented  # let Python try the reflected operation; nothing was computed, so nothing counts
-        if isinstance(other, int):
-            GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
         return result
 
@@ -51,8 +49,6 @@ class CountedFloat(float):
         result = super().__ne__(other)
         if result is NotImplemented:
             return NotImplemented
-        if isinstance(other, int):
-            GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
         return result
 
@@ -61,8 +57,6 @@ class CountedFloat(float):
         result = super().__lt__(other)
         if result is NotImplemented:
             return NotImplemented
-        if isinstance(other, int):
-            GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
         return result
 
@@ -71,8 +65,6 @@ class CountedFloat(float):
         result = super().__le__(other)
         if result is NotImplemented:
             return NotImplemented
-        if isinstance(other, int):
-            GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
         return result
 
@@ -81,8 +73,6 @@ class CountedFloat(float):
         result = super().__gt__(other)
         if result is NotImplemented:
             return NotImplemented
-        if isinstance(other, int):
-            GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
         return result
 
@@ -91,8 +81,6 @@ class CountedFloat(float):
         result = super().__ge__(other)
         if result is NotImplemented:
             return NotImplemented
-        if isinstance(other, int):
-            GLOBAL_COUNTER.incr_i2f()
         GLOBAL_COUNTER.incr_comp()
         return result
 
@@ -138,8 +126,6 @@ class CountedFloat(float):
         if result is NotImplemented:
             return NotImplemented
         GLOBAL_COUNTER.incr_add()
-        if isinstance(other, int):
-            GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(result)
 
     def __radd__(self, other: float) -> CountedFloat:
@@ -148,8 +134,6 @@ class CountedFloat(float):
         if result is NotImplemented:
             return NotImplemented
         GLOBAL_COUNTER.incr_add()
-        if isinstance(other, int):
-            GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(result)
 
     def __sub__(self, other: float) -> CountedFloat:
@@ -158,8 +142,6 @@ class CountedFloat(float):
         if result is NotImplemented:
             return NotImplemented
         GLOBAL_COUNTER.incr_sub()
-        if isinstance(other, int):
-            GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(result)
 
     def __rsub__(self, other: float) -> CountedFloat:
@@ -168,8 +150,6 @@ class CountedFloat(float):
         if result is NotImplemented:
             return NotImplemented
         GLOBAL_COUNTER.incr_sub()
-        if isinstance(other, int):
-            GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(result)
 
     def __mul__(self, other: float) -> CountedFloat:
@@ -178,8 +158,6 @@ class CountedFloat(float):
         if result is NotImplemented:
             return NotImplemented
         GLOBAL_COUNTER.incr_mul()
-        if isinstance(other, int):
-            GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(result)
 
     def __rmul__(self, other: float) -> CountedFloat:
@@ -188,8 +166,6 @@ class CountedFloat(float):
         if result is NotImplemented:
             return NotImplemented
         GLOBAL_COUNTER.incr_mul()
-        if isinstance(other, int):
-            GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(result)
 
     def __truediv__(self, other: float) -> CountedFloat:
@@ -198,8 +174,6 @@ class CountedFloat(float):
         if result is NotImplemented:
             return NotImplemented
         GLOBAL_COUNTER.incr_div()
-        if isinstance(other, int):
-            GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(result)
 
     def __rtruediv__(self, other: float) -> CountedFloat:
@@ -208,18 +182,15 @@ class CountedFloat(float):
         if result is NotImplemented:
             return NotImplemented
         GLOBAL_COUNTER.incr_div()
-        if isinstance(other, int):
-            GLOBAL_COUNTER.incr_i2f()
         return CountedFloat(result)
 
     def __pow__(self, other: float) -> CountedFloat:  # ty: ignore[invalid-method-override] -- no `mod` param; float.__pow__'s mod is None-only and unused here
         """x**other.
 
-        Counting heuristic: an `int` operand is taken as evidence of a hardcoded constant in the
-        source (ints don't fall out of floating-point computations), so `x**2` counts as MUL —
-        the strength reduction (x*x) a compiled port would apply. A float operand may just as well
-        be a runtime variable that happens to hold that value, where a port would compile a
-        generic pow, so `x**2.0` counts as POW.
+        A hardcoded (`int`) exponent enables the strength reduction a compiled port would apply:
+        `x**2` counts as MUL (i.e. `x*x`). A float exponent such as `x**2.0` may be a runtime
+        variable, where a port compiles a generic pow, so it counts as POW. Per the counting
+        model, `int` operands are compile-time constants and never add an I2F conversion.
 
         A negative base with a fractional exponent yields a complex result (as for plain float);
         complex values fall outside the counting model, so nothing is counted and the result is
@@ -233,18 +204,16 @@ class CountedFloat(float):
         if isinstance(other, int) and other == 2:
             GLOBAL_COUNTER.incr_mul()  # x^2 = x*x
         else:
-            if isinstance(other, int):
-                GLOBAL_COUNTER.incr_i2f()
             GLOBAL_COUNTER.incr_pow()
         return CountedFloat(result)
 
     def __rpow__(self, other: float) -> CountedFloat:  # ty: ignore[invalid-method-override] -- no `mod` param; float.__rpow__'s mod is None-only and unused here
         """other**x.
 
-        Same constant-detection heuristic as __pow__, applied to the base: an `int` base 2 or 10
-        is taken as a hardcoded constant, counting as EXP2 / EXP10 (the strength reduction a
-        compiled port would apply); a float base may be a runtime variable, so it counts as
-        generic POW.
+        Strength reduction on the base, as in __pow__: a hardcoded (`int`) base 2 or 10 counts
+        as EXP2 / EXP10 (what a compiled port would emit); any other base counts a generic POW,
+        and a float base may be a runtime variable, so it counts POW too. Per the counting model,
+        `int` operands are compile-time constants and never add an I2F conversion.
 
         A negative base with a fractional exponent yields a complex result (as for plain float);
         complex values fall outside the counting model, so nothing is counted and the result is
@@ -260,7 +229,5 @@ class CountedFloat(float):
         elif isinstance(other, int) and other == 10:
             GLOBAL_COUNTER.incr_exp10()
         else:
-            if isinstance(other, int):
-                GLOBAL_COUNTER.incr_i2f()
             GLOBAL_COUNTER.incr_pow()
         return CountedFloat(result)

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -70,8 +70,8 @@ def math_log(  # noqa: C901 -- branches mirror the per-log-variant counting rule
 ) -> float | CountedFloat:
     """Patch math.log: stdlib contract (optional base), with flop classification per log variant.
 
-    Flop classification for the base follows the same constant-detection heuristic as
-    CountedFloat.__pow__ / __rpow__ (int operand = hardcoded constant in the source):
+    Flop classification for the base treats a hardcoded (`int`) base as a compile-time constant
+    (as everywhere in the counting model), mirroring CountedFloat.__pow__ / __rpow__:
       - base omitted      -> LOG
       - base int 2 / 10   -> LOG2 / LOG10 (a compiled port calls log2/log10 directly)
       - base other int    -> LOG + MUL (a port computes log(x) * C, with C = 1/log(base) folded
@@ -141,8 +141,9 @@ def math_exp2(x: float) -> float | CountedFloat:
 def math_pow(x: float, y: float) -> float | CountedFloat:
     """Patch math.pow: stdlib contract (always-float result, ValueError on domain errors).
 
-    Flop classification is identical to the x**y form — including the constant-detection heuristic
-    documented on CountedFloat.__pow__ / __rpow__ (int operand = hardcoded constant).
+    Flop classification is identical to the x**y form (strength reduction for hardcoded int
+    exponents/bases; int operands are compile-time constants and add no I2F) — see
+    CountedFloat.__pow__ / __rpow__.
     """
     if isinstance(x, CountedFloat) or isinstance(y, CountedFloat):
         # computed first: math.pow raises ValueError on domain errors (e.g. negative base with
@@ -152,8 +153,6 @@ def math_pow(x: float, y: float) -> float | CountedFloat:
             if isinstance(y, int) and y == 2:
                 GLOBAL_COUNTER.incr_mul()  # x^2 = x*x
             else:
-                if isinstance(y, int):
-                    GLOBAL_COUNTER.incr_i2f()
                 GLOBAL_COUNTER.incr_pow()
         else:
             if isinstance(x, int) and x == 2:
@@ -161,8 +160,6 @@ def math_pow(x: float, y: float) -> float | CountedFloat:
             elif isinstance(x, int) and x == 10:
                 GLOBAL_COUNTER.incr_exp10()
             else:
-                if isinstance(x, int):
-                    GLOBAL_COUNTER.incr_i2f()
                 GLOBAL_COUNTER.incr_pow()
         return CountedFloat(result)
     return original_math_pow(x, y)

--- a/tests/counting/test_counted_float.py
+++ b/tests/counting/test_counted_float.py
@@ -501,9 +501,9 @@ def test_counted_float_counts_eq(global_counter):
     _ = cf == 2.34567
 
     # --- assert ------------------------------------------
-    assert global_counter.total_count() == 7
+    assert global_counter.total_count() == 5
     assert global_counter.COMP == 5
-    assert global_counter.I2F == 2
+    assert global_counter.I2F == 0
 
 
 def test_counted_float_counts_ne(global_counter):
@@ -518,9 +518,9 @@ def test_counted_float_counts_ne(global_counter):
     _ = cf != 2.34567
 
     # --- assert ------------------------------------------
-    assert global_counter.total_count() == 7
+    assert global_counter.total_count() == 5
     assert global_counter.COMP == 5
-    assert global_counter.I2F == 2
+    assert global_counter.I2F == 0
 
 
 def test_counted_float_counts_lt(global_counter):
@@ -535,9 +535,9 @@ def test_counted_float_counts_lt(global_counter):
     _ = cf < 2.34567
 
     # --- assert ------------------------------------------
-    assert global_counter.total_count() == 7
+    assert global_counter.total_count() == 5
     assert global_counter.COMP == 5
-    assert global_counter.I2F == 2
+    assert global_counter.I2F == 0
 
 
 def test_counted_float_counts_le(global_counter):
@@ -552,9 +552,9 @@ def test_counted_float_counts_le(global_counter):
     _ = cf <= 2.34567
 
     # --- assert ------------------------------------------
-    assert global_counter.total_count() == 7
+    assert global_counter.total_count() == 5
     assert global_counter.COMP == 5
-    assert global_counter.I2F == 2
+    assert global_counter.I2F == 0
 
 
 def test_counted_float_counts_gt(global_counter):
@@ -569,9 +569,9 @@ def test_counted_float_counts_gt(global_counter):
     _ = cf > 2.34567
 
     # --- assert ------------------------------------------
-    assert global_counter.total_count() == 7
+    assert global_counter.total_count() == 5
     assert global_counter.COMP == 5
-    assert global_counter.I2F == 2
+    assert global_counter.I2F == 0
 
 
 @pytest.mark.parametrize("min_max_fun", [min, max])
@@ -584,7 +584,7 @@ def test_counted_float_counts_min_max(
     min_max_fun: Callable, f1: float, f2: float, cf_left: bool, cf_right: bool, global_counter
 ):
     # --- arrange -----------------------------------------
-    n_integers = int(isinstance(f1, int)) + int(isinstance(f2, int))
+    expected_i2f = int(cf_left and isinstance(f1, int)) + int(cf_right and isinstance(f2, int))
     left = CountedFloat(f1) if cf_left else f1
 
     right = CountedFloat(f2) if cf_right else f2
@@ -595,7 +595,7 @@ def test_counted_float_counts_min_max(
 
     # --- assert ------------------------------------------
     assert global_counter.COMP == 1
-    assert n_integers == global_counter.I2F
+    assert expected_i2f == global_counter.I2F
     assert f_min_max == cf_min_max
 
 
@@ -611,9 +611,9 @@ def test_counted_float_counts_ge(global_counter):
     _ = cf >= 2.34567
 
     # --- assert ------------------------------------------
-    assert global_counter.total_count() == 7
+    assert global_counter.total_count() == 5
     assert global_counter.COMP == 5
-    assert global_counter.I2F == 2
+    assert global_counter.I2F == 0
 
 
 @pytest.mark.parametrize(
@@ -713,9 +713,9 @@ def test_counted_float_counts_add_int(global_counter):
     _ = (cf + i) + i
 
     # --- assert ------------------------------------------
-    assert global_counter.total_count() == 9
+    assert global_counter.total_count() == 5
     assert global_counter.ADD == 5
-    assert global_counter.I2F == 4
+    assert global_counter.I2F == 0
 
 
 def test_counted_float_counts_sub(global_counter):
@@ -746,9 +746,9 @@ def test_counted_float_counts_sub_int(global_counter):
     _ = (cf - i) - i
 
     # --- assert ------------------------------------------
-    assert global_counter.total_count() == 9
+    assert global_counter.total_count() == 5
     assert global_counter.SUB == 5
-    assert global_counter.I2F == 4
+    assert global_counter.I2F == 0
 
 
 def test_counted_float_counts_mul(global_counter):
@@ -779,9 +779,9 @@ def test_counted_float_counts_mul_int(global_counter):
     _ = (cf * i) * i
 
     # --- assert ------------------------------------------
-    assert global_counter.total_count() == 9
+    assert global_counter.total_count() == 5
     assert global_counter.MUL == 5
-    assert global_counter.I2F == 4
+    assert global_counter.I2F == 0
 
 
 def test_counted_float_counts_div(global_counter):
@@ -812,9 +812,9 @@ def test_counted_float_counts_div_int(global_counter):
     _ = (cf / i) / i
 
     # --- assert ------------------------------------------
-    assert global_counter.total_count() == 9
+    assert global_counter.total_count() == 5
     assert global_counter.DIV == 5
-    assert global_counter.I2F == 4
+    assert global_counter.I2F == 0
 
 
 def test_counted_float_counts_pow_1(global_counter):
@@ -834,17 +834,17 @@ def test_counted_float_counts_pow_1(global_counter):
     _ = math.exp2(cf)  # EXP2
     _ = 10**cf  # EXP10
     _ = cf**2  # MUL
-    _ = i**cf  # POW + I2F
-    _ = cf**i  # POW + I2F
+    _ = i**cf  # POW
+    _ = cf**i  # POW
 
     # --- assert ------------------------------------------
-    assert global_counter.total_count() == 16
+    assert global_counter.total_count() == 14
     assert global_counter.POW == 9
     assert global_counter.EXP == 1
     assert global_counter.EXP2 == 2
     assert global_counter.EXP10 == 1
     assert global_counter.MUL == 1
-    assert global_counter.I2F == 2
+    assert global_counter.I2F == 0
 
 
 def test_counted_float_counts_pow_2(global_counter):
@@ -862,16 +862,16 @@ def test_counted_float_counts_pow_2(global_counter):
     _ = math.pow(2, cf)  # EXP2
     _ = math.pow(10, cf)  # EXP10
     _ = math.pow(cf, 2)  # MUL
-    _ = math.pow(i, cf)  # POW + I2F
-    _ = math.pow(cf, i)  # POW + I2F
+    _ = math.pow(i, cf)  # POW
+    _ = math.pow(cf, i)  # POW
 
     # --- assert ------------------------------------------
-    assert global_counter.total_count() == 14
+    assert global_counter.total_count() == 12
     assert global_counter.POW == 9
     assert global_counter.EXP2 == 1
     assert global_counter.EXP10 == 1
     assert global_counter.MUL == 1
-    assert global_counter.I2F == 2
+    assert global_counter.I2F == 0
 
 
 def test_counted_float_counts_sqrt(global_counter):


### PR DESCRIPTION
An `int`/`bool` operand to arithmetic, comparisons, or `**` is a compile-time constant — a compiled port folds it to a float literal — so it no longer adds an `I2F` conversion count. `I2F` is now counted only on explicit `CountedFloat(int)` construction, making a genuine runtime integer's conversion opt-in.

This resolves an internal inconsistency: the counting model documented ints as constants while the code still charged them an `I2F`. Both documentation sections (the counting model and the `FlopType.I2F` reference) are reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)