### PR TITLE
docs: document FMA counting, its weight provenance and its boundaries

### DIFF
--- a/docs/analysis_methodology.md
+++ b/docs/analysis_methodology.md
@@ -93,10 +93,11 @@ pulled toward close relatives rather than the whole-corpus norm.
 # 3. Instruction Mappings
 
 The table below shows the mapping between math operations & FPU instructions for different architectures.
-x87 instructions are provided fyi; for x86 CPUs only SSE2/3/4.1 scalar instructions are considered.
+x87 instructions are provided fyi; for x86 CPUs only the modern scalar instruction set is considered —
+SSE2/3/4.1 plus the FMA3 fused multiply-add, i.e. whatever a current compiler emits for each operation.
 
-| math                   | x87                           | SSE(2/3/4.1)  | ARM v8/9       |
-|------------------------|-------------------------------|---------------|----------------|
+| math                   | x87                           | modern x86 scalar | ARM v8/9       |
+|------------------------|-------------------------------|-------------------|----------------|
 | abs(x)                 | FABS                          | ANDPD (1)     | FABS           |
 | round (double->double) | ?                             | ROUNDSD       | FRINT(N/P/Z/A) |
 | double->int            | FRND                          | CVTSD2SI      | FCVTZS         |
@@ -114,6 +115,7 @@ x87 instructions are provided fyi; for x86 CPUs only SSE2/3/4.1 scalar instructi
 | x - y                  | FSUB                          | SUBSD         | FSUB           |
 | x*y                    | FMUL                          | MULSD         | FMUL           |
 | x/y                    | FDIV                          | DIVSD         | FDIV           |
+| x*y+z (fused)          | /                             | VFMADD213SD   | FMADD          |
 | sqrt(x)                | FSQRT                         | SQRTSD        | FSQRT          |
 | log2(x)                | FYL2X                         | /             | /              |
 | exp2(x)                | F2XM1 + FADD + FSCALE         | /             | /              |

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -69,6 +69,17 @@ is estimated from a low quantile (q10) of its recorded slices, which discards
 residual burst-contaminated rounds. An optional `seed` argument makes the
 input data and round order reproducible.
 
