### PR TITLE
feat: count math.fma as a fused multiply-add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `math.fma` (Python 3.13+) is now counted as a single fused multiply-add instead of a separate multiply and add
 - the FLOPs benchmark now measures fused multiply-add (`FMA`)
 
 ### Changed

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -25,6 +25,17 @@ import math
 from ._counted_float import CountedFloat, count_pow_with_constant_base, count_pow_with_constant_exponent
 from ._global_counter import GLOBAL_COUNTER
 
+
+def _math_fma_unavailable(x: float, y: float, z: float) -> float:
+    """Stand-in for `math.fma` on interpreters predating it (below 3.13).
+
+    Never called: the counting replacement is registered only where `math.fma` exists (see
+    _PATCHES). It exists so the `original_math_fma` reference is callable on every supported
+    interpreter rather than `None`, which would make the patch's own call sites unsound.
+    """
+    raise NotImplementedError("math.fma requires Python 3.13 or newer")
+
+
 # -------------------------------------------------------------------------
 #  original math module functions
 #  (import-time values are only a default; re-captured on every 0->1 patch
@@ -38,6 +49,7 @@ original_math_log10 = math.log10
 original_math_exp = math.exp
 original_math_exp2 = math.exp2
 original_math_pow = math.pow
+original_math_fma = getattr(math, "fma", _math_fma_unavailable)
 original_math_sin = math.sin
 original_math_cos = math.cos
 original_math_tan = math.tan
@@ -178,6 +190,32 @@ def math_pow(x: float, y: float) -> float | CountedFloat:
             count_pow_with_constant_base(x)
         return float.__new__(CountedFloat, result)
     return original_math_pow(x, y)
+
+
+def math_fma(x: float, y: float, z: float) -> float | CountedFloat:
+    """Patch math.fma: stdlib contract (fused multiply-add, a single rounding).
+
+    This is the one place a fusion is observable from Python, so it is the one place it can be
+    counted; `a*b + c` written as operators is invisible to the interpreter and stays MUL + ADD.
+
+    Flop classification follows the constant-folding convention, treating any non-CountedFloat
+    operand as a compile-time constant:
+      - two constant multiplicands -> their product folds, leaving a compiled port with a bare
+                                      add on the remaining runtime value -> ADD
+      - any other counted operand  -> the port emits one fused instruction -> FMA
+    Constant *values* are never inspected: unlike POW, no FMA variant is cheaper than another --
+    every one is a single instruction -- so there is nothing to strength-reduce.
+    """
+    if isinstance(x, CountedFloat) or isinstance(y, CountedFloat) or isinstance(z, CountedFloat):
+        # computed first: math.fma raises ValueError on invalid operand combinations
+        # (e.g. fma(inf, 0.0, z)) and then nothing should be counted
+        result = original_math_fma(x, y, z)
+        if isinstance(x, CountedFloat) or isinstance(y, CountedFloat):
+            GLOBAL_COUNTER.incr_fma()
+        else:
+            GLOBAL_COUNTER.incr_add()  # x*y is a constant product; only the add survives folding
+        return float.__new__(CountedFloat, result)
+    return original_math_fma(x, y, z)
 
 
 def math_sin(x: float) -> float | CountedFloat:
@@ -349,6 +387,10 @@ _PATCHES: dict[str, object] = {
     "acosh": math_acosh,
     "atanh": math_atanh,
 }
+if hasattr(math, "fma"):
+    # Python 3.13+ only. Registering conditionally is what keeps every loop over _PATCHES --
+    # capture, apply, restore -- free of version checks of its own.
+    _PATCHES["fma"] = math_fma
 # the math functions saved at patch time, to be restored at unpatch time
 _saved_originals: dict[str, object] = {}
 
