### PR TITLE
feat: add a verbose switch to the benchmark entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - the `show-data` CLI command accepts `--key-filter` in addition to the original `--key_filter`
+- `run_flops_benchmark()` and `run_counted_float_benchmark()` accept a `verbose` flag to silence progress output
 
 ### Changed
+
+- the FLOPs benchmark's "numba not installed" notice is now a `RuntimeWarning` (filterable and catchable) instead of printed text
 
 ### Deprecated
 

--- a/src/counted_float/_core/benchmarking/__init__.py
+++ b/src/counted_float/_core/benchmarking/__init__.py
@@ -1,3 +1,4 @@
+from ._output import console, output_quiet
 from .counted_float import BenchmarkCountedFloat, BenchmarkFloat, CountedFloatBenchmarkResults
 from .flops import FlopsBenchmarkResults, FlopsBenchmarkSuite
 
@@ -14,16 +15,14 @@ def run_flops_benchmark(
     An optional seed makes input pools and per-round shuffles reproducible. Progress output is
     printed unless verbose is False; a missing-numba RuntimeWarning is emitted regardless.
     """
-    benchmark_results = FlopsBenchmarkSuite().run(
-        t_slice_target_ms=t_slice_target_ms,
-        n_rounds_measure=n_rounds_measure,
-        n_rounds_warmup=n_rounds_warmup,
-        seed=seed,
-        verbose=verbose,
-    )
-
-    if verbose:
-        print()
+    with output_quiet(not verbose):
+        benchmark_results = FlopsBenchmarkSuite().run(
+            t_slice_target_ms=t_slice_target_ms,
+            n_rounds_measure=n_rounds_measure,
+            n_rounds_warmup=n_rounds_warmup,
+            seed=seed,
+        )
+        console.print()
 
     return benchmark_results
 
@@ -33,26 +32,24 @@ def run_counted_float_benchmark(t_target_sec: float = 0.1, verbose: bool = True)
 
     Progress output is printed unless verbose is False.
     """
-    if verbose:
-        print("-" * 120)
-        print("Running CountedFloat benchmark...")
-        print()
+    with output_quiet(not verbose):
+        console.print("-" * 120, soft_wrap=True)
+        console.print("Running CountedFloat benchmark...")
+        console.print()
 
-    result_float = BenchmarkFloat().run_many(
-        n_runs_total=50,
-        n_runs_warmup=15,
-        n_seconds_per_run_target=t_target_sec,
-        verbose=verbose,
-    )
-    result_counted_float = BenchmarkCountedFloat().run_many(
-        n_runs_total=50,
-        n_runs_warmup=15,
-        n_seconds_per_run_target=t_target_sec,
-        verbose=verbose,
-    )
-    if verbose:
-        print("-" * 120)
-        print()
+        result_float = BenchmarkFloat().run_many(
+            n_runs_total=50,
+            n_runs_warmup=15,
+            n_seconds_per_run_target=t_target_sec,
+        )
+        result_counted_float = BenchmarkCountedFloat().run_many(
+            n_runs_total=50,
+            n_runs_warmup=15,
+            n_seconds_per_run_target=t_target_sec,
+        )
+
+        console.print("-" * 120, soft_wrap=True)
+        console.print()
 
     return CountedFloatBenchmarkResults(
         float_time_nsec=result_float.summary_stats_nsecs_per_exec().q50,

--- a/src/counted_float/_core/benchmarking/__init__.py
+++ b/src/counted_float/_core/benchmarking/__init__.py
@@ -7,41 +7,52 @@ def run_flops_benchmark(
     n_rounds_measure: int = 200,
     n_rounds_warmup: int = 3,
     seed: int | None = None,
+    verbose: bool = True,
 ) -> FlopsBenchmarkResults:
     """Run the flops benchmark suite (round-robin interleaved) and return a FlopsBenchmarkResults object.
 
-    An optional seed makes input pools and per-round shuffles reproducible.
+    An optional seed makes input pools and per-round shuffles reproducible. Progress output is
+    printed unless verbose is False; a missing-numba RuntimeWarning is emitted regardless.
     """
     benchmark_results = FlopsBenchmarkSuite().run(
         t_slice_target_ms=t_slice_target_ms,
         n_rounds_measure=n_rounds_measure,
         n_rounds_warmup=n_rounds_warmup,
         seed=seed,
+        verbose=verbose,
     )
 
-    print()
+    if verbose:
+        print()
 
     return benchmark_results
 
 
-def run_counted_float_benchmark(t_target_sec: float = 0.1) -> CountedFloatBenchmarkResults:
-    """Run benchmark to compare performance of float vs CountedFloat."""
-    print("-" * 120)
-    print("Running CountedFloat benchmark...")
-    print()
+def run_counted_float_benchmark(t_target_sec: float = 0.1, verbose: bool = True) -> CountedFloatBenchmarkResults:
+    """Run benchmark to compare performance of float vs CountedFloat.
+
+    Progress output is printed unless verbose is False.
+    """
+    if verbose:
+        print("-" * 120)
+        print("Running CountedFloat benchmark...")
+        print()
 
     result_float = BenchmarkFloat().run_many(
         n_runs_total=50,
         n_runs_warmup=15,
         n_seconds_per_run_target=t_target_sec,
+        verbose=verbose,
     )
     result_counted_float = BenchmarkCountedFloat().run_many(
         n_runs_total=50,
         n_runs_warmup=15,
         n_seconds_per_run_target=t_target_sec,
+        verbose=verbose,
     )
-    print("-" * 120)
-    print()
+    if verbose:
+        print("-" * 120)
+        print()
 
     return CountedFloatBenchmarkResults(
         float_time_nsec=result_float.summary_stats_nsecs_per_exec().q50,

--- a/src/counted_float/_core/benchmarking/_output.py
+++ b/src/counted_float/_core/benchmarking/_output.py
@@ -1,0 +1,34 @@
+"""Centralized console for all benchmark progress output.
+
+A single module-global rich Console funnels every benchmark print, so verbosity is
+governed in exactly one place -- its ``quiet`` flag -- rather than by per-call guards
+scattered across the suite, runner, and entry points. This mirrors the process-global
+model the FLOP counter already uses; thread-safety is a documented non-goal, so a
+shared mutable console is an accepted trade-off.
+
+Markup and highlighting are disabled so the console is a faithful plain-text sink:
+existing output contains literal square brackets that rich markup would otherwise try
+to parse as style tags.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from rich.console import Console
+
+console = Console(markup=False, highlight=False)
+
+
+@contextmanager
+def output_quiet(quiet: bool) -> Iterator[None]:
+    """Set the shared console's quiet flag for the duration of the block, restoring it on exit.
+
+    Args:
+        quiet: When True, silence all console output within the block.
+    """
+    previous = console.quiet
+    console.quiet = quiet
+    try:
+        yield
+    finally:
+        console.quiet = previous

--- a/src/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
+++ b/src/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
@@ -84,7 +84,7 @@ class FlopsBenchmarkSuite:
             n_rounds_measure=n_rounds_measure,
             n_rounds_warmup=n_rounds_warmup,
             seed=seed,
-            show_progress=verbose,
+            verbose=verbose,
         )
         raw_results = runner.run()
 

--- a/src/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
+++ b/src/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
@@ -1,5 +1,6 @@
 import math
 import sys
+import warnings
 from importlib.metadata import version
 
 import numpy as np
@@ -39,6 +40,7 @@ class FlopsBenchmarkSuite:
         n_rounds_measure: int = 200,
         n_rounds_warmup: int = 3,
         seed: int | None = None,
+        verbose: bool = True,
     ) -> FlopsBenchmarkResults:
         """Run entire flops benchmarking suite and return the results as a FlopsBenchmarkResults object.
 
@@ -50,22 +52,29 @@ class FlopsBenchmarkSuite:
         approaches the uncontended latency (q10 rather than the minimum, so a single
         too-low CPU-frequency sample cannot select the worst conversion outlier).
         An optional seed makes input pools and round shuffles reproducible.
-        """
-        # warn if needed
-        if not is_numba_installed():
-            print("========= WARNING =========")
-            print("'numba' was not found; results of this benchmark will be wildly inaccurate & unusable.")
-            print("Install this package with the numba optional dependency: 'pip install counted-float[numba]'")
-            print("========= WARNING =========")
 
-        print()
-        print(f"Running FLOPS benchmarks using counted-float {version('counted-float')} ...")
-        print(
-            f"(Expected duration: "
-            f"~{(n_rounds_measure + n_rounds_warmup) * len(FlopsBenchmarkType) * t_slice_target_ms / 1000:.0f}"
-            f" seconds, plus jit compilation & calibration)"
-        )
-        print()
+        Progress output is printed unless verbose is False; the missing-numba
+        RuntimeWarning is emitted regardless of verbose.
+        """
+        # a missing numba yields unusable results -- always surface it (regardless of
+        # verbose) through the warnings machinery, so callers can filter or escalate it
+        if not is_numba_installed():
+            warnings.warn(
+                "'numba' is not installed; FLOPS benchmark results will be wildly inaccurate "
+                "and unusable. Install the optional dependency with pip install 'counted-float[numba]'.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+        if verbose:
+            print()
+            print(f"Running FLOPS benchmarks using counted-float {version('counted-float')} ...")
+            print(
+                f"(Expected duration: "
+                f"~{(n_rounds_measure + n_rounds_warmup) * len(FlopsBenchmarkType) * t_slice_target_ms / 1000:.0f}"
+                f" seconds, plus jit compilation & calibration)"
+            )
+            print()
 
         # run actual benchmarks (round-robin interleaved)
         benchmarks = self.get_flops_benchmarking_suite(size=array_size)
@@ -75,6 +84,7 @@ class FlopsBenchmarkSuite:
             n_rounds_measure=n_rounds_measure,
             n_rounds_warmup=n_rounds_warmup,
             seed=seed,
+            show_progress=verbose,
         )
         raw_results = runner.run()
 

--- a/src/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
+++ b/src/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
@@ -5,6 +5,7 @@ from importlib.metadata import version
 
 import numpy as np
 
+from counted_float._core.benchmarking._output import console
 from counted_float._core.benchmarking.micro import InterleavedBenchmarkRunner
 from counted_float._core.compatibility import is_numba_installed, numba
 from counted_float._core.models import (
@@ -40,7 +41,6 @@ class FlopsBenchmarkSuite:
         n_rounds_measure: int = 200,
         n_rounds_warmup: int = 3,
         seed: int | None = None,
-        verbose: bool = True,
     ) -> FlopsBenchmarkResults:
         """Run entire flops benchmarking suite and return the results as a FlopsBenchmarkResults object.
 
@@ -53,11 +53,11 @@ class FlopsBenchmarkSuite:
         too-low CPU-frequency sample cannot select the worst conversion outlier).
         An optional seed makes input pools and round shuffles reproducible.
 
-        Progress output is printed unless verbose is False; the missing-numba
-        RuntimeWarning is emitted regardless of verbose.
+        Progress goes to the shared benchmark console (silenced via output_quiet); the
+        missing-numba RuntimeWarning is emitted regardless of console verbosity.
         """
-        # a missing numba yields unusable results -- always surface it (regardless of
-        # verbose) through the warnings machinery, so callers can filter or escalate it
+        # a missing numba yields unusable results -- always surface it (regardless of console
+        # verbosity) through the warnings machinery, so callers can filter or escalate it
         if not is_numba_installed():
             warnings.warn(
                 "'numba' is not installed; FLOPS benchmark results will be wildly inaccurate "
@@ -66,15 +66,14 @@ class FlopsBenchmarkSuite:
                 stacklevel=2,
             )
 
-        if verbose:
-            print()
-            print(f"Running FLOPS benchmarks using counted-float {version('counted-float')} ...")
-            print(
-                f"(Expected duration: "
-                f"~{(n_rounds_measure + n_rounds_warmup) * len(FlopsBenchmarkType) * t_slice_target_ms / 1000:.0f}"
-                f" seconds, plus jit compilation & calibration)"
-            )
-            print()
+        console.print()
+        console.print(f"Running FLOPS benchmarks using counted-float {version('counted-float')} ...")
+        console.print(
+            f"(Expected duration: "
+            f"~{(n_rounds_measure + n_rounds_warmup) * len(FlopsBenchmarkType) * t_slice_target_ms / 1000:.0f}"
+            f" seconds, plus jit compilation & calibration)"
+        )
+        console.print()
 
         # run actual benchmarks (round-robin interleaved)
         benchmarks = self.get_flops_benchmarking_suite(size=array_size)
@@ -84,7 +83,6 @@ class FlopsBenchmarkSuite:
             n_rounds_measure=n_rounds_measure,
             n_rounds_warmup=n_rounds_warmup,
             seed=seed,
-            verbose=verbose,
         )
         raw_results = runner.run()
 

--- a/src/counted_float/_core/benchmarking/micro/_interleaved_runner.py
+++ b/src/counted_float/_core/benchmarking/micro/_interleaved_runner.py
@@ -123,14 +123,14 @@ class InterleavedBenchmarkRunner(Generic[K]):
         n_rounds_measure: int = 200,
         n_rounds_warmup: int = 3,
         seed: int | None = None,
-        show_progress: bool = True,
+        verbose: bool = True,
     ) -> None:
         self.benchmarks = benchmarks
         self.t_slice_target_ms = t_slice_target_ms
         self.n_rounds_measure = n_rounds_measure
         self.n_rounds_warmup = n_rounds_warmup
         self.seed = seed
-        self.show_progress = show_progress
+        self.verbose = verbose
 
     def run(self) -> dict[K, MicroBenchmarkResult]:
         """Run all phases and return one MicroBenchmarkResult per benchmark."""
@@ -184,7 +184,7 @@ class InterleavedBenchmarkRunner(Generic[K]):
 
         # --- report + return -----------------------------
         floored = [str(key) for key, c in controllers.items() if c.execution_floor_active]
-        if floored and self.show_progress:
+        if floored and self.verbose:
             print(f"note: minimum-executions floor was active for: {', '.join(floored)}")
         return {
             key: MicroBenchmarkResult(warmup_runs=warmup_runs[key], benchmark_runs=benchmark_runs[key])
@@ -227,7 +227,7 @@ class InterleavedBenchmarkRunner(Generic[K]):
             MofNCompleteColumn(),
             TimeElapsedColumn(),
             auto_refresh=False,
-            disable=not self.show_progress,
+            disable=not self.verbose,
         )
 
     def _advance(self, progress: Progress, task_id: TaskID, amount: int = 1) -> None:

--- a/src/counted_float/_core/benchmarking/micro/_interleaved_runner.py
+++ b/src/counted_float/_core/benchmarking/micro/_interleaved_runner.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 
 from rich.progress import BarColumn, MofNCompleteColumn, Progress, TaskID, TextColumn, TimeElapsedColumn
 
+from counted_float._core.benchmarking._output import console
 from counted_float._core.models import MicroBenchmarkResult
 from counted_float._core.utils import get_cpu_frequency_mhz_current
 
@@ -123,14 +124,12 @@ class InterleavedBenchmarkRunner(Generic[K]):
         n_rounds_measure: int = 200,
         n_rounds_warmup: int = 3,
         seed: int | None = None,
-        verbose: bool = True,
     ) -> None:
         self.benchmarks = benchmarks
         self.t_slice_target_ms = t_slice_target_ms
         self.n_rounds_measure = n_rounds_measure
         self.n_rounds_warmup = n_rounds_warmup
         self.seed = seed
