### PR TITLE
feat: add spec-sheet FMA latencies to the flop-weight dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- refreshed the built-in flop-weight dataset with re-collected measurements, adding a measured `FMA` weight
+- refreshed the built-in flop-weight dataset with re-collected measurements, adding an `FMA` weight backed by both benchmarks and vendor spec sheets
 
 ### Deprecated
 

--- a/src/counted_float/_core/models/_instruction_latencies.py
+++ b/src/counted_float/_core/models/_instruction_latencies.py
@@ -39,6 +39,14 @@ class Latency(MyBaseModel):
 #  InstructionLatencies - SSE2
 # =================================================================================================
 class InstructionLatencies_SSE2(MyBaseModel):  # noqa: N801 -- established public API name
+    """Latencies of the x86 instructions a modern compiler emits for scalar double-precision math.
+
+    The `sse2` tag distinguishes this from the ancient x87 FPU, rather than asserting that every
+    instruction below belongs to the SSE2 extension: it names the modern scalar x86 baseline, and
+    each field is whatever the current best instruction for that operation is. ROUNDSD (SSE4.1)
+    and VFMADD213SD (FMA3) are both here for that reason.
+    """
+
     # --- primary fields ----------------------------------
     architecture: Literal["sse2"] = "sse2"
 
@@ -54,6 +62,7 @@ class InstructionLatencies_SSE2(MyBaseModel):  # noqa: N801 -- established publi
     SUBSD: Latency = Latency()  # x-y
     MULSD: Latency = Latency()  # x*y
     DIVSD: Latency = Latency()  # x/y
+    VFMADD213SD: Latency = Latency()  # x*y+z, fused
     SQRTSD: Latency = Latency()  # sqrt(x)
 
     # --- helpers -----------------------------------------
@@ -70,6 +79,7 @@ class InstructionLatencies_SSE2(MyBaseModel):  # noqa: N801 -- established publi
                 FlopType.SUB: self.SUBSD.consensus(),
                 FlopType.MUL: self.MULSD.consensus(),
                 FlopType.DIV: self.DIVSD.consensus(),
+                FlopType.FMA: self.VFMADD213SD.consensus(),
                 FlopType.SQRT: self.SQRTSD.consensus(),
             }
         )
@@ -94,6 +104,7 @@ class InstructionLatencies_ARM(MyBaseModel):  # noqa: N801 -- established public
     FSUB: Latency = Latency()  # x-y
     FMUL: Latency = Latency()  # x*y
     FDIV: Latency = Latency()  # x/y
+    FMADD: Latency = Latency()  # x*y+z, fused
     FSQRT: Latency = Latency()  # sqrt(x)
 
     # --- helpers -----------------------------------------
@@ -110,6 +121,7 @@ class InstructionLatencies_ARM(MyBaseModel):  # noqa: N801 -- established public
                 FlopType.SUB: self.FSUB.consensus(),
                 FlopType.MUL: self.FMUL.consensus(),
                 FlopType.DIV: self.FDIV.consensus(),
+                FlopType.FMA: self.FMADD.consensus(),
                 FlopType.SQRT: self.FSQRT.consensus(),
             }
         )

--- a/src/counted_float/data/arm/v8_x/specs/arm_cortex_a76.json
+++ b/src/counted_float/data/arm/v8_x/specs/arm_cortex_a76.json
@@ -66,6 +66,11 @@
             "min_cycles": 7,
             "max_cycles": 15
         },
