### PR TITLE
chore: derive the package version from git tags via hatch-vcs

### DIFF
--- a/.github/workflows/_package_check.yml
+++ b/.github/workflows/_package_check.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
@@ -45,6 +47,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/unit_test
         with:
@@ -57,6 +59,8 @@ jobs:
           exit 1
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:

--- a/.github/workflows/benchmark_linux_arm.yml
+++ b/.github/workflows/benchmark_linux_arm.yml
@@ -12,6 +12,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark

--- a/.github/workflows/benchmark_linux_x86.yml
+++ b/.github/workflows/benchmark_linux_x86.yml
@@ -12,6 +12,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark

--- a/.github/workflows/benchmark_macos_arm.yml
+++ b/.github/workflows/benchmark_macos_arm.yml
@@ -12,6 +12,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark

--- a/.github/workflows/benchmark_macos_x86.yml
+++ b/.github/workflows/benchmark_macos_x86.yml
@@ -12,6 +12,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark

--- a/.github/workflows/benchmark_windows_x86.yml
+++ b/.github/workflows/benchmark_windows_x86.yml
@@ -12,6 +12,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -73,6 +73,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/pre_commit
         with:
@@ -99,6 +101,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0

--- a/.github/workflows/push_to_branch.yml
+++ b/.github/workflows/push_to_branch.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/pre_commit
         with:
@@ -50,6 +52,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/unit_test
         with:

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install uv
@@ -24,7 +26,9 @@ jobs:
 
       - name: Validate tag and version match
         run: |
-          PACKAGE_VERSION=$(uv version --short)
+          # the version is hatch-vcs-derived from the tag itself, so this validates the
+          # derivation is clean (exact-tag checkout => plain X.Y.Z, no dev/dirty suffix)
+          PACKAGE_VERSION=$(uvx --with hatch-vcs hatch version)
           TAG_NAME="${GITHUB_REF_NAME}"
           EXPECTED_TAG="v${PACKAGE_VERSION}"
 
@@ -105,6 +109,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
@@ -126,5 +132,5 @@ jobs:
             --title "$TAG" \
             --notes-file release_notes.md \
             provenance.intoto.jsonl
-  # No bump-version job: release.py owns versioning (it bumps pyproject and opens
-  # the next Unreleased section as part of the local release, before the tag push).
+  # No bump-version job: the package version is derived from the git tag at build
+  # time (hatch-vcs); release.py finalizes the changelog and pushes the tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- the package version is now derived from git at build time; development builds self-report PEP 440 dev versions (e.g. `1.4.1.devN+g<sha>`) instead of the previous release's version
+
 ### Deprecated
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
 [project]
 name = "counted-float"
-version = "1.4.0"
 description = "Count floating-point operations in Python code & benchmark relative flop costs."
 # readme is dynamic: hatch-fancy-pypi-readme builds the PyPI long-description from
 # README.md, rewriting relative links to tag-pinned absolute URLs (config below).
