### PR TITLE
docs: explain the execution-latency choice and document modeling gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ dist
 *.tar.gz
 *.whl
 
+# mkdocs build output (local `mkdocs build`; Read the Docs builds its own)
+site
+
 # Python cache files
 __pycache__
 *.pyc

--- a/docs/analysis_methodology.md
+++ b/docs/analysis_methodology.md
@@ -37,7 +37,20 @@ For most processors, two instruction latency figures can typically be obtained (
 - **execution latency**: time needed for end-to-end execution until a new instruction can start using the end result
 - **(reciprocal) throughput**: time needed per instruction with maximal throughput for independent similar operations
 
-Given the nature of code we intend to analyze, we focus on **execution latency**, i.e. the full end-to-end latency.
+We focus on **execution latency**. Reciprocal throughput is only realized when many
+*independent* same-type operations are in flight; the iterative numerical kernels this package
+targets (root finders, ODE steps, ...) are **dependent chains** — each step consumes the previous
+result (§1.2) — so the cost actually paid per operation is the full end-to-end latency, not the
+pipelined throughput. Code with enough independent parallelism to reach throughput would be
+vectorized, and is out of scope (§1.2). Execution latency is also the conservative choice: it is
+never below reciprocal throughput, so wherever a little instruction-level parallelism does exist we
+over- rather than under-estimate cost.
+
+When a source reports execution latency as a **range** (data-dependent latency for
+division/square-root, or measurement-path variation), we take the **upper bound**. Across the
+built-in corpus this tracks the benchmark-measured cost most closely: a benchmark running real
+operands through a dependent chain realizes the actual latency, which for these variable-latency
+operations sits at the top of the reported range.
 
 ## 1.5. Benchmark setup
 
@@ -59,6 +72,16 @@ We will focus on 3 types of sources for FPU instruction 'cost':
   those instructions that have hardware support.
 
 Given the mentioned PROs & CONs, these 3 sources can be considered complementary, and we can expect them to provide a balanced holistic picture.
+
+## 2.1. Combining incomplete data
+
+No single source covers every (CPU, operation) pair — benchmarks omit int↔float conversions,
+vendor spec sheets omit unpublished cores, and so on. Missing cells are imputed from a log-domain
+rank-1 fit before averaging: each cost is modeled as `speed[cpu] · difficulty[op]` (a *separable*
+model), so a gap is filled from the CPU's overall speed and the operation's typical difficulty.
+Only missing cells are ever filled; observed values are never modified. The assumption's blind spot:
+a CPU with an atypical *relative* profile (e.g. unusually fast division relative to addition) cannot
+be represented by a separable model, so its imputed cells are pulled toward the corpus norm.
 
 # 3. Instruction Mappings
 

--- a/docs/analysis_methodology.md
+++ b/docs/analysis_methodology.md
@@ -75,13 +75,20 @@ Given the mentioned PROs & CONs, these 3 sources can be considered complementary
 
 ## 2.1. Combining incomplete data
 
-No single source covers every (CPU, operation) pair — benchmarks omit int↔float conversions,
-vendor spec sheets omit unpublished cores, and so on. Missing cells are imputed from a log-domain
+No single source covers every (CPU, operation) pair. Benchmarks omit int↔float conversions, and
+spec sheets and third-party analyses only report operations with a direct hardware instruction — so
+transcendentals executed via a `libm` routine (`sin`, `exp`, `log`, ...) have no entry for those
+CPUs. (A CPU absent from a source entirely is simply a missing *row*, not a gap: there is nothing to
+impute, and it just isn't part of that source.) Such missing *cells* are imputed from a log-domain
 rank-1 fit before averaging: each cost is modeled as `speed[cpu] · difficulty[op]` (a *separable*
-model), so a gap is filled from the CPU's overall speed and the operation's typical difficulty.
-Only missing cells are ever filled; observed values are never modified. The assumption's blind spot:
-a CPU with an atypical *relative* profile (e.g. unusually fast division relative to addition) cannot
-be represented by a separable model, so its imputed cells are pulled toward the corpus norm.
+model), so a gap is filled from the CPU's overall speed and the operation's typical difficulty. Only
+missing cells are ever filled; observed values are never modified.
+
+Imputation runs **hierarchically** — a gap is filled from the most similar CPUs first (same
+microarchitecture, then vendor, then ISA family) before the broader corpus, which is the main reason
+the aggregation is nested this way. A separable model still cannot fully capture a CPU with an
+atypical *relative* profile (e.g. unusually fast division relative to addition), but its gaps are
+pulled toward close relatives rather than the whole-corpus norm.
 
 # 3. Instruction Mappings
 

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -87,11 +87,14 @@ patched `math` functions:
 The one place an `I2F` conversion *is* counted is explicit construction from an
 int — `CountedFloat(n)`. That is exactly how you opt a genuine runtime integer
 (a loop index, a computed count) into the counting model: wrap it, and its
-int→float conversion counts like any other FLOP. The constructor counts this
-`I2F` unconditionally — it cannot tell a runtime int from a constant one — so
-wrapping a *constant* int (`CountedFloat(5)`) does register an `I2F` a compiled
-port would fold away; the "wrap only runtime inputs" side of the contract is
-what keeps that from arising in practice.
+int→float conversion counts like any other FLOP. This is deliberate and
+load-bearing: `CountedFloat(n)` is the **only** way a developer can express that
+an integer is a genuine runtime value rather than a constant, so the conversion
+cannot be excluded here without removing that ability entirely. Counting it is
+therefore a pure opt-in that relies on developer discipline to wrap only genuine
+runtime integers — a computed count, not a literal `5`. To admit an integer
+*constant* without counting its conversion, convert with plain `float(n)` first,
+keeping it outside the counting model.
 
 The flip side: an unwrapped runtime input is invisible to the counter — that
 is a wrapping error at your algorithm's boundary, not something the library

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -87,7 +87,11 @@ patched `math` functions:
 The one place an `I2F` conversion *is* counted is explicit construction from an
 int — `CountedFloat(n)`. That is exactly how you opt a genuine runtime integer
 (a loop index, a computed count) into the counting model: wrap it, and its
-int→float conversion counts like any other FLOP.
+int→float conversion counts like any other FLOP. The constructor counts this
+`I2F` unconditionally — it cannot tell a runtime int from a constant one — so
+wrapping a *constant* int (`CountedFloat(5)`) does register an `I2F` a compiled
+port would fold away; the "wrap only runtime inputs" side of the contract is
+what keeps that from arising in practice.
 
 The flip side: an unwrapped runtime input is invisible to the counter — that
 is a wrapping error at your algorithm's boundary, not something the library

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -7,6 +7,12 @@
   [`math` coverage table](math_patching.md#coverage-of-the-math-module) for
   the full per-function status and the
   [FLOP types reference](flop_types.md) for per-operation counting rules
+- fused multiply-add is not modeled: `a*b + c` counts as separate MUL + ADD,
+  but a compiled port on any modern target (x86 FMA3, ARMv8) commonly fuses it
+  into a single FMA instruction with a single rounding, so flop counts
+  over-estimate fusable multiply-add sequences (dot products, Horner
+  evaluation). Python can't observe operator-level fusion; `math.fma` (3.13+)
+  is the one observable case and is currently uncounted (returns a plain float)
 - mixed operations with non-float numeric types are outside the counting
   model: `CountedFloat` delegates to the other operand exactly like `float`
   does, so e.g. a `fractions.Fraction` operand generally yields a correct but

--- a/docs/math_patching.md
+++ b/docs/math_patching.md
@@ -69,11 +69,16 @@ Every commonly used `math` function, and how it participates in counting:
 |---|---|
 | **Instrumented** (patched, counts its FlopType) | `sqrt`, `cbrt`, `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `pow`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `hypot`, `fmod`, `fabs` |
 | **Counted via dunder** (no patch needed — do not expect these in the patch list) | `math.floor` / `math.ceil` / `math.trunc` → F2I through `__floor__`/`__ceil__`/`__trunc__`; the builtins `abs()` → ABS and `round()` → RND/F2I likewise count through their dunders |
-| **Not instrumented** (returns a plain, uncounted `float`) | `copysign`, `remainder`, `frexp`, `ldexp`, `modf`, `degrees`, `radians`, `dist`, `fsum`, `prod`, `gamma`, `lgamma`, `erf`, `erfc`, `nextafter`, `ulp` |
+| **Not instrumented** (returns a plain, uncounted `float`) | `copysign`, `remainder`, `frexp`, `ldexp`, `modf`, `degrees`, `radians`, `dist`, `fsum`, `prod`, `gamma`, `lgamma`, `erf`, `erfc`, `nextafter`, `ulp`, `fma` |
 
 The not-instrumented set breaks contagion: the plain-`float` result silently
 stops all downstream counting, so convert back with `CountedFloat(...)` if a
 result of these feeds counted computation.
+
+`math.fma(x, y, z)` (Python 3.13+) is in this set for a second reason: it is the
+one place a fused multiply-add is observable at the Python level. Counting it
+faithfully would need a dedicated FMA flop type; until then a multiply-add is
+counted as separate MUL + ADD — see [Known limitations](known_limitations.md).
 
 Which functions are patched is also the boundary of what gets counted — see
 [Known limitations](known_limitations.md).

--- a/src/counted_float/_core/models/_instruction_latencies.py
+++ b/src/counted_float/_core/models/_instruction_latencies.py
@@ -39,8 +39,6 @@ class Latency(MyBaseModel):
 #  InstructionLatencies - SSE2
 # =================================================================================================
 class InstructionLatencies_SSE2(MyBaseModel):  # noqa: N801 -- established public API name
-    # SEE: https://github.com/bertpl/counted-float/tree/develop/counted_float/data/fpu_data_sources.md
-
     # --- primary fields ----------------------------------
     architecture: Literal["sse2"] = "sse2"
 
@@ -49,7 +47,7 @@ class InstructionLatencies_SSE2(MyBaseModel):  # noqa: N801 -- established publi
     CVTSD2SI: Latency = Latency()  # double -> int
     CVTSI2SD: Latency = Latency()  # int -> double
     XORPD: Latency = Latency()  # -x
-    UCOMISD: Latency = Latency()  # x < == > y, x < == > 0    NOTE: should be ranges of UCOMISD & COMISD merged
+    UCOMISD: Latency = Latency()  # x < == > y, x < == > 0
     MAXSD: Latency = Latency()  # max(x,y)
     MINSD: Latency = Latency()  # min(x,y)
     ADDSD: Latency = Latency()  # x+y
@@ -81,8 +79,6 @@ class InstructionLatencies_SSE2(MyBaseModel):  # noqa: N801 -- established publi
 #  InstructionLatencies - ARM
 # =================================================================================================
 class InstructionLatencies_ARM(MyBaseModel):  # noqa: N801 -- established public API name
-    # SEE: https://github.com/bertpl/counted-float/tree/develop/counted_float/data/fpu_data_sources.md
-
     # --- primary fields ----------------------------------
     architecture: Literal["arm"] = "arm"
 


### PR DESCRIPTION
Documentation consolidation. Fills several gaps in the counting / benchmark methodology:

- **§1.4 (Analysis methodology):** *why* the analysis models **execution latency** rather than reciprocal throughput — the target workloads (root finders, ODE steps) are dependent chains, so the cost paid per op is the full latency; and *why* a reported latency **range** is reduced to its **upper bound** (it tracks the benchmark-measured cost most closely).
- **FMA limitation:** `a*b + c` counts as MUL + ADD, but a compiled port commonly fuses it into a single FMA (one rounding), so counts over-estimate fusable multiply-add. `math.fma` (3.13+) is documented as uncounted.
- **Imputation:** the rank-1 separability assumption behind missing-data filling, and its blind spot.
- **Counting model:** `CountedFloat(int)` counts an `I2F` unconditionally — clarified against the constant-folding rule.

Plus tracked-source hygiene: two dead source-doc links and a stale note removed from the latency model, and the local mkdocs `site/` output gitignored. Docs-only + comment/hygiene — no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)