+        "FMADD": {
+            "notes": "guide lists '4 (2)'; the parenthetical is the accumulator-forwarding fast path, not the general latency",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "FSQRT": {
             "notes": "",
             "min_cycles": 7,

--- a/src/counted_float/data/arm/v8_x/specs/arm_cortex_x1.json
+++ b/src/counted_float/data/arm/v8_x/specs/arm_cortex_x1.json
@@ -66,6 +66,11 @@
             "min_cycles": 7,
             "max_cycles": 15
         },
+        "FMADD": {
+            "notes": "guide lists '4 (2)'; the parenthetical is the accumulator-forwarding fast path, not the general latency",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "FSQRT": {
             "notes": "",
             "min_cycles": 7,

--- a/src/counted_float/data/arm/v8_x/specs/arm_neoverse_n1.json
+++ b/src/counted_float/data/arm/v8_x/specs/arm_neoverse_n1.json
@@ -66,6 +66,11 @@
             "min_cycles": 7,
             "max_cycles": 15
         },
+        "FMADD": {
+            "notes": "guide lists '4 (2)'; the parenthetical is the accumulator-forwarding fast path, not the general latency",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "FSQRT": {
             "notes": "",
             "min_cycles": 7,

--- a/src/counted_float/data/arm/v8_x/specs/arm_neoverse_v1.json
+++ b/src/counted_float/data/arm/v8_x/specs/arm_neoverse_v1.json
@@ -66,6 +66,11 @@
             "min_cycles": 7,
             "max_cycles": 15
         },
+        "FMADD": {
+            "notes": "guide lists '4 (2)'; the parenthetical is the accumulator-forwarding fast path, not the general latency",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "FSQRT": {
             "notes": "",
             "min_cycles": 7,

--- a/src/counted_float/data/arm/v9_0/specs/arm_cortex_x2.json
+++ b/src/counted_float/data/arm/v9_0/specs/arm_cortex_x2.json
@@ -66,6 +66,11 @@
             "min_cycles": 7,
             "max_cycles": 15
         },
+        "FMADD": {
+            "notes": "guide lists '4 (2)'; the parenthetical is the accumulator-forwarding fast path, not the general latency",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "FSQRT": {
             "notes": "",
             "min_cycles": 7,

--- a/src/counted_float/data/arm/v9_0/specs/arm_cortex_x3.json
+++ b/src/counted_float/data/arm/v9_0/specs/arm_cortex_x3.json
@@ -66,6 +66,11 @@
             "min_cycles": 7,
             "max_cycles": 15
         },
+        "FMADD": {
+            "notes": "guide lists '4 (2)'; the parenthetical is the accumulator-forwarding fast path, not the general latency",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "FSQRT": {
             "notes": "",
             "min_cycles": 7,

--- a/src/counted_float/data/arm/v9_0/specs/arm_neoverse_n2.json
+++ b/src/counted_float/data/arm/v9_0/specs/arm_neoverse_n2.json
@@ -66,6 +66,11 @@
             "min_cycles": 7,
             "max_cycles": 15
         },
+        "FMADD": {
+            "notes": "guide lists '4 (2)'; the parenthetical is the accumulator-forwarding fast path, not the general latency",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "FSQRT": {
             "notes": "",
             "min_cycles": 7,

--- a/src/counted_float/data/arm/v9_0/specs/arm_neoverse_v2.json
+++ b/src/counted_float/data/arm/v9_0/specs/arm_neoverse_v2.json
@@ -66,6 +66,11 @@
             "min_cycles": 7,
             "max_cycles": 15
         },
+        "FMADD": {
+            "notes": "guide lists '4 (2)'; the parenthetical is the accumulator-forwarding fast path, not the general latency",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "FSQRT": {
             "notes": "",
             "min_cycles": 7,

--- a/src/counted_float/data/arm/v9_2/specs/arm_cortex_x4.json
+++ b/src/counted_float/data/arm/v9_2/specs/arm_cortex_x4.json
@@ -66,6 +66,11 @@
             "min_cycles": 13,
             "max_cycles": 13
         },
+        "FMADD": {
+            "notes": "guide lists '4 (2)'; the parenthetical is the accumulator-forwarding fast path, not the general latency",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "FSQRT": {
             "notes": "",
             "min_cycles": 13,

--- a/src/counted_float/data/arm/v9_2/specs/arm_cortex_x925.json
+++ b/src/counted_float/data/arm/v9_2/specs/arm_cortex_x925.json
@@ -66,6 +66,11 @@
             "min_cycles": 12,
             "max_cycles": 12
         },
+        "FMADD": {
+            "notes": "guide lists '4 (2)'; the parenthetical is the accumulator-forwarding fast path, not the general latency",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "FSQRT": {
             "notes": "",
             "min_cycles": 12,

--- a/src/counted_float/data/arm/v9_2/specs/arm_neoverse_v3.json
+++ b/src/counted_float/data/arm/v9_2/specs/arm_neoverse_v3.json
@@ -66,6 +66,11 @@
             "min_cycles": 13,
             "max_cycles": 13
         },
+        "FMADD": {
+            "notes": "guide lists '4 (2)'; the parenthetical is the accumulator-forwarding fast path, not the general latency",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "FSQRT": {
             "notes": "",
             "min_cycles": 13,

--- a/src/counted_float/data/x86/amd/2017_zen1/other/analysis_uops_info_zen1+.json
+++ b/src/counted_float/data/x86/amd/2017_zen1/other/analysis_uops_info_zen1+.json
@@ -65,6 +65,11 @@
             "min_cycles": null,
             "max_cycles": 13
         },
+        "VFMADD213SD": {
+            "note": "https://uops.info/html-lat/ZEN+/VFMADD213SD_XMM_XMM_XMM-Measurements.html",
+            "min_cycles": 5,
+            "max_cycles": 5
+        },
         "SQRTSD": {
             "note": "https://uops.info/html-lat/ZEN+/SQRTSD_XMM_XMM-Measurements.html",
             "min_cycles": null,

--- a/src/counted_float/data/x86/amd/2020_zen3/other/analysis_agner_fog_r7_5800x.json
+++ b/src/counted_float/data/x86/amd/2020_zen3/other/analysis_agner_fog_r7_5800x.json
@@ -66,6 +66,11 @@
             "min_cycles": 13.5,
             "max_cycles": 13.5
         },
+        "VFMADD213SD": {
+            "note": "",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "note": "",
             "min_cycles": 20,

--- a/src/counted_float/data/x86/amd/2020_zen3/other/analysis_uops_info_zen3.json
+++ b/src/counted_float/data/x86/amd/2020_zen3/other/analysis_uops_info_zen3.json
@@ -65,6 +65,11 @@
             "min_cycles": null,
             "max_cycles": 13
         },
+        "VFMADD213SD": {
+            "note": "https://uops.info/html-lat/ZEN3/VFMADD213SD_XMM_XMM_XMM-Measurements.html",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "note": "https://uops.info/html-lat/ZEN3/SQRTSD_XMM_XMM-Measurements.html",
             "min_cycles": null,

--- a/src/counted_float/data/x86/amd/2022_zen4/other/analysis_agner_fog_r9_7900x.json
+++ b/src/counted_float/data/x86/amd/2022_zen4/other/analysis_agner_fog_r9_7900x.json
@@ -66,6 +66,11 @@
             "min_cycles": 13,
             "max_cycles": 13
         },
+        "VFMADD213SD": {
+            "note": "",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "note": "",
             "min_cycles": 21,

--- a/src/counted_float/data/x86/amd/2022_zen4/other/analysis_uops_info_zen4.json
+++ b/src/counted_float/data/x86/amd/2022_zen4/other/analysis_uops_info_zen4.json
@@ -65,6 +65,11 @@
             "min_cycles": null,
             "max_cycles": 13
         },
+        "VFMADD213SD": {
+            "note": "https://uops.info/html-lat/ZEN4/VFMADD213SD_XMM_XMM_XMM-Measurements.html",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "note": "https://uops.info/html-lat/ZEN4/SQRTSD_XMM_XMM-Measurements.html",
             "min_cycles": null,

--- a/src/counted_float/data/x86/amd/2022_zen4/other/specs_amd.json
+++ b/src/counted_float/data/x86/amd/2022_zen4/other/specs_amd.json
@@ -66,6 +66,11 @@
             "min_cycles": 13,
             "max_cycles": 13
         },
+        "VFMADD213SD": {
+            "note": "",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "note": "",
             "min_cycles": 20,

--- a/src/counted_float/data/x86/amd/2024_zen5/other/analysis_agner_fog_r7_9800x3d.json
+++ b/src/counted_float/data/x86/amd/2024_zen5/other/analysis_agner_fog_r7_9800x3d.json
@@ -66,6 +66,11 @@
             "min_cycles": 13,
             "max_cycles": 13
         },
+        "VFMADD213SD": {
+            "note": "",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "note": "",
             "min_cycles": 20,

--- a/src/counted_float/data/x86/amd/2024_zen5/other/specs_amd.json
+++ b/src/counted_float/data/x86/amd/2024_zen5/other/specs_amd.json
@@ -66,6 +66,11 @@
             "min_cycles": 13,
             "max_cycles": 13
         },
+        "VFMADD213SD": {
+            "note": "",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "note": "",
             "min_cycles": 20,

--- a/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/other/analysis_agner_fog_coffee_lake.json
+++ b/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/other/analysis_agner_fog_coffee_lake.json
@@ -67,6 +67,11 @@
             "min_cycles": 13,
             "max_cycles": 14
         },
+        "VFMADD213SD": {
+            "notes": "",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "notes": "",
             "min_cycles": 15,

--- a/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/other/analysis_uops_info_coffee_lake.json
+++ b/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/other/analysis_uops_info_coffee_lake.json
@@ -65,6 +65,11 @@
             "min_cycles": null,
             "max_cycles": 15
         },
+        "VFMADD213SD": {
+            "note": "https://uops.info/html-lat/CFL/VFMADD213SD_XMM_XMM_XMM-Measurements.html",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "note": "https://uops.info/html-lat/CFL/SQRTSD_XMM_XMM-Measurements.html",
             "min_cycles": null,

--- a/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_agner_fog_ice_lake.json
+++ b/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_agner_fog_ice_lake.json
@@ -66,6 +66,11 @@
             "min_cycles": 13,
             "max_cycles": 14
         },
+        "VFMADD213SD": {
+            "notes": "",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "notes": "",
             "min_cycles": 15,

--- a/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_uops_info_ice_lake.json
+++ b/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_uops_info_ice_lake.json
@@ -65,6 +65,11 @@
             "min_cycles": null,
             "max_cycles": 15
         },
+        "VFMADD213SD": {
+            "note": "https://uops.info/html-lat/ICL/VFMADD213SD_XMM_XMM_XMM-Measurements.html",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "note": "https://uops.info/html-lat/ICL/SQRTSD_XMM_XMM-Measurements.html",
             "min_cycles": null,

--- a/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_uops_info_tiger_lake.json
+++ b/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_uops_info_tiger_lake.json
@@ -65,6 +65,11 @@
             "min_cycles": null,
             "max_cycles": 15
         },
+        "VFMADD213SD": {
+            "note": "https://uops.info/html-lat/TGL/VFMADD213SD_XMM_XMM_XMM-Measurements.html",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "note": "https://uops.info/html-lat/TGL/SQRTSD_XMM_XMM-Measurements.html",
             "min_cycles": null,

--- a/src/counted_float/data/x86/intel/2021_golden_cove_gen_12/other/analysis_uops_info_alder_lake_p.json
+++ b/src/counted_float/data/x86/intel/2021_golden_cove_gen_12/other/analysis_uops_info_alder_lake_p.json
@@ -65,6 +65,11 @@
             "min_cycles": null,
             "max_cycles": 15
         },
+        "VFMADD213SD": {
+            "note": "https://uops.info/html-lat/ADL-P/VFMADD213SD_XMM_XMM_XMM-Measurements.html",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "note": "https://uops.info/html-lat/ADL-P/SQRTSD_XMM_XMM-Measurements.html",
             "min_cycles": null,

--- a/src/counted_float/data/x86/intel/2021_golden_cove_gen_12/other/specs_intel.json
+++ b/src/counted_float/data/x86/intel/2021_golden_cove_gen_12/other/specs_intel.json
@@ -66,6 +66,11 @@
             "min_cycles": 14,
             "max_cycles": 14
         },
+        "VFMADD213SD": {
+            "note": "",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "note": "",
             "min_cycles": 18,

--- a/src/counted_float/data/x86/intel/2022_raptor_cove_gen_13_14/other/specs_intel.json
+++ b/src/counted_float/data/x86/intel/2022_raptor_cove_gen_13_14/other/specs_intel.json
@@ -67,6 +67,11 @@
             "min_cycles": 14,
             "max_cycles": 14
         },
+        "VFMADD213SD": {
+            "note": "",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "note": "",
             "min_cycles": 18,

--- a/src/counted_float/data/x86/intel/2023_redwood_cove_ultra_1/other/specs_intel.json
+++ b/src/counted_float/data/x86/intel/2023_redwood_cove_ultra_1/other/specs_intel.json
@@ -66,6 +66,11 @@
             "min_cycles": 14,
             "max_cycles": 14
         },
+        "VFMADD213SD": {
+            "note": "",
+            "min_cycles": 4,
+            "max_cycles": 4
+        },
         "SQRTSD": {
             "note": "",
             "min_cycles": 18,


### PR DESCRIPTION
Adds a fused multiply-add instruction to both instruction-latency models and populates it
across all 28 spec-sheet and third-party sources, taken from the vendor and analysis tables
each file already cites: the ARM software optimization guides (11), Agner Fog's instruction
tables (5), uops.info (7), the AMD instruction-latency spreadsheets (2), and Intel's
throughput/latency tables (3).

Every extraction was validated by first reproducing the basic latencies already in the file
from the same table and column. That caught a real error during this work — a column misread
in the AMD spreadsheets, where the value picked up was the manual volume rather than the
latency — which the check rejected before it could land as a plausible-looking number.

The x86 model keeps its `sse2` discriminator. The tag names the modern scalar x86 baseline as
opposed to the x87 FPU, rather than claiming each instruction belongs to the SSE2 extension —
as the already-present SSE4.1 rounding instruction shows. Renaming would break an established
public class name and the discriminator in every stored x86 file for no gain, so the intent is
recorded on the model instead, since "FMA is not SSE2" is the obvious tripwire.

The spec latencies independently corroborate the measurements: 4/3 on AMD Zen and on every
Neoverse core, 1/1 across Intel, and 5/4 on Zen 1 — which also explains why Zen 1 measured
1.25 while later Zen parts sit at 1.33.

Four Agner sources gain an FMA value but still cannot express an FMA/MUL ratio, because their
`MULSD` was never populated (Agner's Zen tables list only the packed multiply). That gap is
pre-existing and is left alone: imputation already covers it, as it does for their
transcendentals.

Base: #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
