### PR TITLE
fix: complete constant folding for pow and log, plus engineering hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `**` with a constant exponent now strength-reduces beyond the square: `x**0.5` counts SQRT, `x**-1` counts DIV, small int exponents count their multiply chain (e.g. `x**3` -> 2 MUL) instead of a full POW
 - built-in consensus flop weights are now loaded lazily on first use, cutting `import counted_float` time roughly 3x
 
 ### Deprecated
@@ -19,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `math.log(x, base)` with a plain-float base now counts LOG+MUL like an int base (the base is a precomputable constant), instead of charging a runtime DIV
+- `counted_float.__version__` is now available, as Python packaging convention expects
 - the `counted_float` CLI now exits with a clear "install counted-float[cli]" message instead of a raw traceback when the optional `cli` extra is missing
 - the FLOPs benchmark now interleaves kernel execution and uses a low-quantile estimator, making measured weights robust to transient CPU contention and thermal drift (built-in M3 Max data re-measured accordingly)
 - benchmark-derived flop weights are now floored to a small positive value, so a noisy run can no longer produce negative or invalid weights

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -49,18 +49,40 @@ compiled port would fold at compile time or precompute. This is why e.g.
 `math.sqrt(3)` counts nothing: the port ships `sqrt(3)` as a precomputed
 constant.
 
-The library detects constants through two mechanisms, applying the same rule:
+This gives the counting model one unified principle:
 
-- **Unwrapped values** (plain floats): constants by the wrapping contract, as
-  above.
-- **`int` operands**: evidence of a *hardcoded* constant — ints don't fall out
-  of floating-point computations, so an int operand almost certainly appears
-  literally in your source. As a constant it is folded to a float literal by a
-  compiled port, so an `int` operand adds **no `I2F` conversion**; it merely
-  enables the strength reductions such a port would apply: `x**2` counts MUL
-  (i.e. `x*x`), `2**x` counts EXP2, `math.log(x, 10)` counts LOG10 — while
-  `x**2.0`, with a float that *could* be a runtime value, conservatively counts
-  a generic POW.
+> **Only `CountedFloat` values are runtime data. Any non-`CountedFloat`
+> numeric operand — int, bool, or plain float — is an algorithm constant that
+> a compiled port would fold at compile time.**
+
+Two consequences follow, both applied consistently across operators and
+patched `math` functions:
+
+1. **Constants never add cost of their own.** No `I2F` conversion for an int
+   operand, no runtime preparation for a float one — the operation *on the
+   runtime value* still counts (`cf + 2.0` counts one ADD), but the constant
+   contributes nothing extra.
+2. **Known constant *values* enable strength reduction.** Constants fold by
+   value (an int and an equal-valued plain float compile identically), and
+   where the folded value lets a compiled port emit something cheaper than the
+   generic operation, the cheaper form is counted:
+
+   | Expression (constant `c`) | Counts |
+   |---|---|
+   | `x ** 2` (or `2.0`) | MUL |
+   | `x ** n`, integer 2 ≤ \|n\| ≤ 16 | square-and-multiply MULs (`x**3` → 2 MUL, `x**8` → 3 MUL); negative `n` adds one DIV |
+   | `x ** -1` | DIV (reciprocal) |
+   | `x ** 0.5` / `x ** -0.5` | SQRT / SQRT + DIV |
+   | `x ** 0`, `x ** 1` | nothing (folds away; result stays `CountedFloat`) |
+   | `x ** c`, other values | POW |
+   | `2 ** x` / `10 ** x` | EXP2 / EXP10 (POW for other constant bases) |
+   | `math.log(x, 2)` / `math.log(x, 10)` | LOG2 / LOG10 |
+   | `math.log(x, c)`, other values | LOG + MUL (`1/log(c)` folds to a constant multiplier) |
+
+   Beyond \|n\| = 16 real compilers' powi expansion varies, so a generic POW
+   is a fair stand-in. When the exponent, base, or log base is itself a
+   `CountedFloat`, it is genuinely runtime: no folding applies (`x ** y`
+   counts POW; `math.log(x, y)` counts LOG per counted operand + DIV).
 
 The one place an `I2F` conversion *is* counted is explicit construction from an
 int — `CountedFloat(n)`. That is exactly how you opt a genuine runtime integer

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -26,7 +26,7 @@ find:
 | `round(x, n)` | `RND` | operator | ISA | yes (float) |
 | `round(x)`, `int(x)`, `math.floor`/`ceil`/`trunc` | `F2I` | operator | ISA | returns `int` |
 | `CountedFloat(int)` | `I2F` | constructor | ISA | yes |
