### PR TITLE
feat: count math.atan2, hypot, asin/acos/atan, expm1/log1p, fmod, fabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- counting support for `math.atan2`, `hypot`, `asin`/`acos`/`atan`, `expm1`/`log1p`, `fmod`, and `fabs`
+
 ### Changed
 
 - `int`/`bool` operands are now more systematically treated as compile-time constants: arithmetic, comparisons, and `**` with an integer operand no longer add an `I2F` conversion count (wrap a runtime integer in `CountedFloat(...)` to count it)
@@ -18,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- `FlopWeights.get_sorted_flop_types()` now orders types deterministically when some weights are missing (NaN)
 
 ### Security
 

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -16,8 +16,9 @@ find:
 - Relevant CPU instructions
     - **ARM:** `FABS`
     - **x86:** `ANDPD`
-- **Counted Python operations:** `abs(x)` where `x` is a `CountedFloat`
-- **Not counted:** `numpy.abs`, complex abs, abs on non-CountedFloat
+- **Counted Python operations:** `abs(x)` and `math.fabs(x)` where `x` is a
+  `CountedFloat` (both map to the same `FABS`/`ANDPD` instruction)
+- **Not counted:** `numpy.abs`, `numpy.fabs`, complex abs, abs on non-CountedFloat
 
 ## FlopType.MINUS (`-x`)
 
@@ -202,3 +203,71 @@ find:
     - **x86:** (software)
 - **Counted Python operations:** `math.tan(x)` for `CountedFloat`
 - **Not counted:** `tan` on non-CountedFloat, `numpy.tan`
