### PR TITLE
fix: count patched math functions only after the call succeeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- patched `math` functions no longer leave a spurious flop count when the underlying call raises a domain or overflow error
+
 ### Security
 
 ## 1.5.0 (2026-07-14)

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -67,8 +67,9 @@ _NO_BASE = object()
 # -------------------------------------------------------------------------
 def math_sqrt(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_sqrt(x)  # compute first: domain error (x < 0) raises before counting
         GLOBAL_COUNTER.incr_sqrt()
-        return CountedFloat(original_math_sqrt(x))
+        return CountedFloat(result)
     return original_math_sqrt(x)
 
 
@@ -100,8 +101,9 @@ def math_log(  # noqa: C901 -- branches mirror the per-log-variant counting rule
     """
     if base is _NO_BASE:
         if isinstance(x, CountedFloat):
+            result = original_math_log(x)  # compute first: domain error (x <= 0) raises before counting
             GLOBAL_COUNTER.incr_log()
-            return CountedFloat(original_math_log(x))
+            return CountedFloat(result)
         return original_math_log(x)
     # computed first: raises per stdlib contract before anything is counted
     result = original_math_log(x, base)
@@ -127,29 +129,33 @@ def math_log(  # noqa: C901 -- branches mirror the per-log-variant counting rule
 
 def math_log2(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_log2(x)  # compute first: domain error (x <= 0) raises before counting
         GLOBAL_COUNTER.incr_log2()
-        return CountedFloat(original_math_log2(x))
+        return CountedFloat(result)
     return original_math_log2(x)
 
 
 def math_log10(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_log10(x)  # compute first: domain error (x <= 0) raises before counting
         GLOBAL_COUNTER.incr_log10()
-        return CountedFloat(original_math_log10(x))
+        return CountedFloat(result)
     return original_math_log10(x)
 
 
 def math_exp(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_exp(x)  # compute first: exp overflows (OverflowError) before counting
         GLOBAL_COUNTER.incr_exp()
-        return CountedFloat(original_math_exp(x))
+        return CountedFloat(result)
     return original_math_exp(x)
 
 
 def math_exp2(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_exp2(x)  # compute first: exp2 overflows (OverflowError) before counting
         GLOBAL_COUNTER.incr_exp2()
-        return CountedFloat(original_math_exp2(x))
+        return CountedFloat(result)
     return original_math_exp2(x)
 
 
@@ -176,22 +182,25 @@ def math_pow(x: float, y: float) -> float | CountedFloat:
 
 def math_sin(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_sin(x)  # compute first: sin(±inf) raises (ValueError) before counting
         GLOBAL_COUNTER.incr_sin()
-        return CountedFloat(original_math_sin(x))
+        return CountedFloat(result)
     return original_math_sin(x)
 
 
 def math_cos(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_cos(x)  # compute first: cos(±inf) raises (ValueError) before counting
         GLOBAL_COUNTER.incr_cos()
-        return CountedFloat(original_math_cos(x))
+        return CountedFloat(result)
     return original_math_cos(x)
 
 
 def math_tan(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_tan(x)  # compute first: tan(±inf) raises (ValueError) before counting
         GLOBAL_COUNTER.incr_tan()
-        return CountedFloat(original_math_tan(x))
+        return CountedFloat(result)
     return original_math_tan(x)
 
 
@@ -234,8 +243,9 @@ def math_hypot(*coordinates: float) -> float | CountedFloat:
 
 def math_expm1(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_expm1(x)  # compute first: expm1 overflows (OverflowError) before counting
         GLOBAL_COUNTER.incr_expm1()
-        return CountedFloat(original_math_expm1(x))
+        return CountedFloat(result)
     return original_math_expm1(x)
 
 

--- a/tests/counting/test_math_patching.py
+++ b/tests/counting/test_math_patching.py
@@ -263,6 +263,30 @@ def test_math_pow_domain_error_counts_nothing(global_counter):
     assert global_counter.total_count() == 0
 
 
+@pytest.mark.parametrize(
+    ("fname", "arg"),
+    [
+        ("sqrt", CountedFloat(-1.0)),  # domain: x >= 0
+        ("log", CountedFloat(-1.0)),  # domain: x > 0  (single-arg form)
+        ("log2", CountedFloat(-1.0)),  # domain: x > 0
+        ("log10", CountedFloat(-1.0)),  # domain: x > 0
+        ("exp", CountedFloat(710.0)),  # overflow (OverflowError)
+        ("exp2", CountedFloat(2000.0)),  # overflow (OverflowError)
+        ("sin", CountedFloat(math.inf)),  # sin/cos/tan raise on +/-inf
+        ("cos", CountedFloat(math.inf)),
+        ("tan", CountedFloat(math.inf)),
+        ("expm1", CountedFloat(710.0)),  # overflow (OverflowError)
+    ],
+)
+def test_single_arg_math_ops_error_counts_nothing(global_counter, fname, arg):
+    # regression: these all counted BEFORE the underlying call and leaked a phantom flop when it
+    # raised; the compute-first contract now leaves nothing counted (matching the log-base/pow paths)
+    # --- act & assert ------------------------------------
+    with pytest.raises((ValueError, OverflowError)):
+        getattr(math, fname)(arg)
+    assert global_counter.total_count() == 0
+
+
 # =================================================================================================
 #  Patched math functions - new higher-order ops (asin/acos/atan/atan2/hypot/expm1/log1p/fmod/fabs)
 # =================================================================================================

--- a/tests/counting/test_math_patching_property.py
+++ b/tests/counting/test_math_patching_property.py
@@ -1,0 +1,38 @@
+"""Property-based test: a raised ``math.*`` call never leaves a phantom flop count.
+
+Every patched math function counts on the *success* path only — if the underlying call raises
+(domain error, overflow, ...), the active counting context must be left unchanged. Six
+single-argument functions (``sqrt``, ``log``, ``log2``, ``log10``, ``exp``, ``exp2``) once
+counted *before* the underlying call and leaked a count on the exception path; this property
+blankets the whole patched set so that class of bug can't recur silently. The success-path,
+per-op counting is covered point-by-point in ``test_math_patching.py``.
+"""
+
+import math
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from counted_float import CountedFloat
+from counted_float._core.counting import _math_patching
+
+_PATCHED_NAMES = sorted(_math_patching._PATCHES.keys())
+_BINARY = {"atan2", "hypot", "fmod", "pow"}  # invoked with two operands; the rest take one
+
+
+@pytest.mark.parametrize("fname", _PATCHED_NAMES)
+@settings(deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(x=st.floats(allow_nan=True, allow_infinity=True, width=64))
+def test_raising_math_call_leaves_count_unchanged(global_counter, fname: str, x: float) -> None:
+    # --- arrange -----------------------------------------
+    func = getattr(math, fname)  # the fixture keeps a context active, so this is the patched version
+    args = (CountedFloat(x), CountedFloat(x)) if fname in _BINARY else (CountedFloat(x),)
+    global_counter.reset()
+
+    # --- act / assert ------------------------------------
+    try:
+        func(*args)
+    except (ValueError, OverflowError):
+        # compute-first contract: a raised call counts nothing
+        assert global_counter.total_count() == 0


### PR DESCRIPTION
Several patched `math` functions incremented the flop counter *before* invoking the underlying function, so a caught domain or overflow error (e.g. `math.sqrt(CountedFloat(-1))` inside a `try`) left a spurious count in the active context — a violation of the exact-count guarantee.

They now compute first and count only on success, matching the `log`-with-base and `pow` paths that already did so. A hypothesis property over the whole patched set guards against recurrence; it surfaced four functions beyond the originally-spotted set (`sin`/`cos`/`tan` on ±∞, `expm1` on overflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)