-| `x ** y`, `math.pow(x, y)` | `POW` (or `MUL`/`EXP2`/`EXP10` via strength reduction) | operator / patch | benchmarked | yes |
+| `x ** y`, `math.pow(x, y)` | `POW` (or cheaper via constant strength reduction — MULs, SQRT, DIV, EXP2, EXP10) | operator / patch | benchmarked | yes |
 | `math.sqrt(x)` | `SQRT` | patch | ISA | yes |
 | `math.cbrt(x)` | `CBRT` | patch | benchmarked | yes |
 | `math.exp(x)`, `math.exp2(x)`, `2 ** x` | `EXP`, `EXP2` | patch / operator | benchmarked | yes |
@@ -203,9 +203,9 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
     - **ARM:** (software)
     - **x86:** (software)
 - **Counted Python operations:** `math.log(x)` for `CountedFloat`;
-  `math.log(x, base)` for `CountedFloat` decomposes per the constant-detection
-  heuristic (int base 2/10 -> LOG2/LOG10; other int base -> LOG+MUL; float
-  base -> LOG per counted operand + DIV)
+  `math.log(x, base)` for `CountedFloat` decomposes per the constant-folding
+  convention (constant base 2/10 -> LOG2/LOG10; other constant base ->
+  LOG+MUL; CountedFloat base -> LOG per counted operand + DIV)
 - **Not counted:** `numpy.log`, log on non-CountedFloat
 
 ## FlopType.LOG2 (`log2(x)`)
@@ -231,7 +231,10 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
 - Relevant CPU instructions
     - **ARM:** (software)
     - **x86:** (software)
-- **Counted Python operations:** `x ** y`, `pow(x, y)` for `CountedFloat`
+- **Counted Python operations:** `x ** y`, `pow(x, y)` for `CountedFloat`; constant
+  exponents/bases strength-reduce per the constant-folding convention (see the
+  counting-model page): `x**0.5` -> SQRT, `x**-1` -> DIV, integer exponents
+  2 <= |n| <= 16 -> their multiply chain, base 2/10 -> EXP2/EXP10
 - **Not counted:** `pow` on non-CountedFloat, `numpy.pow`
 
 ## FlopType.SIN (`sin(x)`)