+
+## FlopType.ASIN (`asin(x)`)
+
+- Relevant CPU instructions
+    - **ARM:** (software)
+    - **x86:** (software)
+- **Counted Python operations:** `math.asin(x)` for `CountedFloat`
+- **Not counted:** `asin` on non-CountedFloat, `numpy.arcsin`
+
+## FlopType.ACOS (`acos(x)`)
+
+- Relevant CPU instructions
+    - **ARM:** (software)
+    - **x86:** (software)
+- **Counted Python operations:** `math.acos(x)` for `CountedFloat`
+- **Not counted:** `acos` on non-CountedFloat, `numpy.arccos`
+
+## FlopType.ATAN (`atan(x)`)
+
+- Relevant CPU instructions
+    - **ARM:** (software)
+    - **x86:** (software)
+- **Counted Python operations:** `math.atan(x)` for `CountedFloat`
+- **Not counted:** `atan` on non-CountedFloat, `numpy.arctan`
+
+## FlopType.ATAN2 (`atan2(y, x)`)
+
+- Relevant CPU instructions
+    - **ARM:** (software)
+    - **x86:** (software)
+- **Counted Python operations:** `math.atan2(y, x)` for `CountedFloat` —
+  counted when *either* operand is a `CountedFloat`
+- **Not counted:** `atan2` on plain floats only, `numpy.arctan2`
+
+## FlopType.HYPOT (`hypot(x, y)`)
+
+- Relevant CPU instructions
+    - **ARM:** (software)
+    - **x86:** (software)
+- **Counted Python operations:** `math.hypot(x, y, ...)` for `CountedFloat` —
+  counted once when *any* coordinate is a `CountedFloat`
+- **Not counted:** `hypot` on plain floats only, `numpy.hypot`
+
+## FlopType.EXPM1 (`expm1(x)`)
+
+- Relevant CPU instructions
+    - **ARM:** (software)
+    - **x86:** (software)
+- **Counted Python operations:** `math.expm1(x)` for `CountedFloat`
+- **Not counted:** `expm1` on non-CountedFloat, `numpy.expm1`, `math.exp(x) - 1`
+
+## FlopType.LOG1P (`log1p(x)`)
+
+- Relevant CPU instructions
+    - **ARM:** (software)
+    - **x86:** (software)
+- **Counted Python operations:** `math.log1p(x)` for `CountedFloat`
+- **Not counted:** `log1p` on non-CountedFloat, `numpy.log1p`, `math.log(1 + x)`
+
+## FlopType.FMOD (`fmod(x, y)`)
+
+- Relevant CPU instructions
+    - **ARM:** (software)
+    - **x86:** (software)
+- **Counted Python operations:** `math.fmod(x, y)` for `CountedFloat` —
+  counted when *either* operand is a `CountedFloat` (the C-library truncated
+  remainder; distinct from the `%` operator's floored remainder)
+- **Not counted:** `fmod` on plain floats only, `numpy.fmod`

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -2,8 +2,10 @@
 
 - currently any non-Python-built-in math operations are not counted (e.g.
   `numpy`)
-- not all Python built-in math operations are counted (e.g. hyperbolic
-  functions)
+- not all Python built-in math operations are counted — the remaining gaps are
+  the hyperbolic functions (`sinh`/`cosh`/`tanh` and their inverses) and
+  `math.copysign`; see the [FLOP types reference](flop_types.md) for the full
+  list of what is and isn't counted
 - mixed operations with non-float numeric types are outside the counting
   model: `CountedFloat` delegates to the other operand exactly like `float`
   does, so e.g. a `fractions.Fraction` operand generally yields a correct but

--- a/docs/math_patching.md
+++ b/docs/math_patching.md
@@ -43,13 +43,12 @@ the library simply restores its snapshot.
 The counting replacements only count operations touching `CountedFloat`
 values; on plain floats they delegate straight through with no counting (see
 [the counting model](counting_flops.md#the-counting-model-what-gets-counted-and-why)).
-Two functions carry extra classification logic, applying the same
-constant-detection heuristic as the `**` operator (int operand = hardcoded
-constant in the source):
+Two functions carry extra classification logic. As everywhere in the counting
+model, an `int` operand is treated as a compile-time constant — it enables
+strength reduction and never adds an I2F conversion:
 
 - `math.pow(x, y)` classifies like `x ** y`: `x**2` counts MUL, `2**x` counts
-  EXP2, `10**x` counts EXP10, other cases count POW (plus I2F for an int
-  operand).
+  EXP2, `10**x` counts EXP10, other cases count POW.
 - `math.log(x, base)` classifies per log variant: base omitted → LOG; int
   base 2 / 10 → LOG2 / LOG10 (a compiled port calls `log2`/`log10` directly);
   other int base → LOG + MUL (a port computes `log(x) * C` with

--- a/src/counted_float/_core/counting/_global_counter.py
+++ b/src/counted_float/_core/counting/_global_counter.py
@@ -114,6 +114,30 @@ class GlobalFlopCounter:
     def incr_tan(self) -> None:
         self.__counts.TAN += self.__incr
 
+    def incr_asin(self) -> None:
+        self.__counts.ASIN += self.__incr
+
+    def incr_acos(self) -> None:
+        self.__counts.ACOS += self.__incr
+
+    def incr_atan(self) -> None:
+        self.__counts.ATAN += self.__incr
+
+    def incr_atan2(self) -> None:
+        self.__counts.ATAN2 += self.__incr
+
+    def incr_hypot(self) -> None:
+        self.__counts.HYPOT += self.__incr
+
+    def incr_expm1(self) -> None:
+        self.__counts.EXPM1 += self.__incr
+
+    def incr_log1p(self) -> None:
+        self.__counts.LOG1P += self.__incr
+
+    def incr_fmod(self) -> None:
+        self.__counts.FMOD += self.__incr
+
 
 # --- global variable through which we access the global counter ---
 GLOBAL_COUNTER = GlobalFlopCounter()

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -41,6 +41,15 @@ original_math_pow = math.pow
 original_math_sin = math.sin
 original_math_cos = math.cos
 original_math_tan = math.tan
+original_math_asin = math.asin
+original_math_acos = math.acos
+original_math_atan = math.atan
+original_math_atan2 = math.atan2
+original_math_hypot = math.hypot
+original_math_expm1 = math.expm1
+original_math_log1p = math.log1p
+original_math_fmod = math.fmod
+original_math_fabs = math.fabs
 
 # sentinel for math_log's optional base argument; the stdlib signature is math.log(x[, base]),
 # where omitting base is not the same as passing any real value (and None is rejected)
@@ -186,6 +195,73 @@ def math_tan(x: float) -> float | CountedFloat:
     return original_math_tan(x)
 
 
+def math_asin(x: float) -> float | CountedFloat:
+    if isinstance(x, CountedFloat):
+        result = original_math_asin(x)  # compute first: domain errors raise before anything is counted
+        GLOBAL_COUNTER.incr_asin()
+        return CountedFloat(result)
+    return original_math_asin(x)
+
+
+def math_acos(x: float) -> float | CountedFloat:
+    if isinstance(x, CountedFloat):
+        result = original_math_acos(x)  # compute first: domain errors raise before anything is counted
+        GLOBAL_COUNTER.incr_acos()
+        return CountedFloat(result)
+    return original_math_acos(x)
+
+
+def math_atan(x: float) -> float | CountedFloat:
+    if isinstance(x, CountedFloat):
+        GLOBAL_COUNTER.incr_atan()
+        return CountedFloat(original_math_atan(x))
+    return original_math_atan(x)
+
+
+def math_atan2(y: float, x: float) -> float | CountedFloat:
+    if isinstance(y, CountedFloat) or isinstance(x, CountedFloat):
+        GLOBAL_COUNTER.incr_atan2()
+        return CountedFloat(original_math_atan2(y, x))
+    return original_math_atan2(y, x)
+
+
+def math_hypot(*coordinates: float) -> float | CountedFloat:
+    if any(isinstance(c, CountedFloat) for c in coordinates):
+        GLOBAL_COUNTER.incr_hypot()
+        return CountedFloat(original_math_hypot(*coordinates))
+    return original_math_hypot(*coordinates)
+
+
+def math_expm1(x: float) -> float | CountedFloat:
+    if isinstance(x, CountedFloat):
+        GLOBAL_COUNTER.incr_expm1()
+        return CountedFloat(original_math_expm1(x))
+    return original_math_expm1(x)
+
+
+def math_log1p(x: float) -> float | CountedFloat:
+    if isinstance(x, CountedFloat):
+        result = original_math_log1p(x)  # compute first: domain error (x <= -1) raises before counting
+        GLOBAL_COUNTER.incr_log1p()
+        return CountedFloat(result)
+    return original_math_log1p(x)
+
+
+def math_fmod(x: float, y: float) -> float | CountedFloat:
+    if isinstance(x, CountedFloat) or isinstance(y, CountedFloat):
+        result = original_math_fmod(x, y)  # compute first: fmod(x, 0) raises before anything is counted
+        GLOBAL_COUNTER.incr_fmod()
+        return CountedFloat(result)
+    return original_math_fmod(x, y)
+
+
+def math_fabs(x: float) -> float | CountedFloat:
+    if isinstance(x, CountedFloat):
+        GLOBAL_COUNTER.incr_abs()  # same FABS/ANDPD instruction as abs(); reuses FlopType.ABS
+        return CountedFloat(original_math_fabs(x))
+    return original_math_fabs(x)
+
+
 # -------------------------------------------------------------------------
 #  applying / removing the patches
 # -------------------------------------------------------------------------
@@ -201,6 +277,15 @@ _PATCHES: dict[str, object] = {
     "sin": math_sin,
     "cos": math_cos,
     "tan": math_tan,
+    "asin": math_asin,
+    "acos": math_acos,
+    "atan": math_atan,
+    "atan2": math_atan2,
+    "hypot": math_hypot,
+    "expm1": math_expm1,
+    "log1p": math_log1p,
+    "fmod": math_fmod,
+    "fabs": math_fabs,
 }
 # the math functions saved at patch time, to be restored at unpatch time
 _saved_originals: dict[str, object] = {}
@@ -220,6 +305,8 @@ def _capture_originals() -> None:
     global original_math_sqrt, original_math_cbrt, original_math_log, original_math_log2
     global original_math_log10, original_math_exp, original_math_exp2, original_math_pow
     global original_math_sin, original_math_cos, original_math_tan
+    global original_math_asin, original_math_acos, original_math_atan, original_math_atan2
+    global original_math_hypot, original_math_expm1, original_math_log1p, original_math_fmod, original_math_fabs
 
     original_math_sqrt = math.sqrt
     original_math_cbrt = math.cbrt
@@ -232,6 +319,15 @@ def _capture_originals() -> None:
     original_math_sin = math.sin
     original_math_cos = math.cos
     original_math_tan = math.tan
+    original_math_asin = math.asin
+    original_math_acos = math.acos
+    original_math_atan = math.atan
+    original_math_atan2 = math.atan2
+    original_math_hypot = math.hypot
+    original_math_expm1 = math.expm1
+    original_math_log1p = math.log1p
+    original_math_fmod = math.fmod
+    original_math_fabs = math.fabs
 
     _saved_originals.clear()
     for name in _PATCHES:

--- a/src/counted_float/_core/counting/config/_defaults.py
+++ b/src/counted_float/_core/counting/config/_defaults.py
@@ -1,10 +1,56 @@
+import math
 from functools import cache
 from typing import Literal
 
 from counted_float._core.counting._builtin_data import BuiltInData
-from counted_float._core.models import FlopWeights
+from counted_float._core.models import FlopType, FlopWeights
+
+# =================================================================================================
+#  TEMPORARY placeholder weights
+# =================================================================================================
+# The higher-order libm ops below have no measured data yet: they have no hardware instruction
+# (so no spec-sheet latency), and their benchmark kernels + measurements only arrive with the
+# built-in dataset refresh. Until then their consensus weight is NaN, which poisons any
+# total_weighted_cost that mixes them with real ops (0 * nan == nan).
+#
+# These placeholders are order-of-magnitude estimates by analogy with the nearest measured op,
+# so that weighted counting returns sane values in the interim. They are applied ONLY to the
+# specific types listed here and ONLY where the real weight is still NaN, so any *other* type
+# that unexpectedly goes missing still surfaces loudly as NaN.
+#
+# >>> REMOVE this block (and _fill_placeholder_weights) once the dataset refresh provides real,
+# >>> measured weights for these operations. It exists solely to bridge the gap between adding the
+# >>> new FLOP types and collecting their benchmark data.
+_PLACEHOLDER_WEIGHTS: dict[FlopType, float] = {
+    FlopType.ASIN: 30.0,  # ~ SIN / COS
+    FlopType.ACOS: 30.0,  # ~ SIN / COS
+    FlopType.ATAN: 30.0,  # ~ SIN / COS
+    FlopType.ATAN2: 45.0,  # atan + div + quadrant selection
+    FlopType.HYPOT: 12.0,  # overflow-safe sqrt path, pricier than a raw SQRT
+    FlopType.EXPM1: 18.0,  # ~ EXP
+    FlopType.LOG1P: 18.0,  # ~ LOG
+    FlopType.FMOD: 8.0,  # ~ DIV plus a few ops
+}
 
 
+def _fill_placeholder_weights(weights: FlopWeights) -> FlopWeights:
+    """Fill placeholder weights for the not-yet-measured higher-order libm ops.
+
+    TEMPORARY: remove once the dataset refresh provides real measured weights for these types
+    (see `_PLACEHOLDER_WEIGHTS` above). Only fills a placeholder where the current weight is NaN,
+    and only for the specific ops in `_PLACEHOLDER_WEIGHTS`, so any other missing weight still
+    surfaces as NaN rather than being silently masked.
+    """
+    filled = dict(weights.weights)
+    for flop_type, placeholder in _PLACEHOLDER_WEIGHTS.items():
+        if math.isnan(filled[flop_type]):
+            filled[flop_type] = placeholder
+    return FlopWeights(weights=filled)
+
+
+# =================================================================================================
+#  Public accessors
+# =================================================================================================
 def get_default_consensus_flop_weights(rounding_mode: None | Literal["nearest_int", "10%"] = "10%") -> FlopWeights:
     """Get the default CONSENSUS flop weights.
 
@@ -37,6 +83,7 @@ def _get_builtin_flop_weights_cached(
     rounding_mode: None | Literal["nearest_int", "10%"],
 ) -> FlopWeights:
     weights = BuiltInData.get_flop_weights(key_filter=key_filter)
+    weights = _fill_placeholder_weights(weights)  # TEMPORARY: remove with the dataset refresh (see above)
     if rounding_mode is not None:
         return weights.round(mode=rounding_mode)
     return weights

--- a/src/counted_float/_core/models/_flop_counts.py
+++ b/src/counted_float/_core/models/_flop_counts.py
@@ -41,6 +41,14 @@ class FlopCounts:
     SIN: int = 0
     COS: int = 0
     TAN: int = 0
+    ASIN: int = 0
+    ACOS: int = 0
+    ATAN: int = 0
+    ATAN2: int = 0
+    HYPOT: int = 0
+    EXPM1: int = 0
+    LOG1P: int = 0
+    FMOD: int = 0
 
     # --- math --------------------------------------------
     def __add__(self, other: FlopCounts) -> FlopCounts:

--- a/src/counted_float/_core/models/_flop_type.py
+++ b/src/counted_float/_core/models/_flop_type.py
@@ -30,6 +30,14 @@ class FlopType(StrEnum):
     SIN = "sin(x)"
     COS = "cos(x)"
     TAN = "tan(x)"
+    ASIN = "asin(x)"
+    ACOS = "acos(x)"
+    ATAN = "atan(x)"
+    ATAN2 = "atan2(y,x)"
+    HYPOT = "hypot(x,y)"
+    EXPM1 = "expm1(x)"
+    LOG1P = "log1p(x)"
+    FMOD = "fmod(x,y)"
 
     def long_name(self) -> str:
         return f"FlopType.{self.name:<9}  [{self.value}]"

--- a/src/counted_float/_core/models/_flop_weights.py
+++ b/src/counted_float/_core/models/_flop_weights.py
@@ -41,9 +41,20 @@ class FlopWeights(MyBaseModel):
         return any(math.isnan(v) for v in self.weights.values())
 
     def get_sorted_flop_types(self) -> list[FlopType]:
-        """Return flop types sorted in ascending order of corresponding weights."""
-        sorted_flop_weights_and_types = sorted(zip(self.weights.values(), self.weights.keys(), strict=True))
-        return [flop_type for _, flop_type in sorted_flop_weights_and_types]
+        """Return flop types sorted in ascending order of corresponding weights.
+
+        NaN weights (missing data) sort last, deterministically: entries are ordered by
+        (is-NaN, weight, flop-type value), so ties and missing values keep a stable order
+        instead of the arbitrary placement NaN comparisons would otherwise produce.
+        """
+        return sorted(
+            self.weights.keys(),
+            key=lambda ft: (
+                math.isnan(self.weights[ft]),
+                0.0 if math.isnan(self.weights[ft]) else self.weights[ft],
+                ft.value,
+            ),
+        )
 
     # -------------------------------------------------------------------------
     #  Validation

--- a/tests/counting/test_math_patching.py
+++ b/tests/counting/test_math_patching.py
@@ -65,6 +65,15 @@ def test_math_module_patched_inside_context_only(fname):
         ("sin", (2.0,)),
         ("cos", (2.0,)),
         ("tan", (2.0,)),
+        ("asin", (0.5,)),
+        ("acos", (0.5,)),
+        ("atan", (0.5,)),
+        ("atan2", (1.0, 2.0)),
+        ("hypot", (3.0, 4.0)),
+        ("expm1", (0.5,)),
+        ("log1p", (0.5,)),
+        ("fmod", (5.0, 3.0)),
+        ("fabs", (-2.0,)),
     ],
 )
 def test_patched_math_functions_match_stdlib_for_plain_floats(global_counter, fname, args):
@@ -226,6 +235,66 @@ def test_math_pow_domain_error_counts_nothing(global_counter):
     # --- act & assert ------------------------------------
     with pytest.raises(ValueError):  # noqa: PT011 -- domain-error message wording varies across CPython versions
         math.pow(cf, 1 / 3)
+    assert global_counter.total_count() == 0
+
+
+# =================================================================================================
+#  Patched math functions - new higher-order ops (asin/acos/atan/atan2/hypot/expm1/log1p/fmod/fabs)
+# =================================================================================================
+@pytest.mark.parametrize(
+    ("fname", "n_args", "flop_type_name"),
+    [
+        ("asin", 1, "ASIN"),
+        ("acos", 1, "ACOS"),
+        ("atan", 1, "ATAN"),
+        ("atan2", 2, "ATAN2"),
+        ("hypot", 2, "HYPOT"),
+        ("expm1", 1, "EXPM1"),
+        ("log1p", 1, "LOG1P"),
+        ("fmod", 2, "FMOD"),
+        ("fabs", 1, "ABS"),  # fabs reuses the existing ABS type, not a new one
+    ],
+)
+def test_new_math_ops_count_and_are_contagious(global_counter, fname, n_args, flop_type_name):
+    # --- arrange -----------------------------------------
+    args = tuple(CountedFloat(0.5) for _ in range(n_args))
+
+    # --- act ---------------------------------------------
+    result = getattr(math, fname)(*args)
+
+    # --- assert ------------------------------------------
+    assert isinstance(result, CountedFloat)
+    assert getattr(global_counter, flop_type_name) == 1
+    assert global_counter.total_count() == 1
+
+
+@pytest.mark.parametrize("fname", ["atan2", "hypot", "fmod"])
+def test_new_binary_math_ops_count_with_either_operand_counted(global_counter, fname):
+    # counted (and contagious) when EITHER operand is a CountedFloat, like the existing binary ops
+    # --- act ---------------------------------------------
+    r_left = getattr(math, fname)(CountedFloat(3.0), 2.0)
+    r_right = getattr(math, fname)(3.0, CountedFloat(2.0))
+
+    # --- assert ------------------------------------------
+    assert isinstance(r_left, CountedFloat)
+    assert isinstance(r_right, CountedFloat)
+    assert global_counter.total_count() == 2
+
+
+@pytest.mark.parametrize(
+    ("fname", "args"),
+    [
+        ("asin", (CountedFloat(2.0),)),  # domain: |x| <= 1
+        ("acos", (CountedFloat(2.0),)),
+        ("log1p", (CountedFloat(-2.0),)),  # domain: x > -1
+        ("fmod", (CountedFloat(5.0), CountedFloat(0.0))),  # fmod by zero
+    ],
+)
+def test_new_math_ops_domain_error_counts_nothing(global_counter, fname, args):
+    # compute-first contract: a raised domain error leaves nothing counted
+    # --- act & assert ------------------------------------
+    with pytest.raises(ValueError):  # noqa: PT011 -- domain-error message wording varies across CPython versions
+        getattr(math, fname)(*args)
     assert global_counter.total_count() == 0
 
 

--- a/tests/models/test_flop_weights.py
+++ b/tests/models/test_flop_weights.py
@@ -50,6 +50,24 @@ def test_flop_weights_has_missing_data(sample_flop_weights_dict_by_enum, has_mis
     assert flag == has_missing_data
 
 
+def test_get_sorted_flop_types_orders_by_weight_with_nan_last():
+    # --- arrange -----------------------------------------
+    weights = FlopWeights(
+        weights={FlopType.MUL: 3.0, FlopType.ADD: 1.0, FlopType.DIV: 5.0}
+    )  # every other type defaults to NaN via the validator
+
+    # --- act ---------------------------------------------
+    ordered = weights.get_sorted_flop_types()
+
+    # --- assert ------------------------------------------
+    finite = [ft for ft in ordered if not math.isnan(weights.weights[ft])]
+    missing = [ft for ft in ordered if math.isnan(weights.weights[ft])]
+
+    assert finite == [FlopType.ADD, FlopType.MUL, FlopType.DIV]  # finite weights first, ascending
+    assert ordered[: len(finite)] == finite  # ...and all before the NaN block
+    assert missing == sorted(missing, key=lambda ft: ft.value)  # NaN block is deterministically ordered
+
+
 def test_flop_weights_serialization(sample_flop_weights_dict_by_str):
     # --- arrange -----------------------------------------
     flop_weights = FlopWeights(weights=sample_flop_weights_dict_by_str)


### PR DESCRIPTION
Adds eight higher-order libm functions as first-class counted `FlopType`s — `asin`, `acos`, `atan`, `atan2`, `hypot`, `expm1`, `log1p`, and the C-library truncated `fmod` — plus `math.fabs` mapped to the existing `ABS` type. Previously these passed a `CountedFloat` through as an uncounted plain `float`, silently deflating downstream counts.

These ops have no hardware instruction and no benchmark data yet, so a **temporary, clearly-marked placeholder-weight** block gives them order-of-magnitude weights until the dataset refresh supplies real measurements (it fills only these specific types, and only where the weight is NaN, so any other missing weight still surfaces loudly).

Also fixes non-deterministic `FlopType` ordering on partial/filtered weight sets (e.g. `get_builtin_flop_weights(key_filter="specs")`), independent of the new types.

Stacked on top of the int/bool-constant change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)