### PR TITLE
fix: count %, //, divmod, and unary + (contagion completion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `%`, `//`, `divmod()`, and unary `+` on a `CountedFloat` now count and stay `CountedFloat` (they previously returned a plain, uncounted `float`, silently breaking downstream counting)
 - `FlopWeights.get_sorted_flop_types()` now orders types deterministically when some weights are missing (NaN)
 
 ### Security

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -11,6 +11,59 @@ find:
 - Python operations that are counted for this flop type
 - Python operations that are *not* counted for this flop type
 
+## Coverage at a glance
+
+| Python operation | Counts as | Mechanism | Weight source | Stays `CountedFloat`? |
+|---|---|---|---|---|
+| `x + y`, `x - y`, `x * y`, `x / y` | `ADD`, `SUB`, `MUL`, `DIV` | operator | ISA | yes |
+| `x // y` | `DIV + RND` | operator (decomposed) | ISA | yes |
+| `x % y` | `DIV + RND + MUL + SUB` | operator (decomposed) | ISA | yes |
+| `divmod(x, y)` | `DIV + RND + MUL + SUB` | operator (decomposed) | ISA | yes (both) |
+| `-x` | `MINUS` | operator | ISA | yes |
+| `+x` | *(nothing)* | operator | — | yes |
+| `abs(x)`, `math.fabs(x)` | `ABS` | operator / patch | ISA | yes |
+| `x == y`, `x < y`, …, `min`, `max` | `COMP` | operator | ISA | returns `bool` |
+| `round(x, n)` | `RND` | operator | ISA | yes (float) |
+| `round(x)`, `int(x)`, `math.floor`/`ceil`/`trunc` | `F2I` | operator | ISA | returns `int` |
+| `CountedFloat(int)` | `I2F` | constructor | ISA | yes |
+| `x ** y`, `math.pow(x, y)` | `POW` (or `MUL`/`EXP2`/`EXP10` via strength reduction) | operator / patch | benchmarked | yes |
+| `math.sqrt(x)` | `SQRT` | patch | ISA | yes |
+| `math.cbrt(x)` | `CBRT` | patch | benchmarked | yes |
+| `math.exp(x)`, `math.exp2(x)`, `2 ** x` | `EXP`, `EXP2` | patch / operator | benchmarked | yes |
+| `math.log(x[, base])` | `LOG` (or `LOG2`/`LOG10`; decomposes for other bases) | patch | benchmarked | yes |
+| `math.sin`/`cos`/`tan(x)` | `SIN`, `COS`, `TAN` | patch | benchmarked | yes |
+| `math.asin`/`acos`/`atan(x)` | `ASIN`, `ACOS`, `ATAN` | patch | benchmarked | yes |
+| `math.atan2(y, x)` | `ATAN2` | patch | benchmarked | yes |
+| `math.hypot(x, y)` | `HYPOT` | patch | benchmarked | yes |
+| `math.expm1(x)`, `math.log1p(x)` | `EXPM1`, `LOG1P` | patch | benchmarked | yes |
+| `math.fmod(x, y)` | `FMOD` | patch | benchmarked | yes |
+| `math.copysign`, `sinh`/`cosh`/`tanh` and inverses | *(uncounted)* | — | — | no (plain float) |
+| `numpy.*` and other non-stdlib math | *(uncounted)* | — | — | no |
+
+- **Mechanism** — *operator*: a `CountedFloat` dunder, counted everywhere.
+  *patch*: a `math.*` function, counted only inside a `FlopCountingContext`
+  (see [Math patching semantics](math_patching.md)). *decomposed*: no
+  dedicated `FlopType` — counts as a composition of existing types.
+- **Weight source** — *ISA*: backed by a real hardware instruction (spec-sheet
+  latency + benchmarks). *benchmarked*: a libm-level op with no corresponding
+  instruction, so its weight comes from benchmarks alone.
+
+### Decomposed operations
+
+`//`, `%`, and `divmod()` have no dedicated `FlopType`: a compiled port emits
+each as a sequence of primitive operations, and that sequence is what gets
+counted. Python's `//`/`%` use **floored** semantics, so `⌊·⌋` below is a
+float→float round (`RND`), not an `F2I`:
+
+- `x // y` → `DIV + RND` — divide, then floor the quotient.
+- `x % y` → `DIV + RND + MUL + SUB` — the floored remainder `r = x − y·⌊x/y⌋`.
+- `divmod(x, y)` → `DIV + RND + MUL + SUB` — quotient and remainder share the
+  `DIV + RND`, so it costs the same as a lone `%`.
+
+Note the `%` operator (floored) is distinct from `math.fmod` (the truncated C
+remainder, which has its own `FlopType.FMOD`). `math.log(x, base)` also
+decomposes for bases other than 2/10 — see `FlopType.LOG` below.
+
 ## FlopType.ABS (`abs(x)`)
 
 - Relevant CPU instructions

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -36,6 +36,14 @@ class CountedFloat(float):
         GLOBAL_COUNTER.incr_minus()
         return CountedFloat(super().__neg__())
 