--- a/src/counted_float/__init__.py
+++ b/src/counted_float/__init__.py
@@ -1,7 +1,14 @@
 """Top-level public API for flop counting: CountedFloat, FlopCountingContext, and related models."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 import counted_float.benchmarking as benchmarking
 import counted_float.config as config
+
+try:
+    __version__ = version("counted-float")
+except PackageNotFoundError:  # source tree without installed package metadata
+    __version__ = "0.0.0"
 
 from ._core.counting import BuiltInData, CountedFloat, FlopCountingContext, PauseFlopCounting
 from ._core.models import FlopCounts, FlopType, FlopWeights, Quantiles, SystemInfo
@@ -15,6 +22,7 @@ __all__ = [
     "PauseFlopCounting",
     "Quantiles",
     "SystemInfo",
+    "__version__",
     "benchmarking",
     "config",
 ]

--- a/src/counted_float/_core/benchmarking/micro/_micro_benchmark.py
+++ b/src/counted_float/_core/benchmarking/micro/_micro_benchmark.py
@@ -61,7 +61,8 @@ class MicroBenchmark(ABC):
             # --- run benchmark_runs ---
             with Timer() as t:
                 single_run_result = self.run_once(n_executions)
-            t_tot_seconds = t.t_elapsed_sec()  # total time (sec) of prepare + run
+            # floored: an immeasurably fast run must not divide the rescale below by zero
+            t_tot_seconds = max(t.t_elapsed_sec(), 1e-9)  # total time (sec) of prepare + run
 
             # --- capture result ---
             if i < n_runs_warmup:

--- a/src/counted_float/_core/compatibility/_numba.py
+++ b/src/counted_float/_core/compatibility/_numba.py
@@ -3,8 +3,10 @@ from collections.abc import Callable
 try:
     import numba  # ty: ignore[unresolved-import] -- numba is an optional dependency; shimmed below if absent
 
-
+    NUMBA_AVAILABLE = True
 except ImportError:
+    NUMBA_AVAILABLE = False
+
     # dummy decorator that will replace numba.jit and numba.njit
     def dummy_decorator(*args: object, **kwargs: object) -> Callable:
         # dummy decorator that does nothing and can be used with or without arguments
@@ -28,4 +30,4 @@ except ImportError:
 
 
 def is_numba_installed() -> bool:
-    return numba.__version__ != "0.0.0"
+    return NUMBA_AVAILABLE

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -5,6 +5,57 @@ from typing import SupportsIndex
 from ._global_counter import GLOBAL_COUNTER
 
 
+def count_pow_with_constant_exponent(exponent: float) -> None:
+    """Register the flops a compiled port would execute for ``x ** exponent`` with a constant exponent.
+
+    Constants are folded by value (an int and an equal-valued plain float compile identically):
+      - 0, 1                     -> nothing (the expression folds away entirely)
+      - 0.5 / -0.5               -> SQRT / SQRT + DIV
+      - -1                       -> DIV (reciprocal)
+      - integer 2 <= |n| <= 16   -> square-and-multiply MULs (x**3 -> 2 MUL, x**8 -> 3 MUL, ...),
+                                    plus one DIV when negative; the |n| <= 16 cutoff keeps the
+                                    model honest — beyond it real compilers' powi expansion
+                                    varies and a generic POW is a fair stand-in
+      - anything else            -> POW
+    """
+    value = float(exponent)
+    if value in (0.0, 1.0):
+        return
+    if value == 0.5:
+        GLOBAL_COUNTER.incr_sqrt()
+        return
+    if value == -0.5:
+        GLOBAL_COUNTER.incr_sqrt()
+        GLOBAL_COUNTER.incr_div()
+        return
+    if value == -1.0:
+        GLOBAL_COUNTER.incr_div()
+        return
+    if value.is_integer() and 2 <= abs(value) <= 16:
+        n = abs(int(value))
+        n_muls = (n.bit_length() - 1) + bin(n).count("1") - 1  # square-and-multiply cost
+        for _ in range(n_muls):
+            GLOBAL_COUNTER.incr_mul()
+        if value < 0:
+            GLOBAL_COUNTER.incr_div()
+        return
+    GLOBAL_COUNTER.incr_pow()
+
+
+def count_pow_with_constant_base(base: float) -> None:
+    """Register the flops a compiled port would execute for ``base ** x`` with a constant base.
+
+    Constants are folded by value: base 2 -> EXP2, base 10 -> EXP10, anything else -> POW.
+    """
+    value = float(base)
+    if value == 2.0:
+        GLOBAL_COUNTER.incr_exp2()
+    elif value == 10.0:
+        GLOBAL_COUNTER.incr_exp10()
+    else:
+        GLOBAL_COUNTER.incr_pow()
+
+
 class CountedFloat(float):
     # -------------------------------------------------------------------------
     #  CONSTRUCTOR
@@ -271,10 +322,10 @@ class CountedFloat(float):
     def __pow__(self, other: float) -> CountedFloat:  # ty: ignore[invalid-method-override] -- no `mod` param; float.__pow__'s mod is None-only and unused here
         """x**other.
 