@@ -365,7 +407,7 @@ def _capture_originals() -> None:
     possibly another package's patches, not the stdlib originals.
     """
     global original_math_sqrt, original_math_cbrt, original_math_log, original_math_log2
-    global original_math_log10, original_math_exp, original_math_exp2, original_math_pow
+    global original_math_log10, original_math_exp, original_math_exp2, original_math_pow, original_math_fma
     global original_math_sin, original_math_cos, original_math_tan
     global original_math_asin, original_math_acos, original_math_atan, original_math_atan2
     global original_math_hypot, original_math_expm1, original_math_log1p, original_math_fmod, original_math_fabs
@@ -380,6 +422,7 @@ def _capture_originals() -> None:
     original_math_exp = math.exp
     original_math_exp2 = math.exp2
     original_math_pow = math.pow
+    original_math_fma = getattr(math, "fma", _math_fma_unavailable)
     original_math_sin = math.sin
     original_math_cos = math.cos
     original_math_tan = math.tan

--- a/tests/counting/test_math_patching.py
+++ b/tests/counting/test_math_patching.py
@@ -432,3 +432,82 @@ def test_math_functions_do_not_count_outside_context():
     # --- assert ------------------------------------------
     assert result == 2.0
     assert not isinstance(result, CountedFloat)
+
+
+# =================================================================================================
+#  Patched math functions - fused multiply-add
+# =================================================================================================
+requires_fma = pytest.mark.skipif(not hasattr(math, "fma"), reason="math.fma requires Python 3.13+")
+
+
+def test_math_fma_registered_only_where_available():
+    """math.fma is patched exactly on the interpreters that have it, and never elsewhere."""
+    # --- act & assert ------------------------------------
+    assert ("fma" in _math_patching._PATCHES) == hasattr(math, "fma")
+
+
+@requires_fma
+@pytest.mark.parametrize(
+    ("x", "y", "z"),
+    [
+        (CountedFloat(2.0), CountedFloat(3.0), CountedFloat(4.0)),
+        (CountedFloat(2.0), 3.0, 4.0),
+        (2.0, CountedFloat(3.0), 4.0),
+        (CountedFloat(2.0), CountedFloat(3.0), 4.0),
+        (2, CountedFloat(3.0), 4),
+    ],
+    ids=["all_runtime", "constant_y_and_z", "constant_x", "constant_z", "int_constants"],
+)
+def test_math_fma_counts_one_fma(global_counter, x: float, y: float, z: float):
+    """One fused instruction whenever a runtime multiplicand is involved; constants add no cost of their own."""
+    # --- act ---------------------------------------------
+    result = math.fma(x, y, z)
+
+    # --- assert ------------------------------------------
+    # count checked first: comparing a CountedFloat below counts a COMP itself
+    assert global_counter.total_count() == 1
+    assert global_counter.FMA == 1
+    assert result == 10.0
+    assert isinstance(result, CountedFloat)
+
+
+@requires_fma
+def test_math_fma_with_constant_multiplicands_counts_add(global_counter):
+    """Two constant multiplicands fold to one constant, leaving a compiled port with a bare add."""
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(4.0)
+
+    # --- act ---------------------------------------------
+    result = math.fma(2.0, 3.0, cf)
+
+    # --- assert ------------------------------------------
+    assert global_counter.total_count() == 1
+    assert global_counter.ADD == 1
+    assert global_counter.FMA == 0
+    assert result == 10.0
+    assert isinstance(result, CountedFloat)
+
+
+@requires_fma
+def test_math_fma_without_counted_operands_counts_nothing(global_counter):
+    """Every operand constant: the expression folds entirely and contagion does not start."""
+    # --- act ---------------------------------------------
+    result = math.fma(2.0, 3.0, 4.0)
+
+    # --- assert ------------------------------------------
+    assert global_counter.total_count() == 0
+    assert result == 10.0
+    assert type(result) is float
+
+
+@requires_fma
+def test_math_fma_domain_error_counts_nothing(global_counter):
+    """The stdlib's error surfaces before anything is counted."""
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(1.0)
+
+    # --- act & assert ------------------------------------
+    with pytest.raises(ValueError):  # noqa: PT011 -- domain-error message wording varies across CPython versions
+        math.fma(math.inf, 0.0, cf)
+
+    assert global_counter.total_count() == 0

--- a/tests/counting/test_math_patching_property.py
+++ b/tests/counting/test_math_patching_property.py
@@ -18,7 +18,7 @@ from counted_float import CountedFloat
 from counted_float._core.counting import _math_patching
 
 _PATCHED_NAMES = sorted(_math_patching._PATCHES.keys())
-_BINARY = {"atan2", "hypot", "fmod", "pow"}  # invoked with two operands; the rest take one
+_ARITY = {"atan2": 2, "hypot": 2, "fmod": 2, "pow": 2, "fma": 3}  # every other patched function takes one operand
 
 
 @pytest.mark.parametrize("fname", _PATCHED_NAMES)
@@ -27,7 +27,7 @@ _BINARY = {"atan2", "hypot", "fmod", "pow"}  # invoked with two operands; the re
 def test_raising_math_call_leaves_count_unchanged(global_counter, fname: str, x: float) -> None:
     # --- arrange -----------------------------------------
     func = getattr(math, fname)  # the fixture keeps a context active, so this is the patched version
-    args = (CountedFloat(x), CountedFloat(x)) if fname in _BINARY else (CountedFloat(x),)
+    args = tuple(CountedFloat(x) for _ in range(_ARITY.get(fname, 1)))
     global_counter.reset()
 
     # --- act / assert ------------------------------------


### PR DESCRIPTION
Instruments `math.fma`, the one place a fused multiply-add is observable from Python.
Operator-level `a*b + c` is invisible to the interpreter and keeps counting MUL + ADD.

Classification follows the counting model's existing constant-folding convention, under
which a non-`CountedFloat` operand is an algorithm constant a compiled port folds:

- a runtime multiplicand -> one `FMA`;
- two constant multiplicands -> their product folds, leaving a bare add -> `ADD`;
- no counted operand -> nothing counted, plain float result.

Constant *values* are never inspected. Unlike `POW`, no FMA variant is cheaper than
another -- every one is a single instruction -- so there is nothing to strength-reduce.

The replacement is registered only on interpreters that have `math.fma` (3.13+), which is
what keeps 3.11/3.12 support free: capture, apply and restore all iterate the patch
registry and so need no version logic of their own. Verified on 3.12, where the flop type
exists but is never incremented and `a*b + c` counts exactly as before.

Also widens the property test's binary-function set into an arity map -- `fma` is the
first ternary patched function, and the set encoding stopped fitting.

Base: #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)