### PR TITLE
fix: give the CLI a clear error message when the cli extra is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- the `counted_float` CLI now exits with a clear "install counted-float[cli]" message instead of a raw traceback when the optional `cli` extra is missing
 - the FLOPs benchmark now interleaves kernel execution and uses a low-quantile estimator, making measured weights robust to transient CPU contention and thermal drift (built-in M3 Max data re-measured accordingly)
 - benchmark-derived flop weights are now floored to a small positive value, so a noisy run can no longer produce negative or invalid weights
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Flop weights are computed using a highly curated dataset spanning a wide range o
 Use your favorite package manager such as `uv` or `pip`:
 
 ```
-pip install counted-float           # install without numba optional dependency
+pip install counted-float           # install without optional dependencies
 pip install counted-float[numba]    # install with numba optional dependency
+pip install counted-float[cli]      # install with CLI support (click)
 ```
 
 Numba is optional due to its relatively large size (40-50MB, including llvmlite), but without it, benchmarks will

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,9 @@ classifiers = [
 ]
 
 [project.scripts]
-counted_float = "counted_float._core._cli:cli"
+# the guard module (not the click CLI directly): base installs without the `cli` extra
+# get an actionable message instead of a raw ModuleNotFoundError for `click`
+counted_float = "counted_float._core._cli_main:main"
 
 [project.urls]
 Source = "https://github.com/bertpl/counted-float"

--- a/src/counted_float/_core/_cli_main.py
+++ b/src/counted_float/_core/_cli_main.py
@@ -1,0 +1,21 @@
+"""Console-script entry point with a guard for the optional ``cli`` extra.
+
+The ``counted_float`` script is installed unconditionally, but the CLI itself
+needs ``click``, which only comes with the ``cli`` extra — so the click-based
+module is imported lazily and a missing ``click`` yields an actionable message
+instead of a raw traceback.
+"""
+
+import sys
+
+
+def main() -> None:
+    """Run the click-based CLI, or exit with install guidance when click is missing."""
+    try:
+        from counted_float._core._cli import cli
+    except ModuleNotFoundError as e:
+        if e.name == "click":
+            sys.stderr.write('The counted_float CLI requires the "cli" extra: pip install "counted-float[cli]"\n')
+            raise SystemExit(1) from None
+        raise
+    cli()

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -1,0 +1,39 @@
+import builtins
+
+import pytest
+
+from counted_float._core import _cli_main
+
+
+def test_main_runs_cli_when_click_available(monkeypatch):
+    # --- arrange -----------------------------------------
+    called = []
+    from counted_float._core import _cli
+
+    monkeypatch.setattr(_cli, "cli", lambda: called.append(True))
+
+    # --- act ---------------------------------------------
+    _cli_main.main()
+
+    # --- assert ------------------------------------------
+    assert called == [True]
+
+
+def test_main_exits_with_guidance_when_click_missing(monkeypatch, capsys):
+    # --- arrange -----------------------------------------
+    # simulate a base install: importing the click-based CLI module raises for `click`
+    monkeypatch.delitem(__import__("sys").modules, "counted_float._core._cli", raising=False)
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "click":
+            raise ModuleNotFoundError("No module named 'click'", name="click")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    # --- act & assert ------------------------------------
+    with pytest.raises(SystemExit) as exc_info:
+        _cli_main.main()
+    assert exc_info.value.code == 1
+    assert 'pip install "counted-float[cli]"' in capsys.readouterr().err


### PR DESCRIPTION
The `counted_float` console script is installed unconditionally, but `click` lives only in the optional `cli` extra — a plain `pip install counted-float` got a raw `ModuleNotFoundError` traceback when invoking a documented feature. The entry point now goes through a small guard module that imports the click-based CLI lazily and, when click is absent, exits with: install `counted-float[cli]`. README install section now mentions the `cli` extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)