### PR TITLE
feat: warn when the benchmark can't read the CPU frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- the FLOPs benchmark now warns when it can't read the CPU frequency, since its per-op cycle figures are then effectively nanoseconds (flop-weight ratios are unaffected)
+
 ### Changed
 
 ### Deprecated

--- a/src/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
+++ b/src/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
@@ -16,6 +16,7 @@ from counted_float._core.models import (
     Quantiles,
     SystemInfo,
 )
+from counted_float._core.utils import get_cpu_frequency_mhz_current
 
 from ._array_generator import ArrayGenerator
 from ._flops_micro_benchmark import FlopsMicroBenchmark
@@ -62,6 +63,17 @@ class FlopsBenchmarkSuite:
             warnings.warn(
                 "'numba' is not installed; FLOPS benchmark results will be wildly inaccurate "
                 "and unusable. Install the optional dependency with pip install 'counted-float[numba]'.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+        # a missing CPU-frequency reading makes the ns->cycles conversion fall back to a nominal
+        # 1 GHz (see convert_nsecs_to_cycles), so the reported per-op "cycle" figures are then really
+        # nanoseconds -- surface that; only the derived flop-weight ratios (scale-invariant) stay valid
+        if get_cpu_frequency_mhz_current() is None:
+            warnings.warn(
+                "CPU frequency is unavailable; benchmark per-op figures are reported in nanoseconds, "
+                "not cycles. The derived flop weights (ratios) are unaffected.",
                 RuntimeWarning,
                 stacklevel=2,
             )

--- a/tests/benchmarking/flops/test_run_flops_benchmark.py
+++ b/tests/benchmarking/flops/test_run_flops_benchmark.py
@@ -27,3 +27,27 @@ def test_run_flops_benchmark_warns_when_numba_missing(monkeypatch):
     # --- act / assert -----------------
     with pytest.warns(RuntimeWarning, match="numba"):
         run_flops_benchmark(t_slice_target_ms=0.1, n_rounds_measure=5, n_rounds_warmup=1, seed=42, verbose=False)
+
+
+def test_run_flops_benchmark_warns_when_cpu_freq_unavailable(monkeypatch):
+    """A missing CPU-frequency reading is surfaced as a RuntimeWarning, even with progress silenced."""
+
+    # --- arrange ----------------------
+    monkeypatch.setattr(_flops_benchmark_suite, "get_cpu_frequency_mhz_current", lambda: None)
+
+    # --- act / assert -----------------
+    with pytest.warns(RuntimeWarning, match="frequency is unavailable"):
+        run_flops_benchmark(t_slice_target_ms=0.1, n_rounds_measure=5, n_rounds_warmup=1, seed=42, verbose=False)
+
+
+def test_run_flops_benchmark_no_freq_warning_when_available(monkeypatch, recwarn):
+    """When the CPU frequency reads back, no nanoseconds/frequency warning is emitted."""
+
+    # --- arrange ----------------------
+    monkeypatch.setattr(_flops_benchmark_suite, "get_cpu_frequency_mhz_current", lambda: 3000.0)
+
+    # --- act --------------------------
+    run_flops_benchmark(t_slice_target_ms=0.1, n_rounds_measure=5, n_rounds_warmup=1, seed=42, verbose=False)
+
+    # --- assert -----------------------
+    assert not [w for w in recwarn if issubclass(w.category, RuntimeWarning) and "frequency" in str(w.message)]


### PR DESCRIPTION
When `psutil` can't read the CPU frequency, the benchmark's nanoseconds→cycles conversion falls back to a nominal 1 GHz, so the reported per-op `n_cycles_per_op` / `estimated_flop_latencies` figures are really nanoseconds — silently, on most EC2/ARM boxes. The derived flop weights are unaffected (they are ADD-normalized ratios, and the scale cancels), but a user calibrating on their own hardware had no signal.

The benchmark now emits a `RuntimeWarning` in that case, fired regardless of `verbose` and filterable through the warnings machinery, mirroring the existing numba-absent notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)