+    def __pos__(self) -> CountedFloat:
+        """+x.
+
+        Unary plus is the identity; a compiled port emits no instruction, so nothing is counted.
+        The type is preserved (returns a CountedFloat) so downstream counting survives.
+        """
+        return CountedFloat(super().__pos__())
+
     def __eq__(self, other: object) -> bool:
         """x==other or other==x."""
         result = super().__eq__(other)
@@ -183,6 +191,82 @@ class CountedFloat(float):
             return NotImplemented
         GLOBAL_COUNTER.incr_div()
         return CountedFloat(result)
+
+    def __floordiv__(self, other: float) -> CountedFloat:
+        """x//y.
+
+        Floored division decomposes into DIV + RND: a compiled port computes x/y and rounds the
+        quotient toward -inf, a float->float round (RND / FRINTM / ROUNDSD class), not an F2I.
+        """
+        result = super().__floordiv__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        GLOBAL_COUNTER.incr_div()
+        GLOBAL_COUNTER.incr_rnd()
+        return CountedFloat(result)
+
+    def __rfloordiv__(self, other: float) -> CountedFloat:
+        """other//x. See __floordiv__ for the DIV + RND decomposition."""
+        result = super().__rfloordiv__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        GLOBAL_COUNTER.incr_div()
+        GLOBAL_COUNTER.incr_rnd()
+        return CountedFloat(result)
+
+    def __mod__(self, other: float) -> CountedFloat:
+        """x%y.
+
+        Python's % is the floored remainder r = x - y*floor(x/y), which a compiled port emits as
+        DIV + RND (the floor) + MUL + SUB. Distinct from math.fmod, the truncated C remainder.
+        """
+        result = super().__mod__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        GLOBAL_COUNTER.incr_div()
+        GLOBAL_COUNTER.incr_rnd()
+        GLOBAL_COUNTER.incr_mul()
+        GLOBAL_COUNTER.incr_sub()
+        return CountedFloat(result)
+
+    def __rmod__(self, other: float) -> CountedFloat:
+        """other%x. See __mod__ for the DIV + RND + MUL + SUB decomposition."""
+        result = super().__rmod__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        GLOBAL_COUNTER.incr_div()
+        GLOBAL_COUNTER.incr_rnd()
+        GLOBAL_COUNTER.incr_mul()
+        GLOBAL_COUNTER.incr_sub()
+        return CountedFloat(result)
+
+    def __divmod__(self, other: float) -> tuple[CountedFloat, CountedFloat]:
+        """divmod(x, y) = (x//y, x%y).
+
+        Quotient and remainder share the DIV + RND (the floor); the remainder adds MUL + SUB, so
+        divmod counts DIV + RND + MUL + SUB — the same as a lone %, since the // part is shared.
+        """
+        result = super().__divmod__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        GLOBAL_COUNTER.incr_div()
+        GLOBAL_COUNTER.incr_rnd()
+        GLOBAL_COUNTER.incr_mul()
+        GLOBAL_COUNTER.incr_sub()
+        quotient, remainder = result
+        return CountedFloat(quotient), CountedFloat(remainder)
+
+    def __rdivmod__(self, other: float) -> tuple[CountedFloat, CountedFloat]:
+        """divmod(other, x). See __divmod__ for the DIV + RND + MUL + SUB decomposition."""
+        result = super().__rdivmod__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        GLOBAL_COUNTER.incr_div()
+        GLOBAL_COUNTER.incr_rnd()
+        GLOBAL_COUNTER.incr_mul()
+        GLOBAL_COUNTER.incr_sub()
+        quotient, remainder = result
+        return CountedFloat(quotient), CountedFloat(remainder)
 
     def __pow__(self, other: float) -> CountedFloat:  # ty: ignore[invalid-method-override] -- no `mod` param; float.__pow__'s mod is None-only and unused here
         """x**other.

--- a/tests/counting/test_counted_float.py
+++ b/tests/counting/test_counted_float.py
@@ -1,4 +1,5 @@
 import math
+import operator
 from collections.abc import Callable
 
 import pytest
@@ -942,3 +943,93 @@ def test_counted_float_counts_sin_cos_tan(global_counter):
     assert global_counter.SIN == 1
     assert global_counter.COS == 2
     assert global_counter.TAN == 3
+
+
+# =================================================================================================
+#  CountedFloat - %, //, divmod, unary + (contagion completion)
+# =================================================================================================
+def test_counted_float_counts_floordiv(global_counter):
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(7.5)
+
+    # --- act ---------------------------------------------
+    forward = cf // 2.0
+    reflected = 17.0 // cf
+
+    # --- assert ------------------------------------------
+    # values compared via float() so the comparison itself does not count a COMP
+    assert isinstance(forward, CountedFloat)
+    assert isinstance(reflected, CountedFloat)
+    assert (float(forward), float(reflected)) == (3.0, 2.0)
+    assert global_counter.DIV == 2  # each // counts DIV + RND
+    assert global_counter.RND == 2
+    assert global_counter.total_count() == 4
+
+
+def test_counted_float_counts_mod(global_counter):
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(7.5)
+
+    # --- act ---------------------------------------------
+    forward = cf % 2.0
+    reflected = 17.0 % cf
+
+    # --- assert ------------------------------------------
+    assert isinstance(forward, CountedFloat)
+    assert isinstance(reflected, CountedFloat)
+    assert (float(forward), float(reflected)) == (1.5, 2.0)
+    # each % counts the floored-remainder decomposition DIV + RND + MUL + SUB
+    assert global_counter.DIV == 2
+    assert global_counter.RND == 2
+    assert global_counter.MUL == 2
+    assert global_counter.SUB == 2
+    assert global_counter.total_count() == 8
+
+
+def test_counted_float_counts_divmod(global_counter):
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(7.5)
+
+    # --- act ---------------------------------------------
+    q, r = divmod(cf, 2.0)
+    rq, rr = divmod(17.0, cf)
+
+    # --- assert ------------------------------------------
+    assert isinstance(q, CountedFloat)
+    assert isinstance(r, CountedFloat)
+    assert isinstance(rq, CountedFloat)
+    assert isinstance(rr, CountedFloat)
+    assert (float(q), float(r)) == (3.0, 1.5)
+    # each divmod shares the quotient's DIV + RND with the remainder: DIV + RND + MUL + SUB per call
+    assert global_counter.DIV == 2
+    assert global_counter.RND == 2
+    assert global_counter.MUL == 2
+    assert global_counter.SUB == 2
+    assert global_counter.total_count() == 8
+
+
+def test_counted_float_unary_plus_preserves_type_and_counts_nothing(global_counter):
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(1.23456)
+
+    # --- act ---------------------------------------------
+    result = +cf
+
+    # --- assert ------------------------------------------
+    assert isinstance(result, CountedFloat)
+    assert float(result) == 1.23456
+    assert global_counter.total_count() == 0
+
+
+@pytest.mark.parametrize("op", [operator.floordiv, operator.mod, divmod])
+def test_counted_float_mod_floordiv_divmod_zero_division_counts_nothing(global_counter, op: Callable):
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(7.5)
+    cf_zero = CountedFloat(0.0)  # construction from a float counts nothing
+
+    # --- act & assert ------------------------------------
+    with pytest.raises(ZeroDivisionError):
+        op(cf, 0.0)  # forward path: cf // 0.0
+    with pytest.raises(ZeroDivisionError):
+        op(17.0, cf_zero)  # reflected path: 17.0 // cf_zero
+    assert global_counter.total_count() == 0

--- a/tests/counting/test_numeric_protocol.py
+++ b/tests/counting/test_numeric_protocol.py
@@ -16,7 +16,15 @@ import pytest
 from counted_float._core.counting._counted_float import CountedFloat
 from counted_float._core.counting._global_counter import GlobalFlopCounter
 
-ARITHMETIC_OPERATORS = [operator.add, operator.sub, operator.mul, operator.truediv, operator.pow]
+ARITHMETIC_OPERATORS = [
+    operator.add,
+    operator.sub,
+    operator.mul,
+    operator.truediv,
+    operator.floordiv,
+    operator.mod,
+    operator.pow,
+]
 COMPARISON_OPERATORS = [operator.eq, operator.ne, operator.lt, operator.le, operator.gt, operator.ge]
 
 
@@ -38,6 +46,15 @@ class ReflectedOps:
     def __rpow__(self, other: float) -> str:
         return "rpow"
 
+    def __rmod__(self, other: float) -> str:
+        return "rmod"
+
+    def __rfloordiv__(self, other: float) -> str:
+        return "rfloordiv"
+
+    def __rdivmod__(self, other: float) -> tuple:
+        return ("rdivmod",)
+
     def __gt__(self, other: float) -> str:
         return "gt"  # reflected counterpart of CountedFloat.__lt__
 
@@ -45,7 +62,9 @@ class ReflectedOps:
 # =================================================================================================
 #  Delegation to the other operand
 # =================================================================================================
-@pytest.mark.parametrize("op", [operator.add, operator.sub, operator.mul, operator.truediv])
+@pytest.mark.parametrize(
+    "op", [operator.add, operator.sub, operator.mul, operator.truediv, operator.floordiv, operator.mod]
+)
 def test_arithmetic_with_fraction_matches_float(op: Callable, global_counter: GlobalFlopCounter):
     # --- arrange -----------------------------------------
     cf = CountedFloat(1.5)
@@ -103,6 +122,9 @@ def test_reflected_operators_of_foreign_type_win(global_counter: GlobalFlopCount
     assert cf * foreign == "rmul"
     assert cf / foreign == "rtruediv"
     assert cf**foreign == "rpow"
+    assert cf % foreign == "rmod"
+    assert cf // foreign == "rfloordiv"
+    assert divmod(cf, foreign) == ("rdivmod",)
     assert (cf < foreign) == "gt"
     assert global_counter.total_count() == 0
 


### PR DESCRIPTION
`cf % y`, `cf // y`, `divmod(cf, y)`, and `+cf` previously returned a plain, uncounted `float` — silently demoting the type and breaking all downstream counting. They now count and stay `CountedFloat`, decomposed into existing types the way a compiled port would emit them:

- `x // y` → `DIV + RND` (divide, then floor the quotient — a float→float round, not an F2I)
- `x % y` → `DIV + RND + MUL + SUB` (the floored remainder `x - y*floor(x/y)`)
- `divmod(x, y)` → `DIV + RND + MUL + SUB` (quotient and remainder share the DIV+RND)
- `+x` → nothing counted, type preserved

Zero-division raises and foreign operands (e.g. `Fraction`) delegate, both counting nothing — matching plain `float`. Docs gain a coverage-at-a-glance matrix and a decomposed-operations section.

Stacked on the new-FLOP-types change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)