### PR TITLE
fix: floor benchmark-derived flop latencies to a positive value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- benchmark-derived flop weights are now floored to a small positive value, so a noisy run can no longer produce negative or invalid weights
+
 ### Security
 
 ## 1.4.1 (2026-07-13)

--- a/src/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
+++ b/src/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
@@ -1,4 +1,5 @@
 import math
+import sys
 from importlib.metadata import version
 
 import numpy as np
@@ -20,6 +21,13 @@ FBT = FlopsBenchmarkType
 
 
 class FlopsBenchmarkSuite:
+    # differencing noisy per-kernel statistics can yield estimates <= 0 for cheap ops
+    # (ABS, MINUS, COMP) on a loaded machine; latencies are floored to this fraction of
+    # the measured ADD cost — well below any plausible genuine latency (the cheapest
+    # measured ops sit around 0.3-1x ADD), so it only ever binds on noise artifacts.
+    # The spec-sheet path applies its own floor via Latency.consensus().
+    MIN_LATENCY_ADD_FRACTION = 0.1
+
     # -------------------------------------------------------------------------
     #  Main API
     # -------------------------------------------------------------------------
@@ -106,6 +114,7 @@ class FlopsBenchmarkSuite:
             FlopType.COSH: n_cycles_per_op[FBT.ADD_ACOSH_COSH].q50 - n_cycles_per_op[FBT.ADD_ACOSH].q50,
             FlopType.ATANH: n_cycles_per_op[FBT.ADD_HALFSIN_ATANH].q50 - n_cycles_per_op[FBT.ADD_HALFSIN].q50,
         }
+        estimated_flop_latencies = self.floor_latencies(estimated_flop_latencies)
 
         # put results in appropriate format
         return FlopsBenchmarkResults(
@@ -123,6 +132,19 @@ class FlopsBenchmarkSuite:
     # -------------------------------------------------------------------------
     #  Static methods
     # -------------------------------------------------------------------------
+    @classmethod
+    def floor_latencies(cls, latencies: dict[FlopType, float]) -> dict[FlopType, float]:
+        """Clamp estimated per-flop latencies to a small positive floor.
+
+        The floor is MIN_LATENCY_ADD_FRACTION times the estimated ADD latency, so a noisy
+        run can never produce zero, negative, or otherwise invalid weights downstream
+        (a negative weight reaching a geometric mean would go complex).  If even the ADD
+        estimate is non-positive, the run is garbage anyway; the floor then degrades to
+        the smallest positive float so results remain representable.
+        """
+        floor = cls.MIN_LATENCY_ADD_FRACTION * max(latencies[FlopType.ADD], sys.float_info.min)
+        return {flop_type: max(latency, floor) for flop_type, latency in latencies.items()}
+
     @staticmethod
     def get_flops_benchmarking_suite(size: int) -> dict[FlopsBenchmarkType, FlopsMicroBenchmark]:  # noqa: C901 -- flat registry of per-flop-type jit kernels
         """Returns a benchmark for each FlopsBenchmarkType, of requested array size."""

--- a/tests/benchmarking/flops/test_flops_benchmark_suite.py
+++ b/tests/benchmarking/flops/test_flops_benchmark_suite.py
@@ -1,5 +1,9 @@
+import math
+
+import pytest
+
 from counted_float._core.benchmarking.flops import FlopsBenchmarkSuite, FlopsMicroBenchmark
-from counted_float._core.models import FlopsBenchmarkResults, FlopsBenchmarkType
+from counted_float._core.models import FlopsBenchmarkResults, FlopsBenchmarkType, FlopType, FlopWeights
 
 
 def test_flops_benchmarking_suite_get():
@@ -29,3 +33,59 @@ def test_flops_benchmarking_suite_run():
 
     # --- assert ------------------------------------------
     assert isinstance(result, FlopsBenchmarkResults)
+
+
+# =================================================================================================
+#  floor_latencies
+# =================================================================================================
+def _latencies(overrides: dict[FlopType, float]) -> dict[FlopType, float]:
+    """Build a full latency dict with plausible defaults, then apply overrides."""
+    latencies = dict.fromkeys(FlopType, 5.0)
+    latencies.update(overrides)
+    return latencies
+
+
+def test_floor_latencies_leaves_genuine_values_untouched():
+    # --- arrange -----------------------------------------
+    latencies = _latencies({FlopType.ABS: 2.0, FlopType.POW: 150.0})
+
+    # --- act ---------------------------------------------
+    floored = FlopsBenchmarkSuite.floor_latencies(latencies)
+
+    # --- assert ------------------------------------------
+    assert floored == latencies
+
+
+@pytest.mark.parametrize("bad_value", [0.0, -0.3, -100.0])
+def test_floor_latencies_clamps_non_positive_values(bad_value: float):
+    # --- arrange -----------------------------------------
+    latencies = _latencies({FlopType.ABS: bad_value})
+
+    # --- act ---------------------------------------------
+    floored = FlopsBenchmarkSuite.floor_latencies(latencies)
+
+    # --- assert ------------------------------------------
+    assert floored[FlopType.ABS] == FlopsBenchmarkSuite.MIN_LATENCY_ADD_FRACTION * latencies[FlopType.ADD]
+    assert all(v > 0 for v in floored.values())
+
+
+def test_floor_latencies_survives_non_positive_add():
+    # --- arrange -----------------------------------------
+    latencies = _latencies({FlopType.ADD: -1.0, FlopType.ABS: -2.0})
+
+    # --- act ---------------------------------------------
+    floored = FlopsBenchmarkSuite.floor_latencies(latencies)
+
+    # --- assert ------------------------------------------
+    assert all(v > 0 for v in floored.values())
+
+
+def test_floored_latencies_yield_finite_positive_weights():
+    # --- arrange -----------------------------------------
+    latencies = _latencies({FlopType.ABS: -0.5, FlopType.MINUS: 0.0})
+
+    # --- act ---------------------------------------------
+    weights = FlopWeights.from_abs_flop_costs(FlopsBenchmarkSuite.floor_latencies(latencies))
+
+    # --- assert ------------------------------------------
+    assert all(math.isfinite(w) and w > 0 for w in weights.weights.values())


### PR DESCRIPTION
Differencing noisy per-kernel statistics can yield estimates <= 0 for cheap ops (ABS, MINUS, COMP) on a loaded machine; nothing clamped them, so the public own-hardware-calibration path could produce negative weights — or complex values once a negative weight reached a geometric mean. Estimated latencies are now floored at 0.1x the measured ADD cost (well below any plausible genuine latency), mirroring the floor the spec-sheet path already applies via `Latency.consensus()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)