### PR TITLE
docs: split the overhead figure into native-op and math.* costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,19 @@ counts.total_count()         # 2
 
 ## Performance overhead
 
-Using `CountedFloat` instead of plain `float` costs roughly **20–40× per
-operation** (environment-dependent) — the price of Python-level operator
-dispatch and result wrapping. Measure your own machine with
-`counted_float benchmark-counted-float`. Two facts worth knowing:
+`CountedFloat` adds counting overhead in two forms — the price of Python-level
+operator dispatch and result wrapping. Measured on an Apple M3 Max (measure your
+own machine with `counted_float benchmark-counted-float`):
+
+- **native float ops** (`+`, `-`, `*`, `/`, comparisons): roughly **20–40×**
+  slower than plain `float` per operation, environment-dependent (~23× on the M3
+  Max bisection benchmark);
+- **patched `math.*` calls** (`math.sqrt`, `math.exp`, …): a roughly fixed
+  **~0.1 µs** of overhead per call — about **6–7×** for cheap functions like
+  `sqrt`, and a smaller multiple for costlier ones (the fixed overhead is a
+  smaller share of a slower call).
+
+Two facts worth knowing:
 
 - the overhead is inherent and `PauseFlopCounting` does **not** reduce it
   (the instrumented operators still execute; only count registration stops) —

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -87,13 +87,13 @@ Micro-benchmarking of a bisection algorithm using
 ------------------------------------------------------------------------------------------------------------------------
 Running CountedFloat benchmark...
 
-float                              : wwwwwwwwwwwwwww...................................   [  12.34 µs ±  1.2% | 50.1K cpu cycles ±  1.2% ]  /  execution
-CountedFloat                       : wwwwwwwwwwwwwww...................................   [ 459.95 µs ±  0.2% | 1.87M cpu cycles ±  0.2% ]  /  execution
+float                              : wwwwwwwwwwwwwww...................................   [  12.54 µs ±  3.7% | 50.8K cpu cycles ±  3.7% ]  /  execution
+CountedFloat                       : wwwwwwwwwwwwwww...................................   [ 283.91 µs ±  0.3% | 1.15M cpu cycles ±  0.3% ]  /  execution
 ------------------------------------------------------------------------------------------------------------------------
 
 CountedFloat Benchmark Results:
-  Bisection using float        :   12.34 µs / execution
-  Bisection using CountedFloat :  459.95 µs / execution
+  Bisection using float        :   12.54 µs / execution
+  Bisection using CountedFloat :  283.91 µs / execution
 
-CountedFloat is 37.3x slower than float
+CountedFloat is 22.6x slower than float
 ```

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -186,10 +186,13 @@ counts.total_count()         # 2
 
 ## Performance overhead
 
-Counting costs roughly 40–60× per operation vs. plain `float` (see the
-[Benchmarking page](benchmarking.md#performance-impact) for a measured
-example). The overhead is inherent to Python-level instrumentation;
-`PauseFlopCounting` stops count registration but not the instrumented
-dispatch, so hot regions that need raw speed should convert back to plain
-`float`. Counts themselves are always exact — overhead affects wall time,
-never accuracy.
+Counting adds overhead in two forms, measured on an Apple M3 Max (see the
+[Benchmarking page](benchmarking.md#performance-impact) for the CLI example):
+native float ops (`+`, `-`, `*`, `/`, comparisons) run roughly 20–40× slower
+than plain `float` per operation (environment-dependent), while a
+patched `math.*` call carries a roughly fixed ~0.1 µs of overhead — about 6–7×
+for cheap functions like `sqrt`, less for costlier ones. The overhead is inherent
+to Python-level instrumentation; `PauseFlopCounting` stops count registration but
+not the instrumented dispatch, so hot regions that need raw speed should convert
+back to plain `float`. Counts themselves are always exact — overhead affects wall
+time, never accuracy.


### PR DESCRIPTION
Splits the "Performance overhead" figure in the README and the counting-flops doc into the two measured surfaces (Apple M3 Max): native float ops (~20–40×) and patched `math.*` calls (a fixed ~0.1 µs per call, ~6–7× for cheap functions like `sqrt`). Also refreshes the stale `benchmark-counted-float` example (37.3× → 22.6×) to the post-optimization figure.

Docs only; stacked on #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)