### PR TITLE
feat: accept --key-filter alongside the --key_filter CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- the `show-data` CLI command accepts `--key-filter` in addition to the original `--key_filter`
+
 ### Changed
 
 ### Deprecated

--- a/src/counted_float/_core/_cli.py
+++ b/src/counted_float/_core/_cli.py
@@ -30,7 +30,13 @@ def benchmark(output: Path | None) -> None:
 
 
 @cli.command(short_help="show all built-in data")
-@click.option("--key_filter", default="", help="Optional key filter for built-in data")
+@click.option(
+    "--key-filter",
+    "--key_filter",
+    "key_filter",
+    default="",
+    help="Optional key filter for built-in data",
+)
 def show_data(key_filter: str) -> None:
     BuiltInData.show(key_filter=key_filter)
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from counted_float import BuiltInData
@@ -11,6 +12,22 @@ from counted_float._core.models import FlopsBenchmarkResults
 def test_show_data():
     runner = CliRunner()
     runner.invoke(show_data)
+
+
+@pytest.mark.parametrize("flag", ["--key-filter", "--key_filter"])
+def test_show_data_key_filter_spellings(flag: str, monkeypatch) -> None:
+    """Both the kebab-case flag and its underscore alias forward the same filter value."""
+
+    # --- arrange ----------------------
+    seen: list[str] = []
+    monkeypatch.setattr(BuiltInData, "show", classmethod(lambda cls, key_filter="": seen.append(key_filter)))
+
+    # --- act --------------------------
+    result = CliRunner().invoke(show_data, [flag, "arm"])
+
+    # --- assert -----------------------
+    assert result.exit_code == 0
+    assert seen == ["arm"]
 
 
 def test_benchmark_counted_float():


### PR DESCRIPTION
The `show-data` filter flag now offers the conventional kebab-case `--key-filter` spelling. The original `--key_filter` stays as a permanent alias, so this is purely additive and nothing breaks.