-        self.verbose = verbose
 
     def run(self) -> dict[K, MicroBenchmarkResult]:
         """Run all phases and return one MicroBenchmarkResult per benchmark."""
@@ -184,8 +183,8 @@ class InterleavedBenchmarkRunner(Generic[K]):
 
         # --- report + return -----------------------------
         floored = [str(key) for key, c in controllers.items() if c.execution_floor_active]
-        if floored and self.verbose:
-            print(f"note: minimum-executions floor was active for: {', '.join(floored)}")
+        if floored:
+            console.print(f"note: minimum-executions floor was active for: {', '.join(floored)}")
         return {
             key: MicroBenchmarkResult(warmup_runs=warmup_runs[key], benchmark_runs=benchmark_runs[key])
             for key in self.benchmarks
@@ -221,13 +220,17 @@ class InterleavedBenchmarkRunner(Generic[K]):
         all terminal I/O happens on our explicit per-item/per-round updates, in the gap
         between timed regions (the same discipline as the rest of the inter-slice path).
         """
+        # render onto the shared benchmark console; when it is quiet (output_quiet), the bar
+        # is disabled and nothing -- not even the stray newline older rich emits on a merely
+        # disabled progress context -- reaches stdout
         return Progress(
             TextColumn("{task.description:<9}"),
             BarColumn(),
             MofNCompleteColumn(),
             TimeElapsedColumn(),
             auto_refresh=False,
-            disable=not self.verbose,
+            disable=console.quiet,
+            console=console,
         )
 
     def _advance(self, progress: Progress, task_id: TaskID, amount: int = 1) -> None:

--- a/src/counted_float/_core/benchmarking/micro/_micro_benchmark.py
+++ b/src/counted_float/_core/benchmarking/micro/_micro_benchmark.py
@@ -1,6 +1,7 @@
 import random
 from abc import ABC, abstractmethod
 
+from counted_float._core.benchmarking._output import console
 from counted_float._core.models import MicroBenchmarkResult, SingleRunResult
 from counted_float._core.utils import (
     Timer,
@@ -37,13 +38,11 @@ class MicroBenchmark(ABC):
         self.single_execution = single_execution
 
     def run_many(
-        self,
-        n_runs_total: int = 20,
-        n_runs_warmup: int = 5,
-        n_seconds_per_run_target: float = 0.5,
-        verbose: bool = True,
+        self, n_runs_total: int = 20, n_runs_warmup: int = 5, n_seconds_per_run_target: float = 0.5
     ) -> MicroBenchmarkResult:
         """Run the MicroBenchmark multiple times and return (q25, q50, q75) quantiles of run times in nanoseconds.
+
+        Per-run progress goes to the shared benchmark console (silenced via output_quiet).
 
         Runs consist of warmup_runs & actual test runs, with the provided parameters.
         :param n_runs_total: (int, default=20) total number of benchmark_runs runs
@@ -54,10 +53,8 @@ class MicroBenchmark(ABC):
                                                  in a stable, representative state
         :param n_seconds_per_run_target: (float, default=0.5) target time (sec) per benchmark_runs run (prepare + run).
                                              n_executions will be iteratively adjusted to achieve this target time.
-        :param verbose: (bool, default=True) print per-run progress; set False to run silently.
         """
-        if verbose:
-            print(f"{self.name.ljust(35)}: ", end="")
+        console.print(f"{self.name.ljust(35)}: ", end="")
 
         # repeat benchmark_runs n_runs_total times
         n_executions = 1  # start with a benchmark_runs of 1 operation and scale up as needed
@@ -73,13 +70,11 @@ class MicroBenchmark(ABC):
             # --- capture result ---
             if i < n_runs_warmup:
                 # warmup run that doesn't count
-                if verbose:
-                    print("w", end="", flush=True)
+                console.print("w", end="")
                 warmup_runs.append(single_run_result)
             else:
                 # benchmark run that does count
-                if verbose:
-                    print(".", end="", flush=True)
+                console.print(".", end="")
                 benchmark_runs.append(single_run_result)
 
             # --- adjust n_ops ---
@@ -98,8 +93,7 @@ class MicroBenchmark(ABC):
         stats_cycles = benchmark_result.summary_stats_cycles_per_exec()
         s_time_duration = f"{format_time_duration(stats_nsecs.q50)} ± {stats_nsecs.format_uncertainty()}"
         s_latency = f"{format_latency(stats_cycles.q50)} ± {stats_cycles.format_uncertainty()}"
-        if verbose:
-            print(f"   [{s_time_duration} | {s_latency} ]  /  {self.single_execution}")
+        console.print(f"   [{s_time_duration} | {s_latency} ]  /  {self.single_execution}")
 
         # return final result
         return benchmark_result

--- a/src/counted_float/_core/benchmarking/micro/_micro_benchmark.py
+++ b/src/counted_float/_core/benchmarking/micro/_micro_benchmark.py
@@ -37,7 +37,11 @@ class MicroBenchmark(ABC):
         self.single_execution = single_execution
 
     def run_many(
-        self, n_runs_total: int = 20, n_runs_warmup: int = 5, n_seconds_per_run_target: float = 0.5
+        self,
+        n_runs_total: int = 20,
+        n_runs_warmup: int = 5,
+        n_seconds_per_run_target: float = 0.5,
+        verbose: bool = True,
     ) -> MicroBenchmarkResult:
         """Run the MicroBenchmark multiple times and return (q25, q50, q75) quantiles of run times in nanoseconds.
 
@@ -50,8 +54,10 @@ class MicroBenchmark(ABC):
                                                  in a stable, representative state
         :param n_seconds_per_run_target: (float, default=0.5) target time (sec) per benchmark_runs run (prepare + run).
                                              n_executions will be iteratively adjusted to achieve this target time.
+        :param verbose: (bool, default=True) print per-run progress; set False to run silently.
         """
-        print(f"{self.name.ljust(35)}: ", end="")
+        if verbose:
+            print(f"{self.name.ljust(35)}: ", end="")
 
         # repeat benchmark_runs n_runs_total times
         n_executions = 1  # start with a benchmark_runs of 1 operation and scale up as needed
@@ -67,11 +73,13 @@ class MicroBenchmark(ABC):
             # --- capture result ---
             if i < n_runs_warmup:
                 # warmup run that doesn't count
-                print("w", end="", flush=True)
+                if verbose:
+                    print("w", end="", flush=True)
                 warmup_runs.append(single_run_result)
             else:
                 # benchmark run that does count
-                print(".", end="", flush=True)
+                if verbose:
+                    print(".", end="", flush=True)
                 benchmark_runs.append(single_run_result)
 
             # --- adjust n_ops ---
@@ -90,7 +98,8 @@ class MicroBenchmark(ABC):
         stats_cycles = benchmark_result.summary_stats_cycles_per_exec()
         s_time_duration = f"{format_time_duration(stats_nsecs.q50)} ± {stats_nsecs.format_uncertainty()}"
         s_latency = f"{format_latency(stats_cycles.q50)} ± {stats_cycles.format_uncertainty()}"
-        print(f"   [{s_time_duration} | {s_latency} ]  /  {self.single_execution}")
+        if verbose:
+            print(f"   [{s_time_duration} | {s_latency} ]  /  {self.single_execution}")
 
         # return final result
         return benchmark_result

--- a/tests/benchmarking/counted_float/test_counted_float_benchmark.py
+++ b/tests/benchmarking/counted_float/test_counted_float_benchmark.py
@@ -5,3 +5,11 @@ def test_run_counted_float_benchmark():
     # Rudimentary test to check the benchmark runs without errors
     result = run_counted_float_benchmark(t_target_sec=0.001)
     result.show()
+
+
+def test_run_counted_float_benchmark_verbose_false_is_silent(capsys):
+    # --- act --------------------------
+    run_counted_float_benchmark(t_target_sec=0.001, verbose=False)
+
+    # --- assert -----------------------
+    assert capsys.readouterr().out == ""

--- a/tests/benchmarking/flops/test_run_flops_benchmark.py
+++ b/tests/benchmarking/flops/test_run_flops_benchmark.py
@@ -1,7 +1,29 @@
+import pytest
+
 from counted_float._core.benchmarking import run_flops_benchmark
+from counted_float._core.benchmarking.flops import _flops_benchmark_suite
 
 
 def test_run_flops_benchmark():
     # simple test to see if no exceptions are raised
     result = run_flops_benchmark(t_slice_target_ms=0.1, n_rounds_measure=5, n_rounds_warmup=1, seed=42)
     result.show()
+
+
+def test_run_flops_benchmark_verbose_false_is_silent(capsys):
+    # --- act --------------------------
+    run_flops_benchmark(t_slice_target_ms=0.1, n_rounds_measure=5, n_rounds_warmup=1, seed=42, verbose=False)
+
+    # --- assert -----------------------
+    assert capsys.readouterr().out == ""
+
+
+def test_run_flops_benchmark_warns_when_numba_missing(monkeypatch):
+    """The missing-numba notice is a RuntimeWarning and fires even with progress silenced."""
+
+    # --- arrange ----------------------
+    monkeypatch.setattr(_flops_benchmark_suite, "is_numba_installed", lambda: False)
+
+    # --- act / assert -----------------
+    with pytest.warns(RuntimeWarning, match="numba"):
+        run_flops_benchmark(t_slice_target_ms=0.1, n_rounds_measure=5, n_rounds_warmup=1, seed=42, verbose=False)

--- a/tests/benchmarking/micro/test_interleaved_runner.py
+++ b/tests/benchmarking/micro/test_interleaved_runner.py
@@ -119,7 +119,7 @@ def fake_benchmarks() -> dict[str, FakeBenchmark]:
 def test_runner_returns_requested_number_of_recorded_slices(fake_benchmarks):
     # --- arrange -----------------------------------------
     runner = InterleavedBenchmarkRunner(
-        fake_benchmarks, t_slice_target_ms=0.001, n_rounds_measure=7, n_rounds_warmup=2, seed=1, show_progress=False
+        fake_benchmarks, t_slice_target_ms=0.001, n_rounds_measure=7, n_rounds_warmup=2, seed=1, verbose=False
     )
 
     # --- act ---------------------------------------------
@@ -136,7 +136,7 @@ def test_runner_returns_requested_number_of_recorded_slices(fake_benchmarks):
 def test_runner_prepares_each_suite_exactly_once(fake_benchmarks):
     # --- arrange -----------------------------------------
     runner = InterleavedBenchmarkRunner(
-        fake_benchmarks, t_slice_target_ms=0.001, n_rounds_measure=3, n_rounds_warmup=1, seed=1, show_progress=False
+        fake_benchmarks, t_slice_target_ms=0.001, n_rounds_measure=3, n_rounds_warmup=1, seed=1, verbose=False
     )
 
     # --- act ---------------------------------------------
@@ -155,7 +155,7 @@ def test_runner_runs_every_benchmark_exactly_once_per_round(fake_benchmarks):
         n_rounds_measure=n_rounds_measure,
         n_rounds_warmup=n_rounds_warmup,
         seed=1,
-        show_progress=False,
+        verbose=False,
     )
 
     # --- act ---------------------------------------------
@@ -186,7 +186,7 @@ def test_runner_shuffles_order_between_rounds():
         n_rounds_measure=n_rounds_measure,
         n_rounds_warmup=0,
         seed=123,
-        show_progress=False,
+        verbose=False,
     )
 
     # --- act ---------------------------------------------
@@ -213,7 +213,7 @@ def test_runner_schedule_is_reproducible_with_seed():
         shared_log: list[tuple[str, int]] = []
         benchmarks = {name: FakeBenchmark(name, shared_log) for name in ["alpha", "beta", "gamma"]}
         InterleavedBenchmarkRunner(
-            benchmarks, t_slice_target_ms=0.001, n_rounds_measure=4, n_rounds_warmup=1, seed=seed, show_progress=False
+            benchmarks, t_slice_target_ms=0.001, n_rounds_measure=4, n_rounds_warmup=1, seed=seed, verbose=False
         ).run()
         return shared_log
 

--- a/tests/benchmarking/micro/test_interleaved_runner.py
+++ b/tests/benchmarking/micro/test_interleaved_runner.py
@@ -2,8 +2,16 @@ import random
 
 import pytest
 
+from counted_float._core.benchmarking._output import output_quiet
 from counted_float._core.benchmarking.micro import InterleavedBenchmarkRunner, MicroBenchmark, SliceController
 from counted_float._core.models import MicroBenchmarkResult
+
+
+@pytest.fixture(autouse=True)
+def _quiet_console():
+    """Silence the shared benchmark console for the runner tests (they assert on results, not output)."""
+    with output_quiet(True):
+        yield
 
 
 # =================================================================================================
@@ -119,7 +127,7 @@ def fake_benchmarks() -> dict[str, FakeBenchmark]:
 def test_runner_returns_requested_number_of_recorded_slices(fake_benchmarks):
     # --- arrange -----------------------------------------
     runner = InterleavedBenchmarkRunner(
-        fake_benchmarks, t_slice_target_ms=0.001, n_rounds_measure=7, n_rounds_warmup=2, seed=1, verbose=False
+        fake_benchmarks, t_slice_target_ms=0.001, n_rounds_measure=7, n_rounds_warmup=2, seed=1
     )
 
     # --- act ---------------------------------------------
@@ -136,7 +144,7 @@ def test_runner_returns_requested_number_of_recorded_slices(fake_benchmarks):
 def test_runner_prepares_each_suite_exactly_once(fake_benchmarks):
     # --- arrange -----------------------------------------
     runner = InterleavedBenchmarkRunner(
-        fake_benchmarks, t_slice_target_ms=0.001, n_rounds_measure=3, n_rounds_warmup=1, seed=1, verbose=False
+        fake_benchmarks, t_slice_target_ms=0.001, n_rounds_measure=3, n_rounds_warmup=1, seed=1
     )
 
     # --- act ---------------------------------------------
@@ -155,7 +163,6 @@ def test_runner_runs_every_benchmark_exactly_once_per_round(fake_benchmarks):
         n_rounds_measure=n_rounds_measure,
         n_rounds_warmup=n_rounds_warmup,
         seed=1,
-        verbose=False,
     )
 
     # --- act ---------------------------------------------
@@ -186,7 +193,6 @@ def test_runner_shuffles_order_between_rounds():
         n_rounds_measure=n_rounds_measure,
         n_rounds_warmup=0,
         seed=123,
-        verbose=False,
     )
 
     # --- act ---------------------------------------------
@@ -213,7 +219,7 @@ def test_runner_schedule_is_reproducible_with_seed():
         shared_log: list[tuple[str, int]] = []
         benchmarks = {name: FakeBenchmark(name, shared_log) for name in ["alpha", "beta", "gamma"]}
         InterleavedBenchmarkRunner(
-            benchmarks, t_slice_target_ms=0.001, n_rounds_measure=4, n_rounds_warmup=1, seed=seed, verbose=False
+            benchmarks, t_slice_target_ms=0.001, n_rounds_measure=4, n_rounds_warmup=1, seed=seed
         ).run()
         return shared_log
 

--- a/tests/benchmarking/micro/test_micro_benchmark.py
+++ b/tests/benchmarking/micro/test_micro_benchmark.py
@@ -78,6 +78,17 @@ def test_micro_benchmark(n_runs_total: int, n_runs_warmup: int, n_seconds_per_ru
     )
 
 
+def test_micro_benchmark_run_many_verbose_false_is_silent(capsys):
+    # --- arrange ----------------------
+    benchmark = DummyMicroBenchmark(nsecs_per_execution=1_000)
+
+    # --- act --------------------------
+    benchmark.run_many(n_runs_total=6, n_runs_warmup=2, n_seconds_per_run_target=0.001, verbose=False)
+
+    # --- assert -----------------------
+    assert capsys.readouterr().out == ""
+
+
 class FlatRuntimeMicroBenchmark(MicroBenchmark):
     """Benchmark whose runtime does not scale with n_executions, mimicking a dead-code-eliminated kernel."""
 

--- a/tests/benchmarking/micro/test_micro_benchmark.py
+++ b/tests/benchmarking/micro/test_micro_benchmark.py
@@ -2,6 +2,7 @@ import time
 
 import pytest
 
+from counted_float._core.benchmarking._output import output_quiet
 from counted_float._core.benchmarking.micro import MicroBenchmark
 from counted_float._core.models import MicroBenchmarkResult
 from counted_float._core.utils import Timer
@@ -78,15 +79,18 @@ def test_micro_benchmark(n_runs_total: int, n_runs_warmup: int, n_seconds_per_ru
     )
 
 
-def test_micro_benchmark_run_many_verbose_false_is_silent(capsys):
+def test_micro_benchmark_run_many_console_verbosity(capsys):
+    """run_many prints per-run progress by default and is fully silent under output_quiet."""
     # --- arrange ----------------------
     benchmark = DummyMicroBenchmark(nsecs_per_execution=1_000)
 
-    # --- act --------------------------
-    benchmark.run_many(n_runs_total=6, n_runs_warmup=2, n_seconds_per_run_target=0.001, verbose=False)
+    # --- act / assert -----------------
+    benchmark.run_many(n_runs_total=4, n_runs_warmup=1, n_seconds_per_run_target=0.001)
+    assert capsys.readouterr().out != ""  # baseline: progress reaches stdout (confirms capture works)
 
-    # --- assert -----------------------
-    assert capsys.readouterr().out == ""
+    with output_quiet(True):
+        benchmark.run_many(n_runs_total=4, n_runs_warmup=1, n_seconds_per_run_target=0.001)
+    assert capsys.readouterr().out == ""  # silenced: nothing reaches stdout
 
 
 class FlatRuntimeMicroBenchmark(MicroBenchmark):


### PR DESCRIPTION
`run_flops_benchmark()` and `run_counted_float_benchmark()` gain a `verbose` parameter (default `True`, preserving current output) that silences progress output when `False`. The "numba not installed" notice now goes through the warnings machinery as a `RuntimeWarning`, so it surfaces regardless of `verbose` and can be filtered or escalated by the caller.

Stacked on #186 — review that first; this PR's diff is against its branch.