-dynamic = ["readme"]
+# version is dynamic: hatch-vcs derives it from git at build time — a checkout of tag
+# vX.Y.Z builds as exactly X.Y.Z, an untagged commit as the PEP 440 dev version
+# X.Y.(Z+1).devN+g<sha> — so dev builds self-report their provenance (config below).
+dynamic = ["readme", "version"]
 requires-python = ">=3.11"
 dependencies = [
     # Per-Python floors: each compiled dep's floor is the earliest version shipping a
@@ -82,8 +84,11 @@ docs = [
 ]
 
 [build-system]
-requires = ["hatchling", "hatch-fancy-pypi-readme"]
+requires = ["hatchling", "hatch-fancy-pypi-readme", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.metadata.hooks.fancy-pypi-readme]
 content-type = "text/markdown"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,8 +1,9 @@
 """Release driver for counted-float.
 
-Run via ``make release VERSION=X.Y.Z``.  Validates state, bumps
-version, finalizes the changelog, commits, tags, opens a new
-Unreleased section, commits, and pushes main + tag atomically.
+Run via ``make release VERSION=X.Y.Z``.  Validates state, finalizes the
+changelog, commits, tags, opens a new Unreleased section, commits, and
+pushes main + tag atomically.  The package version itself is derived from
+the git tag at build time (hatch-vcs), so no version bump is written.
 """
 
 from __future__ import annotations
@@ -65,13 +66,10 @@ def parse_semver(version: str) -> tuple[int, int, int]:
     return tuple(int(p) for p in version.split("."))  # type: ignore[return-value]
 
 
-def read_pyproject_version() -> str:
-    """Read the current version from pyproject.toml."""
-    text = PYPROJECT.read_text()
-    m = re.search(r'(?m)^version\s*=\s*"([^"]+)"', text)
-    if not m:
-        fail_with_message("Could not find version in pyproject.toml")
-    return m.group(1)
+def read_latest_tag_version() -> str:
+    """Read the latest released version from the git tags reachable from HEAD."""
+    tag = run_command(["git", "describe", "--tags", "--abbrev=0", "--match", "v[0-9]*"]).strip()
+    return tag.removeprefix("v")
 
 
 def read_python_versions() -> list[str]:
@@ -104,12 +102,12 @@ def step_2_check_in_sync() -> None:
 
 
 def step_3_check_version_upgrade(version: str) -> None:
-    """Validate VERSION is strictly greater than current."""
+    """Validate VERSION is strictly greater than the latest released tag."""
     print_step(3, f"VERSION {version} is an upgrade")
     new = parse_semver(version)
-    current = parse_semver(read_pyproject_version())
+    current = parse_semver(read_latest_tag_version())
     if new <= current:
-        fail_with_message(f"VERSION {version} is not greater than current {'.'.join(str(p) for p in current)}")
+        fail_with_message(f"VERSION {version} is not greater than latest tag {'.'.join(str(p) for p in current)}")
 
 
 def step_4_check_tag_doesnt_exist(version: str) -> None:
@@ -163,23 +161,11 @@ def step_7_check_changelog_has_entries() -> None:
 
 
 # ==================================================================================================
-#  release commit steps (8-12)
+#  release commit steps (8-10)
 # ==================================================================================================
-def step_8_bump_version(version: str) -> None:
-    """Set version in pyproject.toml."""
-    print_step(8, f"bump version to {version}")
-    run_command(["uv", "version", version])
-
-
-def step_9_lock() -> None:
-    """Refresh uv.lock after version bump."""
-    print_step(9, "refresh uv.lock")
-    run_command(["uv", "lock"])
-
-
-def step_10_finalize_changelog(version: str) -> None:
+def step_8_finalize_changelog(version: str) -> None:
     """Move Unreleased entries to a dated version section."""
-    print_step(10, f"finalize CHANGELOG.md '## Unreleased' -> '## {version} ({date.today().isoformat()})'")
+    print_step(8, f"finalize CHANGELOG.md '## Unreleased' -> '## {version} ({date.today().isoformat()})'")
     text = CHANGELOG.read_text()
     m = re.search(r"^## Unreleased\s*$(.*?)(?=^## |\Z)", text, re.MULTILINE | re.DOTALL)
     if not m:
@@ -296,26 +282,26 @@ def refresh_readme_badges() -> None:
     README.write_text(text)
 
 
-def step_11_commit_release(version: str) -> None:
+def step_9_commit_release(version: str) -> None:
     """Refresh README badges, then create the release commit."""
-    print_step(11, f"refresh README badges + commit 'release: {version}'")
+    print_step(9, f"refresh README badges + commit 'release: {version}'")
     refresh_readme_badges()
-    run_command(["git", "add", "pyproject.toml", "uv.lock", "CHANGELOG.md", "README.md"])
+    run_command(["git", "add", "CHANGELOG.md", "README.md"])
     run_command(["git", "commit", "-m", f"release: {version}"])
 
 
-def step_12_tag(version: str) -> None:
+def step_10_tag(version: str) -> None:
     """Create the version tag."""
-    print_step(12, f"create tag v{version}")
+    print_step(10, f"create tag v{version}")
     run_command(["git", "tag", f"v{version}"])
 
 
 # ==================================================================================================
-#  post-release steps (13-15)
+#  post-release steps (11-13)
 # ==================================================================================================
-def step_13_add_unreleased_section() -> None:
+def step_11_add_unreleased_section() -> None:
     """Add a fresh Unreleased section to the changelog."""
-    print_step(13, "add fresh '## Unreleased' section to CHANGELOG.md")
+    print_step(11, "add fresh '## Unreleased' section to CHANGELOG.md")
     text = CHANGELOG.read_text()
     m = re.search(r"^## ", text, re.MULTILINE)
     if not m:
@@ -325,16 +311,16 @@ def step_13_add_unreleased_section() -> None:
     CHANGELOG.write_text(text)
 
 
-def step_14_commit_next_cycle() -> None:
+def step_12_commit_next_cycle() -> None:
     """Commit the fresh Unreleased section."""
-    print_step(14, "commit 'chore: begin next development cycle'")
+    print_step(12, "commit 'chore: begin next development cycle'")
     run_command(["git", "add", "CHANGELOG.md"])
     run_command(["git", "commit", "-m", "chore: begin next development cycle"])
 
 
-def step_15_push(version: str) -> None:
+def step_13_push(version: str) -> None:
     """Push main and the tag atomically."""
-    print_step(15, f"push main + v{version} atomically")
+    print_step(13, f"push main + v{version} atomically")
     run_command(["git", "push", "--atomic", "origin", "main", f"refs/tags/v{version}"])
 
 
@@ -374,24 +360,22 @@ def main() -> None:
     step_7_check_changelog_has_entries()
 
     print("\nRelease commit:")
-    step_8_bump_version(version)
-    step_9_lock()
-    step_10_finalize_changelog(version)
-    step_11_commit_release(version)
-    step_12_tag(version)
+    step_8_finalize_changelog(version)
+    step_9_commit_release(version)
+    step_10_tag(version)
 
     print("\nPost-release:")
     also_next_cycle = False
     try:
-        step_13_add_unreleased_section()
-        step_14_commit_next_cycle()
+        step_11_add_unreleased_section()
+        step_12_commit_next_cycle()
         also_next_cycle = True
-        step_15_push(version)
+        step_13_push(version)
     except subprocess.CalledProcessError:
-        post_tag_recovery_hint(13, version, also_next_cycle)
+        post_tag_recovery_hint(11, version, also_next_cycle)
         sys.exit(1)
     except SystemExit:
-        post_tag_recovery_hint(13, version, also_next_cycle)
+        post_tag_recovery_hint(11, version, also_next_cycle)
         raise
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -194,7 +194,6 @@ wheels = [
 
 [[package]]
 name = "counted-float"
-version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -249,7 +248,7 @@ requires-dist = [
     { name = "pydantic", marker = "python_full_version >= '3.14'", specifier = ">=2.12" },
     { name = "rich", specifier = ">=13.0.0" },
 ]
-provides-extras = ["numba", "cli"]
+provides-extras = ["cli", "numba"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Dev builds previously self-reported the last released version, so in-cycle artifacts (notably benchmark JSONs) carried wrong provenance unless hand-stamped. The version is now hatch-vcs-derived from git at build time: a tag checkout builds as the exact release version, an untagged commit as a PEP 440 dev version pinned to its commit (`1.4.1.devN+g<sha>`).

release.py no longer writes a version bump (the tag is the version), the tag workflow validates the derived version instead of the pyproject field, and CI checkouts fetch full history so version derivation works everywhere the package is built.

Verified in a clean clone: an exact-tag checkout derives the bare tag version; an untagged commit derives the pinned dev version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)