+The fused multiply-add kernels are the one exception to how the kernels are
+compiled: they alone enable LLVM's `contract` fast-math flag, because a
+multiply-add is fused into a single FMA instruction only where the compiler is
+permitted to, and without that permission the kernels would time a separate
+multiply and add and report the result as an FMA latency. Only `contract` is
+granted — not the blanket fast-math switch, which would also permit
+reassociation and no-NaN/no-Inf assumptions that have no place in a latency
+measurement — and only on those kernels, so every other measurement times the
+operation it is named for. The test suite pins both halves of that by inspecting
+the emitted assembly.
+
 The resulting weights can then be configured as the active flop weights — see
 [Configuring FLOP weights](flop_weights.md#configuring-flop-weights).
 

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -84,6 +84,15 @@ patched `math` functions:
    `CountedFloat`, it is genuinely runtime: no folding applies (`x ** y`
    counts POW; `math.log(x, y)` counts LOG per counted operand + DIV).
 
+   Reduction by *value* only earns its keep where the folded form is genuinely
+   cheaper — a short chain of multiplies instead of a libm `pow` call is an
+   enormous saving. So it stops where that stops being true: `math.fma` gets no
+   value-based reduction, because every variant of it (`fma(x, 1.0, z)`,
+   `fma(x, 0.0, z)`, or any other) is the same single instruction and folding a
+   value would buy nothing. Its one fold is structural rather than value-based —
+   two constant multiplicands collapse to a single constant, leaving a compiled
+   port with a bare add, so that counts ADD.
+
 The one place an `I2F` conversion *is* counted is explicit construction from an
 int — `CountedFloat(n)`. That is exactly how you opt a genuine runtime integer
 (a loop index, a computed count) into the counting model: wrap it, and its
@@ -105,6 +114,28 @@ participate in counting (and in contagion) only while a `FlopCountingContext`
 is active. Operator-based contagion (`+`, `*`, `**`, ...) works everywhere,
 but counts are meant to be read through a context — so the practical rule is
 simply: run your measured algorithm inside one.
+
+### What the library will and will not instrument
+
+The library's side of the contract counts what a compiled port would execute —
+but only for operations your Python code actually performs. It *instruments*; it
+does not offer a vocabulary for *declaring* costs. That boundary explains two
+things that would otherwise look inconsistent:
+
+- **`math.fma` is counted; `a*b + c` is not fused.** A compiled port emits a
+  fused multiply-add as one instruction with one rounding, and `math.fma`
+  (Python 3.13+) is the single place that fusion is observable from Python — so
+  it counts as one `FMA`. The operator form is invisible to the interpreter,
+  which sees nothing distinguishing it from any other multiply followed by any
+  other add, so it stays MUL + ADD.
+- **No portable `fma` is provided.** It would be simple to ship a
+  `counted_float.fma()` that counts one `FMA` everywhere and computes `x*y + z`
+  where `math.fma` is missing. That is deliberately not done. It would turn the
+  library from an instrument of what your code executes into a cost-annotation
+  API, where a count asserts what you *intend* a port to do rather than
+  recording an operation that happened — and it would silently return a
+  differently-rounded result depending on the interpreter underneath. Counting
+  stays tied to what actually ran.
 
 Not everything is counted — see [Known limitations](known_limitations.md) for
 what falls outside the counting model (e.g. `numpy` operations).

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -27,6 +27,7 @@ find:
 | `round(x)`, `int(x)`, `math.floor`/`ceil`/`trunc` | `F2I` | operator | ISA | returns `int` |
 | `CountedFloat(int)` | `I2F` | constructor | ISA | yes |
 | `x ** y`, `math.pow(x, y)` | `POW` (or cheaper via constant strength reduction — MULs, SQRT, DIV, EXP2, EXP10) | operator / patch | benchmarked | yes |
+| `math.fma(x, y, z)` (3.13+) | `FMA` (or `ADD` when both multiplicands are constant) | patch | ISA | yes |
 | `math.sqrt(x)` | `SQRT` | patch | ISA | yes |
 | `math.cbrt(x)` | `CBRT` | patch | benchmarked | yes |
 | `math.exp(x)`, `math.exp2(x)`, `2 ** x` | `EXP`, `EXP2` | patch / operator | benchmarked | yes |
@@ -154,6 +155,23 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
     - **x86:** `DIVSD`
 - **Counted Python operations:** `x / y` or `y / x` for `CountedFloat`
 - **Not counted:** Division on non-CountedFloat, numpy division
+
+## FlopType.FMA (`x*y+z`)
+
+- Relevant CPU instructions
+    - **ARM:** `FMADD`
+    - **x86:** `VFMADD213SD`
+- **Counted Python operations:** `math.fma(x, y, z)` (Python 3.13+) — counted
+  when *any* operand is a `CountedFloat`, as one fused multiply-add: a single
+  instruction with a single rounding
+- **Constant multiplicands decompose:** when *both* `x` and `y` are constants
+  their product folds at compile time, leaving a compiled port with a bare add,
+  so that counts ADD rather than FMA. No reduction is done by constant *value* —
+  every FMA variant is one instruction, so there is nothing to win (see
+  [the counting model](counting_flops.md#the-counting-model-what-gets-counted-and-why))
+- **Not counted:** `math.fma` on plain floats only; `a*b + c` written with
+  operators, which counts MUL + ADD because the interpreter cannot observe the
+  fusion (see [Known limitations](known_limitations.md))
 
 ## FlopType.SQRT (`sqrt(x)`)
 

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -7,12 +7,15 @@
   [`math` coverage table](math_patching.md#coverage-of-the-math-module) for
   the full per-function status and the
   [FLOP types reference](flop_types.md) for per-operation counting rules
-- fused multiply-add is not modeled: `a*b + c` counts as separate MUL + ADD,
-  but a compiled port on any modern target (x86 FMA3, ARMv8) commonly fuses it
-  into a single FMA instruction with a single rounding, so flop counts
-  over-estimate fusable multiply-add sequences (dot products, Horner
-  evaluation). Python can't observe operator-level fusion; `math.fma` (3.13+)
-  is the one observable case and is currently uncounted (returns a plain float)
+- operator-level fused multiply-add is not modeled: `a*b + c` counts as separate
+  MUL + ADD, but a compiled port on any modern target (x86 FMA3, ARMv8) commonly
+  fuses it into a single FMA instruction with a single rounding, so flop counts
+  over-estimate fusable multiply-add sequences (dot products, Horner evaluation).
+  Python cannot observe operator-level fusion, so the library cannot count it.
+  `math.fma` (Python 3.13+) is the one place a fusion *is* observable, and it is
+  counted as a single `FMA`; expressing a multiply-add that way is therefore the
+  only means of having one counted as fused — and there is none on older
+  interpreters, where `math.fma` does not exist
 - mixed operations with non-float numeric types are outside the counting
   model: `CountedFloat` delegates to the other operand exactly like `float`
   does, so e.g. a `fractions.Fraction` operand generally yields a correct but

--- a/docs/math_patching.md
+++ b/docs/math_patching.md
@@ -67,18 +67,21 @@ Every commonly used `math` function, and how it participates in counting:
 
 | Coverage | Functions |
 |---|---|
-| **Instrumented** (patched, counts its FlopType) | `sqrt`, `cbrt`, `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `pow`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `hypot`, `fmod`, `fabs` |
+| **Instrumented** (patched, counts its FlopType) | `sqrt`, `cbrt`, `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `pow`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `hypot`, `fmod`, `fabs`, `fma` (Python 3.13+) |
 | **Counted via dunder** (no patch needed — do not expect these in the patch list) | `math.floor` / `math.ceil` / `math.trunc` → F2I through `__floor__`/`__ceil__`/`__trunc__`; the builtins `abs()` → ABS and `round()` → RND/F2I likewise count through their dunders |
-| **Not instrumented** (returns a plain, uncounted `float`) | `copysign`, `remainder`, `frexp`, `ldexp`, `modf`, `degrees`, `radians`, `dist`, `fsum`, `prod`, `gamma`, `lgamma`, `erf`, `erfc`, `nextafter`, `ulp`, `fma` |
+| **Not instrumented** (returns a plain, uncounted `float`) | `copysign`, `remainder`, `frexp`, `ldexp`, `modf`, `degrees`, `radians`, `dist`, `fsum`, `prod`, `gamma`, `lgamma`, `erf`, `erfc`, `nextafter`, `ulp` |
 
 The not-instrumented set breaks contagion: the plain-`float` result silently
 stops all downstream counting, so convert back with `CountedFloat(...)` if a
 result of these feeds counted computation.
 
-`math.fma(x, y, z)` (Python 3.13+) is in this set for a second reason: it is the
-one place a fused multiply-add is observable at the Python level. Counting it
-faithfully would need a dedicated FMA flop type; until then a multiply-add is
-counted as separate MUL + ADD — see [Known limitations](known_limitations.md).
+`math.fma(x, y, z)` exists only from Python 3.13 on, and is patched exactly where
+it exists — on older interpreters there is no such function to call, and a
+multiply-add written as `a*b + c` counts MUL + ADD there as everywhere else. It is
+the one place a fused multiply-add is observable at the Python level, which is why
+it is also the only place one is counted; see [FLOP types](flop_types.md#floptypefma-xyz)
+for its counting rules and [Known limitations](known_limitations.md) for what
+operator-level fusion still costs.
 
 Which functions are patched is also the boundary of what gets counted — see
 [Known limitations](known_limitations.md).


### PR DESCRIPTION
Documents FMA across the six surfaces it touches, and records the two boundaries the
narrow counting scope rests on so they do not get re-litigated.

**Corrections.** `math_patching.md` moves `fma` from the not-instrumented set into the
instrumented one and drops the paragraph explaining why it could not be counted.
`known_limitations.md`'s FMA bullet is rewritten to the new invariant: operator-level
`a*b + c` is still not fused because Python cannot observe it, `math.fma` is counted where
it exists, and there is nothing on older interpreters. `flop_types.md` gains an `FMA`
section and a coverage row; its weight source is the existing *ISA* category — backed by a
real instruction, with both spec-sheet latencies and benchmarks behind it, exactly like MUL.
`analysis_methodology.md` gains the instruction-mapping row, and its preamble no longer
claims only SSE2/3/4.1 are considered, which the FMA3 instruction made untrue.

**Rationales.** Both land in `counting_flops.md`, beside the contract and the
strength-reduction principle they qualify:

- *The boundary of strength reduction* — reduction by value earns its keep only where the
  folded form is genuinely cheaper (a multiply chain instead of a libm `pow` call). Every
  FMA variant is one instruction, so folding a value would buy nothing and is deliberately
  not done. Its single fold is structural, not value-based: two constant multiplicands
  collapse to a constant, leaving a bare add.
- *What the library will and will not instrument* — it counts what a compiled port would
  execute, but only for operations Python actually performs. It instruments; it does not
  offer a vocabulary for declaring costs. That is why `math.fma` is counted while the
  operator form is not, and why no portable `counted_float.fma()` is provided: that would
  turn a count into an assertion of intent rather than a record of an operation, and would
  silently change rounding depending on the interpreter underneath.

`benchmarking.md` explains why the FMA kernels alone are compiled with LLVM contraction
enabled — so nobody tidies the flag away and leaves the pair silently timing a separate
multiply and add.

Anchors verified against the built HTML, and the docs build passes `--strict`.

Base: #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
