### PR TITLE
refactor: retire the legacy contiguous-scheme BenchmarkSettings fields

### DIFF
--- a/src/counted_float/_core/models/_flops_benchmark_meta_data.py
+++ b/src/counted_float/_core/models/_flops_benchmark_meta_data.py
@@ -15,24 +15,16 @@ from ._base import MyBaseModel
 #  Benchmark Settings
 # =================================================================================================
 class BenchmarkSettings(MyBaseModel):
-    """Settings the benchmark data was collected with.
+    """Settings the round-robin interleaved benchmark run was collected with.
 
-    Two collection schemes coexist in stored data, and a settings block self-documents
-    which one produced it:
-      - contiguous per-benchmark blocks (legacy): n_runs_total / n_runs_warmup /
-        n_seconds_per_run_target
-      - round-robin interleaved rounds: t_slice_target_ms / n_rounds_measure /
-        n_rounds_warmup / input_pool_size / order_shuffled
-    All scheme fields are optional so results from either scheme (including data
-    collected before this distinction existed) parse unchanged.
+    The fields describing the run shape are optional so a partial or future-scheme
+    settings block still parses. Data collected under the earlier contiguous-block
+    scheme carried `n_runs_total` / `n_runs_warmup` / `n_seconds_per_run_target`
+    instead; those fields have been retired, and since the model ignores unknown keys,
+    such older or externally-saved results still parse (the retired keys are dropped).
     """
 
     array_size: int
-    # legacy contiguous scheme
-    n_runs_total: int | None = None
-    n_runs_warmup: int | None = None
-    n_seconds_per_run_target: float | None = None
-    # interleaved scheme
     t_slice_target_ms: float | None = None
     n_rounds_measure: int | None = None
     n_rounds_warmup: int | None = None

--- a/src/counted_float/data/arm/v8_x/benchmarks/apple_m1_github_actions.json
+++ b/src/counted_float/data/arm/v8_x/benchmarks/apple_m1_github_actions.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/arm/v8_x/benchmarks/apple_m3_max_mbp16.json
+++ b/src/counted_float/data/arm/v8_x/benchmarks/apple_m3_max_mbp16.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/arm/v8_x/benchmarks/apple_m3_mba15.json
+++ b/src/counted_float/data/arm/v8_x/benchmarks/apple_m3_mba15.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/arm/v8_x/benchmarks/aws_graviton_2_neoverse_n1_ec2_m6g_large.json
+++ b/src/counted_float/data/arm/v8_x/benchmarks/aws_graviton_2_neoverse_n1_ec2_m6g_large.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/arm/v8_x/benchmarks/aws_graviton_3_neoverse_v1_ec2_m7g_large.json
+++ b/src/counted_float/data/arm/v8_x/benchmarks/aws_graviton_3_neoverse_v1_ec2_m7g_large.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/arm/v9_0/benchmarks/aws_graviton_4_neoverse_v2_ec2_m8g_large.json
+++ b/src/counted_float/data/arm/v9_0/benchmarks/aws_graviton_4_neoverse_v2_ec2_m8g_large.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/arm/v9_0/benchmarks/azure_cobalt_100_neoverse_n2_github_actions.json
+++ b/src/counted_float/data/arm/v9_0/benchmarks/azure_cobalt_100_neoverse_n2_github_actions.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/arm/v9_2/benchmarks/apple_m4_pro_mbp16.json
+++ b/src/counted_float/data/arm/v9_2/benchmarks/apple_m4_pro_mbp16.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/arm/v9_2/benchmarks/aws_graviton_5_neoverse_v3_ec2_m9g_large.json
+++ b/src/counted_float/data/arm/v9_2/benchmarks/aws_graviton_5_neoverse_v3_ec2_m9g_large.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/x86/amd/2017_zen1/benchmarks/amd_epyc_7571_ec2_m5a_xlarge.json
+++ b/src/counted_float/data/x86/amd/2017_zen1/benchmarks/amd_epyc_7571_ec2_m5a_xlarge.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/x86/amd/2020_zen3/benchmarks/amd_epyc_7r13_ec2_m6a_xlarge.json
+++ b/src/counted_float/data/x86/amd/2020_zen3/benchmarks/amd_epyc_7r13_ec2_m6a_xlarge.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/x86/amd/2022_zen4/benchmarks/amd_epyc_9r14_ec2_m7a_large.json
+++ b/src/counted_float/data/x86/amd/2022_zen4/benchmarks/amd_epyc_9r14_ec2_m7a_large.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/x86/amd/2024_zen5/benchmarks/amd_epyc_9r45_ec2_m8a_large.json
+++ b/src/counted_float/data/x86/amd/2024_zen5/benchmarks/amd_epyc_9r45_ec2_m8a_large.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/benchmarks/intel_i7_8550U_windows.json
+++ b/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/benchmarks/intel_i7_8550U_windows.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/benchmarks/intel_i7_8700B_macos_github_actions.json
+++ b/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/benchmarks/intel_i7_8700B_macos_github_actions.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/benchmarks/intel_xeon_8375c_ice_lake_ec2_m6i_xlarge.json
+++ b/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/benchmarks/intel_xeon_8375c_ice_lake_ec2_m6i_xlarge.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/x86/intel/2021_golden_cove_gen_12/benchmarks/intel_xeon_8488c_sapphire_rapids_ec2_m7i_xlarge.json
+++ b/src/counted_float/data/x86/intel/2021_golden_cove_gen_12/benchmarks/intel_xeon_8488c_sapphire_rapids_ec2_m7i_xlarge.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/x86/intel/2022_raptor_cove_gen_13_14/benchmarks/intel_xeon_8559c_emerald_rapids_ec2_i7i_xlarge.json
+++ b/src/counted_float/data/x86/intel/2022_raptor_cove_gen_13_14/benchmarks/intel_xeon_8559c_emerald_rapids_ec2_i7i_xlarge.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/src/counted_float/data/x86/intel/2023_redwood_cove_ultra_1/benchmarks/intel_xeon_6975p_granite_rapids_ec2_m8i_xlarge.json
+++ b/src/counted_float/data/x86/intel/2023_redwood_cove_ultra_1/benchmarks/intel_xeon_6975p_granite_rapids_ec2_m8i_xlarge.json
@@ -30,9 +30,6 @@
     },
     "benchmark_settings": {
         "array_size": 1000,
-        "n_runs_total": null,
-        "n_runs_warmup": null,
-        "n_seconds_per_run_target": null,
         "t_slice_target_ms": 20.0,
         "n_rounds_measure": 200,
         "n_rounds_warmup": 3,

--- a/tests/models/test_flops_benchmark_meta_data.py
+++ b/tests/models/test_flops_benchmark_meta_data.py
@@ -64,9 +64,10 @@ def test_package_info():
 # =================================================================================================
 #  BenchmarkSettings
 # =================================================================================================
-def test_benchmark_settings_parses_legacy_contiguous_scheme():
+def test_benchmark_settings_still_parses_retired_legacy_fields():
+    # a settings block from the retired contiguous scheme must still parse: the retired
+    # keys are unknown now and silently ignored (model default extra="ignore")
     # --- arrange -----------------------------------------
-    # settings block as embedded in data files collected with the contiguous scheme
     legacy = {"array_size": 1000, "n_runs_total": 40, "n_runs_warmup": 15, "n_seconds_per_run_target": 0.1}
 
     # --- act ---------------------------------------------
@@ -74,9 +75,8 @@ def test_benchmark_settings_parses_legacy_contiguous_scheme():
 
     # --- assert ------------------------------------------
     assert settings.array_size == 1000
-    assert settings.n_runs_total == 40
+    assert not hasattr(settings, "n_runs_total")  # retired field is dropped, not stored
     assert settings.t_slice_target_ms is None
-    assert settings.order_shuffled is None
 
 
 def test_benchmark_settings_round_trips_interleaved_scheme():
@@ -95,4 +95,5 @@ def test_benchmark_settings_round_trips_interleaved_scheme():
 
     # --- assert ------------------------------------------
     assert parsed == settings
-    assert parsed.n_runs_total is None
+    # the serialized form no longer carries the retired legacy keys
+    assert "n_runs_total" not in settings.model_dump_json()


### PR DESCRIPTION
The three contiguous-scheme settings (`n_runs_total`, `n_runs_warmup`, `n_seconds_per_run_target`) were kept optional only as a transition aid while the built-in dataset mixed the old and new benchmark schemes. The dataset refresh completed that migration, so every data file carried them as dead `null` weight and the model carried three dead fields.

This drops them from `BenchmarkSettings` and strips them from all 19 data files. The model's default `extra="ignore"` keeps any older or externally-saved result JSON parseable — the retired keys are simply ignored (covered by a regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)