-        A hardcoded (`int`) exponent enables the strength reduction a compiled port would apply:
-        `x**2` counts as MUL (i.e. `x*x`). A float exponent such as `x**2.0` may be a runtime
-        variable, where a port compiles a generic pow, so it counts as POW. Per the counting
-        model, `int` operands are compile-time constants and never add an I2F conversion.
+        A constant (non-CountedFloat) exponent enables the strength reduction a compiled port
+        would apply — see count_pow_with_constant_exponent for the value-based rules (`x**2` ->
+        MUL, `x**0.5` -> SQRT, `x**-1` -> DIV, small int exponents -> their multiply chain).
+        Per the counting model, constant operands never add an I2F conversion.
 
         A negative base with a fractional exponent yields a complex result (as for plain float);
         complex values fall outside the counting model, so nothing is counted and the result is
@@ -285,19 +336,19 @@ class CountedFloat(float):
             return NotImplemented
         if not isinstance(result, float):
             return result
-        if isinstance(other, int) and other == 2:
-            GLOBAL_COUNTER.incr_mul()  # x^2 = x*x
+        if isinstance(other, CountedFloat):
+            GLOBAL_COUNTER.incr_pow()  # genuinely runtime exponent
         else:
-            GLOBAL_COUNTER.incr_pow()
+            count_pow_with_constant_exponent(other)
         return CountedFloat(result)
 
     def __rpow__(self, other: float) -> CountedFloat:  # ty: ignore[invalid-method-override] -- no `mod` param; float.__rpow__'s mod is None-only and unused here
         """other**x.
 
-        Strength reduction on the base, as in __pow__: a hardcoded (`int`) base 2 or 10 counts
-        as EXP2 / EXP10 (what a compiled port would emit); any other base counts a generic POW,
-        and a float base may be a runtime variable, so it counts POW too. Per the counting model,
-        `int` operands are compile-time constants and never add an I2F conversion.
+        Strength reduction on the base, as in __pow__: a constant (non-CountedFloat) base 2 or
+        10 counts as EXP2 / EXP10 (what a compiled port would emit, folding constants by value);
+        any other base counts a generic POW. Per the counting model, constant operands never add
+        an I2F conversion.
 
         A negative base with a fractional exponent yields a complex result (as for plain float);
         complex values fall outside the counting model, so nothing is counted and the result is
@@ -308,10 +359,8 @@ class CountedFloat(float):
             return NotImplemented
         if not isinstance(result, float):
             return result
-        if isinstance(other, int) and other == 2:
-            GLOBAL_COUNTER.incr_exp2()
-        elif isinstance(other, int) and other == 10:
-            GLOBAL_COUNTER.incr_exp10()
+        if isinstance(other, CountedFloat):
+            GLOBAL_COUNTER.incr_pow()  # genuinely runtime base
         else:
-            GLOBAL_COUNTER.incr_pow()
+            count_pow_with_constant_base(other)
         return CountedFloat(result)

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import math
 
-from ._counted_float import CountedFloat
+from ._counted_float import CountedFloat, count_pow_with_constant_base, count_pow_with_constant_exponent
 from ._global_counter import GLOBAL_COUNTER
 
 # -------------------------------------------------------------------------
@@ -85,13 +85,15 @@ def math_log(  # noqa: C901 -- branches mirror the per-log-variant counting rule
 ) -> float | CountedFloat:
     """Patch math.log: stdlib contract (optional base), with flop classification per log variant.
 
