### PR TITLE
docs: complete coverage documentation of the counting model

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ counts = ctx.flop_counts()   # {FlopType.MUL: 1, FlopType.ADD: 1}
 counts.total_count()         # 2
 ```
 
+## Performance overhead
+
+Using `CountedFloat` instead of plain `float` costs roughly **40–60× per
+operation** (environment-dependent) — the price of Python-level operator
+dispatch and result wrapping. Measure your own machine with
+`counted_float benchmark-counted-float`. Two facts worth knowing:
+
+- the overhead is inherent and `PauseFlopCounting` does **not** reduce it
+  (the instrumented operators still execute; only count registration stops) —
+  the escape hatch for hot uncounted regions is converting back via
+  `float(x)`;
+- overhead never affects *count* accuracy — counts are exact regardless.
+
+This makes `CountedFloat` a tool for research and prototyping code, not
+production hot loops.
+
 ## Documentation
 
 The [documentation site](https://counted-float.readthedocs.io/) covers the rest:

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -176,3 +176,13 @@ with FlopCountingContext() as ctx:
 counts = ctx.flop_counts()   # {FlopType.MUL: 1, FlopType.SUB: 1}
 counts.total_count()         # 2
 ```
+
+## Performance overhead
+
+Counting costs roughly 40–60× per operation vs. plain `float` (see the
+[Benchmarking page](benchmarking.md#performance-impact) for a measured
+example). The overhead is inherent to Python-level instrumentation;
+`PauseFlopCounting` stops count registration but not the instrumented
+dispatch, so hot regions that need raw speed should convert back to plain
+`float`. Counts themselves are always exact — overhead affects wall time,
+never accuracy.

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -302,6 +302,10 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
 - **Counted Python operations:** `math.hypot(x, y, ...)` for `CountedFloat` —
   counted once when *any* coordinate is a `CountedFloat`
 - **Not counted:** `hypot` on plain floats only, `numpy.hypot`
+- **Arity assumption:** `HYPOT` is modeled as a 2D primitive. `math.hypot`
+  accepts any number of coordinates, but an n-D call still counts a single
+  `HYPOT` — under-counting vs. the n·MUL + (n−1)·ADD + SQRT a port would
+  execute. Decompose manually if n-D `hypot` cost matters.
 
 ## FlopType.EXPM1 (`expm1(x)`)
 

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -3,14 +3,25 @@
 - currently any non-Python-built-in math operations are not counted (e.g.
   `numpy`)
 - a few Python built-in math operations remain uncounted — notably
-  `math.copysign`; see the [FLOP types reference](flop_types.md) for the full
-  list of what is and isn't counted
+  `math.copysign`; see the
+  [`math` coverage table](math_patching.md#coverage-of-the-math-module) for
+  the full per-function status and the
+  [FLOP types reference](flop_types.md) for per-operation counting rules
 - mixed operations with non-float numeric types are outside the counting
   model: `CountedFloat` delegates to the other operand exactly like `float`
   does, so e.g. a `fractions.Fraction` operand generally yields a correct but
   plain — and uncounted — `float` result (downstream counting stops), while a
   `decimal.Decimal` operand raises `TypeError` just as with plain `float`.
   Numerical algorithms should use `float`/`CountedFloat` values throughout.
+- counting state is process-global and **not thread-safe or async-safe**:
+  concurrent counted computations interfere with each other's counts (and on
+  free-threaded Python builds concurrent increments can be lost), so run one
+  counted algorithm at a time
+- dict/set membership of `CountedFloat` keys inflates `COMP`: hash-bucket
+  equality checks count as comparisons. This is consistent with the model
+  (those comparisons really execute) but can surprise when a dict is used as
+  bookkeeping rather than algorithm — pause counting or use plain-float keys
+  for bookkeeping structures
 - flop weights should be taken with a grain of salt and should only provide
   relative ballpark estimates w.r.t. computational complexity. Production
   implementations in a compiled language could have vastly differing

--- a/docs/math_patching.md
+++ b/docs/math_patching.md
@@ -44,19 +44,36 @@ The counting replacements only count operations touching `CountedFloat`
 values; on plain floats they delegate straight through with no counting (see
 [the counting model](counting_flops.md#the-counting-model-what-gets-counted-and-why)).
 Two functions carry extra classification logic. As everywhere in the counting
-model, an `int` operand is treated as a compile-time constant — it enables
+model, any constant (non-`CountedFloat`) operand folds by value — it enables
 strength reduction and never adds an I2F conversion:
 
-- `math.pow(x, y)` classifies like `x ** y`: `x**2` counts MUL, `2**x` counts
-  EXP2, `10**x` counts EXP10, other cases count POW.
-- `math.log(x, base)` classifies per log variant: base omitted → LOG; int
-  base 2 / 10 → LOG2 / LOG10 (a compiled port calls `log2`/`log10` directly);
-  other int base → LOG + MUL (a port computes `log(x) * C` with
-  `C = 1/log(base)` folded at compile time); float base → a port computes
-  `log(x)/log(base)`: LOG per counted operand + DIV.
+- `math.pow(x, y)` classifies like `x ** y`: constant exponents/bases
+  strength-reduce (`x**2` → MUL, `x**0.5` → SQRT, `x**-1` → DIV, small int
+  exponents → their multiply chain, base 2/10 → EXP2/EXP10), other cases
+  count POW.
+- `math.log(x, base)` classifies per log variant: base omitted → LOG;
+  constant base 2 / 10 → LOG2 / LOG10 (a compiled port calls `log2`/`log10`
+  directly); other constant base → LOG + MUL (a port computes `log(x) * C`
+  with `C = 1/log(base)` folded at compile time); `CountedFloat` base →
+  genuinely runtime, a port computes `log(x)/log(base)`: LOG per counted
+  operand + DIV.
 
 The full per-operation counting rules are in the
 [FLOP types reference](flop_types.md).
+
+## Coverage of the `math` module
+
+Every commonly used `math` function, and how it participates in counting:
+
+| Coverage | Functions |
+|---|---|
+| **Instrumented** (patched, counts its FlopType) | `sqrt`, `cbrt`, `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `pow`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `hypot`, `fmod`, `fabs` |
+| **Counted via dunder** (no patch needed — do not expect these in the patch list) | `math.floor` / `math.ceil` / `math.trunc` → F2I through `__floor__`/`__ceil__`/`__trunc__`; the builtins `abs()` → ABS and `round()` → RND/F2I likewise count through their dunders |
+| **Not instrumented** (returns a plain, uncounted `float`) | `copysign`, `remainder`, `frexp`, `ldexp`, `modf`, `degrees`, `radians`, `dist`, `fsum`, `prod`, `gamma`, `lgamma`, `erf`, `erfc`, `nextafter`, `ulp` |
+
+The not-instrumented set breaks contagion: the plain-`float` result silently
+stops all downstream counting, so convert back with `CountedFloat(...)` if a
+result of these feeds counted computation.
 
 Which functions are patched is also the boundary of what gets counted — see
 [Known limitations](known_limitations.md).


### PR DESCRIPTION
Docs-only pass closing the documentation gaps flagged in recent code audits:

- **`math` coverage table** on the math-patching page: every commonly used function classified as instrumented / counted-via-dunder / not instrumented, with the limitations page linking to it — near-complete coverage is now decisively documented instead of vaguely referenced.
- **Limitations page**: explicit thread/async-safety note (previously docstring-only) and a note on COMP inflation from dict/set membership of `CountedFloat` keys.
- **HYPOT arity assumption**: documented as a 2D primitive; n-D calls under-count.
- **README "Performance overhead" section**: honest ~40–60× figure, pointer to the self-measurement command, and the two key facts (pausing doesn't reduce overhead; counts stay exact regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)