-    Flop classification for the base treats a hardcoded (`int`) base as a compile-time constant
-    (as everywhere in the counting model), mirroring CountedFloat.__pow__ / __rpow__:
-      - base omitted      -> LOG
-      - base int 2 / 10   -> LOG2 / LOG10 (a compiled port calls log2/log10 directly)
-      - base other int    -> LOG + MUL (a port computes log(x) * C, with C = 1/log(base) folded
-                             at compile time)
-      - base float        -> a port computes log(x)/log(base): LOG per CountedFloat operand + DIV
+    Flop classification for the base treats any constant (non-CountedFloat) base as a
+    compile-time constant, folded by value (as everywhere in the counting model), mirroring
+    CountedFloat.__pow__ / __rpow__:
+      - base omitted           -> LOG
+      - constant base 2 / 10   -> LOG2 / LOG10 (a compiled port calls log2/log10 directly)
+      - other constant base    -> LOG + MUL (a port computes log(x) * C, with C = 1/log(base)
+                                  folded at compile time)
+      - CountedFloat base      -> genuinely runtime: a port computes log(x)/log(base), so
+                                  LOG per CountedFloat operand + DIV
     As everywhere in the counting model, only operations touching CountedFloat values are counted:
     any runtime input to the counted algorithm should itself be a CountedFloat; whatever remains a
     plain float is by definition not part of the core algorithm and/or precomputable.
@@ -103,23 +105,21 @@ def math_log(  # noqa: C901 -- branches mirror the per-log-variant counting rule
         return original_math_log(x)
     # computed first: raises per stdlib contract before anything is counted
     result = original_math_log(x, base)
-    if isinstance(base, int) and base == 2:
-        if isinstance(x, CountedFloat):
-            GLOBAL_COUNTER.incr_log2()
-    elif isinstance(base, int) and base == 10:
-        if isinstance(x, CountedFloat):
-            GLOBAL_COUNTER.incr_log10()
-    elif isinstance(base, int):
+    if isinstance(base, CountedFloat):
         if isinstance(x, CountedFloat):
             GLOBAL_COUNTER.incr_log()
-            GLOBAL_COUNTER.incr_mul()
+        GLOBAL_COUNTER.incr_log()
+        GLOBAL_COUNTER.incr_div()
+    elif float(base) == 2.0:
+        if isinstance(x, CountedFloat):
+            GLOBAL_COUNTER.incr_log2()
+    elif float(base) == 10.0:
+        if isinstance(x, CountedFloat):
+            GLOBAL_COUNTER.incr_log10()
     else:
         if isinstance(x, CountedFloat):
             GLOBAL_COUNTER.incr_log()
-        if isinstance(base, CountedFloat):
-            GLOBAL_COUNTER.incr_log()
-        if isinstance(x, CountedFloat) or isinstance(base, CountedFloat):
-            GLOBAL_COUNTER.incr_div()
+            GLOBAL_COUNTER.incr_mul()
     if isinstance(x, CountedFloat) or isinstance(base, CountedFloat):
         return CountedFloat(result)
     return result
@@ -164,18 +164,12 @@ def math_pow(x: float, y: float) -> float | CountedFloat:
         # computed first: math.pow raises ValueError on domain errors (e.g. negative base with
         # fractional exponent) and then nothing should be counted
         result = original_math_pow(x, y)
-        if isinstance(x, CountedFloat):
-            if isinstance(y, int) and y == 2:
-                GLOBAL_COUNTER.incr_mul()  # x^2 = x*x
-            else:
-                GLOBAL_COUNTER.incr_pow()
+        if isinstance(x, CountedFloat) and isinstance(y, CountedFloat):
+            GLOBAL_COUNTER.incr_pow()  # genuinely runtime base and exponent
+        elif isinstance(x, CountedFloat):
+            count_pow_with_constant_exponent(y)
         else:
-            if isinstance(x, int) and x == 2:
-                GLOBAL_COUNTER.incr_exp2()
-            elif isinstance(x, int) and x == 10:
-                GLOBAL_COUNTER.incr_exp10()
-            else:
-                GLOBAL_COUNTER.incr_pow()
+            count_pow_with_constant_base(x)
         return CountedFloat(result)
     return original_math_pow(x, y)
 

--- a/src/counted_float/_core/utils/_geo_mean.py
+++ b/src/counted_float/_core/utils/_geo_mean.py
@@ -2,10 +2,17 @@ import math
 
 
 def geo_mean(values: list[float | int]) -> float:
-    """Take geometric mean of list of values, returning 0.0 for an empty list.
+    """Take the geometric mean of a list of values, computed in log-space.
 
-    nan values propagate (nan in -> nan out).
+    Log-space summation avoids the overflow the naive product-then-root form hits for
+    large corpora or large raw costs.  nan values propagate (nan in -> nan out), a zero
+    yields 0.0, negative values and an empty list are rejected: both would silently
+    poison downstream aggregates (a negative product can turn a fractional root complex).
     """
     if len(values) == 0:
+        raise ValueError("geo_mean of an empty list is undefined")
+    if any(v < 0 for v in values):
+        raise ValueError("geo_mean requires non-negative values")
+    if any(v == 0 for v in values):
         return 0.0
-    return pow(math.prod(values), 1 / len(values))
+    return math.exp(math.fsum(math.log(v) for v in values) / len(values))

--- a/tests/counting/test_counted_float.py
+++ b/tests/counting/test_counted_float.py
@@ -836,15 +836,15 @@ def test_counted_float_counts_pow_1(global_counter):
     _ = 10**cf  # EXP10
     _ = cf**2  # MUL
     _ = i**cf  # POW
-    _ = cf**i  # POW
+    _ = cf**i  # 4 x MUL (i == 9: square-and-multiply)
 
     # --- assert ------------------------------------------
-    assert global_counter.total_count() == 14
-    assert global_counter.POW == 9
+    assert global_counter.total_count() == 17
+    assert global_counter.POW == 8
     assert global_counter.EXP == 1
     assert global_counter.EXP2 == 2
     assert global_counter.EXP10 == 1
-    assert global_counter.MUL == 1
+    assert global_counter.MUL == 5
     assert global_counter.I2F == 0
 
 
@@ -864,14 +864,14 @@ def test_counted_float_counts_pow_2(global_counter):
     _ = math.pow(10, cf)  # EXP10
     _ = math.pow(cf, 2)  # MUL
     _ = math.pow(i, cf)  # POW
-    _ = math.pow(cf, i)  # POW
+    _ = math.pow(cf, i)  # 4 x MUL (i == 9: square-and-multiply)
 
     # --- assert ------------------------------------------
-    assert global_counter.total_count() == 12
-    assert global_counter.POW == 9
+    assert global_counter.total_count() == 15
+    assert global_counter.POW == 8
     assert global_counter.EXP2 == 1
     assert global_counter.EXP10 == 1
-    assert global_counter.MUL == 1
+    assert global_counter.MUL == 5
     assert global_counter.I2F == 0
 
 
@@ -1033,3 +1033,88 @@ def test_counted_float_mod_floordiv_divmod_zero_division_counts_nothing(global_c
     with pytest.raises(ZeroDivisionError):
         op(17.0, cf_zero)  # reflected path: 17.0 // cf_zero
     assert global_counter.total_count() == 0
+
+
+@pytest.mark.parametrize(
+    ("exponent", "expected_counts"),
+    [
+        (0, {}),  # folds away entirely
+        (1, {}),
+        (2, {"MUL": 1}),
+        (2.0, {"MUL": 1}),  # constants fold by value: 2.0 compiles like 2
+        (3, {"MUL": 2}),  # x*x, *x
+        (4, {"MUL": 2}),  # square twice
+        (8, {"MUL": 3}),
+        (9, {"MUL": 4}),
+        (16, {"MUL": 4}),
+        (-1, {"DIV": 1}),  # reciprocal
+        (-3, {"MUL": 2, "DIV": 1}),
+        (0.5, {"SQRT": 1}),
+        (-0.5, {"SQRT": 1, "DIV": 1}),
+        (17, {"POW": 1}),  # beyond the powi cutoff
+        (-17, {"POW": 1}),
+        (2.5, {"POW": 1}),  # non-integral, non-special value
+        (math.nan, {"POW": 1}),
+    ],
+)
+def test_counted_float_pow_constant_exponent_strength_reduction(global_counter, exponent, expected_counts):
+    """A constant exponent counts what a compiled port would emit, folded by value."""
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(1.23456)
+
+    # --- act ---------------------------------------------
+    result = cf**exponent
+
+    # --- assert ------------------------------------------
+    assert isinstance(result, CountedFloat)
+    assert global_counter.total_count() == sum(expected_counts.values())
+    for flop_name, count in expected_counts.items():
+        assert getattr(global_counter, flop_name) == count
+
+
+def test_counted_float_pow_strength_reduction_mirrored_in_math_pow(global_counter):
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(1.23456)
+
+    # --- act ---------------------------------------------
+    _ = math.pow(cf, 0.5)  # SQRT
+    _ = math.pow(cf, -1)  # DIV
+    _ = math.pow(cf, 3)  # 2 x MUL
+    _ = math.pow(2.0, cf)  # EXP2 (constant base folds by value)
+    _ = math.pow(10.0, cf)  # EXP10
+
+    # --- assert ------------------------------------------
+    assert global_counter.total_count() == 6
+    assert global_counter.SQRT == 1
+    assert global_counter.DIV == 1
+    assert global_counter.MUL == 2
+    assert global_counter.EXP2 == 1
+    assert global_counter.EXP10 == 1
+
+
+def test_counted_float_rpow_constant_float_base_folds_by_value(global_counter):
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(1.23456)
+
+    # --- act ---------------------------------------------
+    _ = 2.0**cf  # EXP2
+    _ = 10.0**cf  # EXP10
+    _ = 3.0**cf  # POW
+
+    # --- assert ------------------------------------------
+    assert global_counter.total_count() == 3
+    assert global_counter.EXP2 == 1
+    assert global_counter.EXP10 == 1
+    assert global_counter.POW == 1
+
+
+def test_counted_float_pow_runtime_counted_exponent_counts_pow(global_counter):
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(1.23456)
+
+    # --- act ---------------------------------------------
+    _ = cf ** CountedFloat(2.0)  # a CountedFloat exponent is genuinely runtime: no folding
+
+    # --- assert ------------------------------------------
+    assert global_counter.total_count() == 1
+    assert global_counter.POW == 1

--- a/tests/counting/test_math_patching.py
+++ b/tests/counting/test_math_patching.py
@@ -172,21 +172,40 @@ def test_math_log_other_int_base_counts_log_mul(global_counter):
     assert isinstance(result, CountedFloat)
 
 
-def test_math_log_float_base_counts_per_counted_operand(global_counter):
-    # a runtime (float) base means a compiled port computes log(x)/log(base)
+def test_math_log_constant_float_base_folds_like_int(global_counter):
+    # constants fold by value: a plain-float base is as precomputable as an int one, so a
+    # compiled port emits log(x) * (1/log(base)) — LOG + MUL, not a runtime DIV
     # --- arrange -----------------------------------------
     cf = CountedFloat(8.0)
 
     # --- act & assert ------------------------------------
-    # counted x, plain base: LOG + DIV (log of the untracked base is precomputable)
-    result = math.log(cf, 2.0)
+    result = math.log(cf, 3.0)
     assert global_counter.total_count() == 2
     assert global_counter.LOG == 1
-    assert global_counter.DIV == 1
+    assert global_counter.MUL == 1
     assert isinstance(result, CountedFloat)
 
-    # plain x, counted base: LOG + DIV
+    # special constant values fold all the way to the dedicated instruction
     global_counter.reset()
+    result = math.log(cf, 2.0)
+    assert global_counter.total_count() == 1
+    assert global_counter.LOG2 == 1
+    assert isinstance(result, CountedFloat)
+
+    global_counter.reset()
+    result = math.log(cf, 10.0)
+    assert global_counter.total_count() == 1
+    assert global_counter.LOG10 == 1
+    assert isinstance(result, CountedFloat)
+
+
+def test_math_log_counted_base_counts_runtime_division(global_counter):
+    # a CountedFloat base is genuinely runtime: a port computes log(x)/log(base)
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(8.0)
+
+    # --- act & assert ------------------------------------
+    # plain x, counted base: LOG (of the base) + DIV
     result = math.log(16.0, CountedFloat(2.0))
     assert global_counter.total_count() == 2
     assert global_counter.LOG == 1

--- a/tests/counting/test_numeric_protocol.py
+++ b/tests/counting/test_numeric_protocol.py
@@ -91,10 +91,10 @@ def test_pow_with_fraction_stays_counted(global_counter: GlobalFlopCounter):
     # --- assert ------------------------------------------
     # unlike the other operators, Fraction.__rpow__ computes base ** float(exponent) without
     # stripping the subclass, so the operation lands back in CountedFloat.__pow__: the result
-    # stays contagious and is counted
+    # stays contagious and is counted (the 0.5 exponent strength-reduces to SQRT)
     assert result == 1.5 ** Fraction(1, 2)
     assert isinstance(result, CountedFloat)
-    assert global_counter.POW == 1
+    assert global_counter.SQRT == 1
 
 
 @pytest.mark.parametrize("op", COMPARISON_OPERATORS)

--- a/tests/utils/test_geo_mean.py
+++ b/tests/utils/test_geo_mean.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 
 from counted_float._core.utils import geo_mean
@@ -10,8 +12,8 @@ from counted_float._core.utils import geo_mean
         ([1, 1, 1], 1.0),
         ([1, 10, 100], 10.0),
         ([2, 8], 4.0),
-        ([], 0.0),  # edge case: empty list
         ([5], 5.0),  # edge case: single value
+        ([1e200, 1e200, 1e200], 1e200),  # would overflow the naive product-then-root form
     ],
 )
 def test_geo_mean(values: list, expected_result: float):
@@ -19,4 +21,17 @@ def test_geo_mean(values: list, expected_result: float):
     result = geo_mean(values)
 
     # --- assert ------------------------------------------
-    assert result == pytest.approx(expected_result, rel=1e-14, abs=1e-14)
+    assert result == pytest.approx(expected_result, rel=1e-12, abs=1e-12)
+
+
+def test_geo_mean_nan_propagates():
+    # --- act & assert ------------------------------------
+    assert math.isnan(geo_mean([1.0, math.nan, 4.0]))
+
+
+@pytest.mark.parametrize("values", [[], [1.0, -2.0]])
+def test_geo_mean_rejects_degenerate_input(values: list):
+    # empty input and negative values would silently poison downstream aggregates
+    # --- act & assert ------------------------------------
+    with pytest.raises(ValueError, match="geo_mean"):
+        geo_mean(values)


### PR DESCRIPTION
**Counting-model consistency.** The model's convention is that any non-`CountedFloat` operand is an algorithm constant a compiled port folds at compile time — but two spots applied it incompletely:

- `math.log(x, base)` charged a runtime DIV for a plain-float base where an int base folded to LOG+MUL; both now fold (and constant base 2.0/10.0 goes straight to LOG2/LOG10).
- `**` strength reduction stopped at exponent 2: `x**0.5` counted a full POW (~30x ADD) where a port emits SQRT, `x**3` counted POW where powi expansion emits two MULs. Constant exponents/bases now fold by value: 0.5 → SQRT, -1 → DIV, integer exponents 2 ≤ |n| ≤ 16 → their square-and-multiply chain (+DIV when negative), base 2/10 → EXP2/EXP10; beyond that, generic POW. Mirrored across `__pow__`/`__rpow__`/`math.pow`, every rule pinned by exact-count tests, and the docs now state the constant convention as one unified principle on the counting-model page.

**Hardening riders:** `geo_mean` computes in log-space (overflow-safe) and rejects empty/negative input instead of silently poisoning aggregates; `MicroBenchmark.run_many` floors its wall-time divide; `counted_float.__version__` is exported per packaging convention; numba detection uses a boolean set at import instead of comparing against the shim's magic version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)