### PR TITLE
fix: correct third-party instruction latencies read from the wrong table row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- corrected a number of third-party instruction latencies that had been transcribed from the wrong table row, slightly adjusting the built-in flop weights
+
 ### Security
 
 ## 1.5.2 (2026-07-14)

--- a/src/counted_float/data/x86/amd/2017_zen1/other/analysis_uops_info_zen1+.json
+++ b/src/counted_float/data/x86/amd/2017_zen1/other/analysis_uops_info_zen1+.json
@@ -1,7 +1,8 @@
 {
     "notes": [
         "Data from uops.info/table.html",
-        "Zen 1+ - SSE - Measurements - Latency"
+        "Zen 1+ - SSE - Measurements - Latency",
+        "VFMADD213SD is an FMA3 instruction and so falls outside the SSE view above; as for every entry, its value comes from the per-instruction measurement page linked in its note"
     ],
     "latencies": {
         "architecture": "sse2",
@@ -27,7 +28,7 @@
         },
         "XORPD": {
             "note": "https://uops.info/html-lat/ZEN+/XORPD_XMM_XMM-Measurements.html",
-            "min_cycles": 0,
+            "min_cycles": 1,
             "max_cycles": 1
         },
         "UCOMISD": {

--- a/src/counted_float/data/x86/amd/2020_zen3/other/analysis_agner_fog_r7_5800x.json
+++ b/src/counted_float/data/x86/amd/2020_zen3/other/analysis_agner_fog_r7_5800x.json
@@ -57,7 +57,7 @@
             "max_cycles": 3
         },
         "MULSD": {
-            "note": "",
+            "note": "no scalar form in this table: multiply is listed only as packed (MULPS MULPD)",
             "min_cycles": null,
             "max_cycles": null
         },
@@ -67,7 +67,7 @@
             "max_cycles": 13.5
         },
         "VFMADD213SD": {
-            "note": "",
+            "note": "table lists VFMADD132PS/PD followed by 'All other FMA3 instructions: same as above', which covers the scalar form",
             "min_cycles": 4,
             "max_cycles": 4
         },

--- a/src/counted_float/data/x86/amd/2020_zen3/other/analysis_agner_fog_r7_5800x.json
+++ b/src/counted_float/data/x86/amd/2020_zen3/other/analysis_agner_fog_r7_5800x.json
@@ -3,7 +3,7 @@
         "Data from Agner Fog's instruction tables",
         "https://www.agner.org/optimize/instruction_tables.pdf",
         "pages 122-124, column 'latency'",
-        "page numbers above refer to the revision last updated 2025-07-25 (485 pages, sha256 753d4a4d3f40e99909ea7b0cddb2ea69fd24f32cc6f5aa8a49945bac39f9ff18); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
+        "page numbers above refer to the revision last updated 2025-09-20 (485 pages, sha256 6b9b58d1177884f9dcb5b88fbb4ac43135565a4295e76101464d1a5d286fe25a); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
     ],
     "latencies": {
         "architecture": "sse2",

--- a/src/counted_float/data/x86/amd/2020_zen3/other/analysis_agner_fog_r7_5800x.json
+++ b/src/counted_float/data/x86/amd/2020_zen3/other/analysis_agner_fog_r7_5800x.json
@@ -2,7 +2,8 @@
     "notes": [
         "Data from Agner Fog's instruction tables",
         "https://www.agner.org/optimize/instruction_tables.pdf",
-        "pages 122-124, column 'latency'"
+        "pages 122-124, column 'latency'",
+        "page numbers above refer to the revision last updated 2025-07-25 (485 pages, sha256 753d4a4d3f40e99909ea7b0cddb2ea69fd24f32cc6f5aa8a49945bac39f9ff18); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
     ],
     "latencies": {
         "architecture": "sse2",

--- a/src/counted_float/data/x86/amd/2020_zen3/other/analysis_uops_info_zen3.json
+++ b/src/counted_float/data/x86/amd/2020_zen3/other/analysis_uops_info_zen3.json
@@ -1,7 +1,8 @@
 {
     "notes": [
         "Data from uops.info/table.html",
-        "Zen 3 - SSE - Measurements - Latency"
+        "Zen 3 - SSE - Measurements - Latency",
+        "VFMADD213SD is an FMA3 instruction and so falls outside the SSE view above; as for every entry, its value comes from the per-instruction measurement page linked in its note"
     ],
     "latencies": {
         "architecture": "sse2",
@@ -27,7 +28,7 @@
         },
         "XORPD": {
             "note": "https://uops.info/html-lat/ZEN3/XORPD_XMM_XMM-Measurements.html",
-            "min_cycles": 0,
+            "min_cycles": 1,
             "max_cycles": 1
         },
         "UCOMISD": {

--- a/src/counted_float/data/x86/amd/2022_zen4/other/analysis_agner_fog_r9_7900x.json
+++ b/src/counted_float/data/x86/amd/2022_zen4/other/analysis_agner_fog_r9_7900x.json
@@ -2,7 +2,8 @@
     "notes": [
         "Data from Agner Fog's instruction tables",
         "https://www.agner.org/optimize/instruction_tables.pdf",
-        "pages 136-141, column 'latency'"
+        "pages 136-141, column 'latency'",
+        "page numbers above refer to the revision last updated 2025-07-25 (485 pages, sha256 753d4a4d3f40e99909ea7b0cddb2ea69fd24f32cc6f5aa8a49945bac39f9ff18); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
     ],
     "latencies": {
         "architecture": "sse2",

--- a/src/counted_float/data/x86/amd/2022_zen4/other/analysis_agner_fog_r9_7900x.json
+++ b/src/counted_float/data/x86/amd/2022_zen4/other/analysis_agner_fog_r9_7900x.json
@@ -3,7 +3,7 @@
         "Data from Agner Fog's instruction tables",
         "https://www.agner.org/optimize/instruction_tables.pdf",
         "pages 136-141, column 'latency'",
-        "page numbers above refer to the revision last updated 2025-07-25 (485 pages, sha256 753d4a4d3f40e99909ea7b0cddb2ea69fd24f32cc6f5aa8a49945bac39f9ff18); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
+        "page numbers above refer to the revision last updated 2025-09-20 (485 pages, sha256 6b9b58d1177884f9dcb5b88fbb4ac43135565a4295e76101464d1a5d286fe25a); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
     ],
     "latencies": {
         "architecture": "sse2",

--- a/src/counted_float/data/x86/amd/2022_zen4/other/analysis_agner_fog_r9_7900x.json
+++ b/src/counted_float/data/x86/amd/2022_zen4/other/analysis_agner_fog_r9_7900x.json
@@ -57,7 +57,7 @@
             "max_cycles": 3
         },
         "MULSD": {
-            "note": "",
+            "note": "no scalar form in this table: multiply is listed only as packed (MULPS MULPD)",
             "min_cycles": null,
             "max_cycles": null
         },
@@ -67,9 +67,9 @@
             "max_cycles": 13
         },
         "VFMADD213SD": {
-            "note": "",
-            "min_cycles": 4,
-            "max_cycles": 4
+            "note": "no scalar form in this table: the FMA row lists only packed forms (VFMADD...PS/PD)",
+            "min_cycles": null,
+            "max_cycles": null
         },
         "SQRTSD": {
             "note": "",

--- a/src/counted_float/data/x86/amd/2022_zen4/other/analysis_uops_info_zen4.json
+++ b/src/counted_float/data/x86/amd/2022_zen4/other/analysis_uops_info_zen4.json
@@ -1,7 +1,8 @@
 {
     "notes": [
         "Data from uops.info/table.html",
-        "Zen 4 - SSE - Measurements - Latency"
+        "Zen 4 - SSE - Measurements - Latency",
+        "VFMADD213SD is an FMA3 instruction and so falls outside the SSE view above; as for every entry, its value comes from the per-instruction measurement page linked in its note"
     ],
     "latencies": {
         "architecture": "sse2",
@@ -27,7 +28,7 @@
         },
         "XORPD": {
             "note": "https://uops.info/html-lat/ZEN4/XORPD_XMM_XMM-Measurements.html",
-            "min_cycles": 0,
+            "min_cycles": 1,
             "max_cycles": 1
         },
         "UCOMISD": {

--- a/src/counted_float/data/x86/amd/2024_zen5/other/analysis_agner_fog_r7_9800x3d.json
+++ b/src/counted_float/data/x86/amd/2024_zen5/other/analysis_agner_fog_r7_9800x3d.json
@@ -2,7 +2,8 @@
     "notes": [
         "Data from Agner Fog's instruction tables",
         "https://www.agner.org/optimize/instruction_tables.pdf",
-        "pages 152-156, column 'latency'"
+        "pages 152-156, column 'latency'",
+        "page numbers above refer to the revision last updated 2025-07-25 (485 pages, sha256 753d4a4d3f40e99909ea7b0cddb2ea69fd24f32cc6f5aa8a49945bac39f9ff18); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
     ],
     "latencies": {
         "architecture": "sse2",

--- a/src/counted_float/data/x86/amd/2024_zen5/other/analysis_agner_fog_r7_9800x3d.json
+++ b/src/counted_float/data/x86/amd/2024_zen5/other/analysis_agner_fog_r7_9800x3d.json
@@ -57,7 +57,7 @@
             "max_cycles": 2
         },
         "MULSD": {
-            "note": "",
+            "note": "no scalar form in this table: multiply is listed only as packed (MULPS MULPD)",
             "min_cycles": null,
             "max_cycles": null
         },
@@ -67,9 +67,9 @@
             "max_cycles": 13
         },
         "VFMADD213SD": {
-            "note": "",
-            "min_cycles": 4,
-            "max_cycles": 4
+            "note": "no scalar form in this table: the FMA row lists only packed forms (VFMADD...PS/PD)",
+            "min_cycles": null,
+            "max_cycles": null
         },
         "SQRTSD": {
             "note": "",

--- a/src/counted_float/data/x86/amd/2024_zen5/other/analysis_agner_fog_r7_9800x3d.json
+++ b/src/counted_float/data/x86/amd/2024_zen5/other/analysis_agner_fog_r7_9800x3d.json
@@ -3,7 +3,7 @@
         "Data from Agner Fog's instruction tables",
         "https://www.agner.org/optimize/instruction_tables.pdf",
         "pages 152-156, column 'latency'",
-        "page numbers above refer to the revision last updated 2025-07-25 (485 pages, sha256 753d4a4d3f40e99909ea7b0cddb2ea69fd24f32cc6f5aa8a49945bac39f9ff18); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
+        "page numbers above refer to the revision last updated 2025-09-20 (485 pages, sha256 6b9b58d1177884f9dcb5b88fbb4ac43135565a4295e76101464d1a5d286fe25a); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
     ],
     "latencies": {
         "architecture": "sse2",

--- a/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/other/analysis_agner_fog_coffee_lake.json
+++ b/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/other/analysis_agner_fog_coffee_lake.json
@@ -3,7 +3,7 @@
         "Data from Agner Fog's instruction tables",
         "https://www.agner.org/optimize/instruction_tables.pdf",
         "pages 341-345, column 'latency'",
-        "page numbers above refer to the revision last updated 2025-07-25 (485 pages, sha256 753d4a4d3f40e99909ea7b0cddb2ea69fd24f32cc6f5aa8a49945bac39f9ff18); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
+        "page numbers above refer to the revision last updated 2025-09-20 (485 pages, sha256 6b9b58d1177884f9dcb5b88fbb4ac43135565a4295e76101464d1a5d286fe25a); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
     ],
     "latencies": {
         "architecture": "sse2",

--- a/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/other/analysis_agner_fog_coffee_lake.json
+++ b/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/other/analysis_agner_fog_coffee_lake.json
@@ -68,7 +68,7 @@
             "max_cycles": 14
         },
         "VFMADD213SD": {
-            "notes": "",
+            "notes": "table row reads 'VFMADD... (all FMA instr.)', which covers the scalar form",
             "min_cycles": 4,
             "max_cycles": 4
         },

--- a/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/other/analysis_agner_fog_coffee_lake.json
+++ b/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/other/analysis_agner_fog_coffee_lake.json
@@ -3,7 +3,7 @@
         "Data from Agner Fog's instruction tables",
         "https://www.agner.org/optimize/instruction_tables.pdf",
         "pages 341-345, column 'latency'",
-        ""
+        "page numbers above refer to the revision last updated 2025-07-25 (485 pages, sha256 753d4a4d3f40e99909ea7b0cddb2ea69fd24f32cc6f5aa8a49945bac39f9ff18); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
     ],
     "latencies": {
         "architecture": "sse2",

--- a/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/other/analysis_uops_info_coffee_lake.json
+++ b/src/counted_float/data/x86/intel/2017_coffee_lake_gen_8/other/analysis_uops_info_coffee_lake.json
@@ -1,7 +1,8 @@
 {
     "notes": [
         "Data from uops.info/table.html",
-        "Coffee Lake - SSE - Measurements - Latency"
+        "Coffee Lake - SSE - Measurements - Latency",
+        "VFMADD213SD is an FMA3 instruction and so falls outside the SSE view above; as for every entry, its value comes from the per-instruction measurement page linked in its note"
     ],
     "latencies": {
         "architecture": "sse2",
@@ -63,7 +64,7 @@
         "DIVSD": {
             "note": "https://uops.info/html-lat/CFL/DIVSD_XMM_XMM-Measurements.html",
             "min_cycles": null,
-            "max_cycles": 15
+            "max_cycles": 13
         },
         "VFMADD213SD": {
             "note": "https://uops.info/html-lat/CFL/VFMADD213SD_XMM_XMM_XMM-Measurements.html",
@@ -73,7 +74,7 @@
         "SQRTSD": {
             "note": "https://uops.info/html-lat/CFL/SQRTSD_XMM_XMM-Measurements.html",
             "min_cycles": null,
-            "max_cycles": 19
+            "max_cycles": 13
         }
     }
 }

--- a/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_agner_fog_ice_lake.json
+++ b/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_agner_fog_ice_lake.json
@@ -58,8 +58,8 @@
         },
         "MULSD": {
             "notes": "",
-            "min_cycles": null,
-            "max_cycles": null
+            "min_cycles": 4,
+            "max_cycles": 4
         },
         "DIVSD": {
             "notes": "",
@@ -67,7 +67,7 @@
             "max_cycles": 14
         },
         "VFMADD213SD": {
-            "notes": "",
+            "notes": "table row reads 'VFMADD... (all FMA instr.)', which covers the scalar form",
             "min_cycles": 4,
             "max_cycles": 4
         },

--- a/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_agner_fog_ice_lake.json
+++ b/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_agner_fog_ice_lake.json
@@ -2,7 +2,8 @@
     "notes": [
         "Data from Agner Fog's instruction tables",
         "https://www.agner.org/optimize/instruction_tables.pdf",
-        "pages 376-380, column 'latency'"
+        "pages 376-380, column 'latency'",
+        "page numbers above refer to the revision last updated 2025-07-25 (485 pages, sha256 753d4a4d3f40e99909ea7b0cddb2ea69fd24f32cc6f5aa8a49945bac39f9ff18); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
     ],
     "latencies": {
         "architecture": "sse2",

--- a/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_agner_fog_ice_lake.json
+++ b/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_agner_fog_ice_lake.json
@@ -3,7 +3,7 @@
         "Data from Agner Fog's instruction tables",
         "https://www.agner.org/optimize/instruction_tables.pdf",
         "pages 376-380, column 'latency'",
-        "page numbers above refer to the revision last updated 2025-07-25 (485 pages, sha256 753d4a4d3f40e99909ea7b0cddb2ea69fd24f32cc6f5aa8a49945bac39f9ff18); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
+        "page numbers above refer to the revision last updated 2025-09-20 (485 pages, sha256 6b9b58d1177884f9dcb5b88fbb4ac43135565a4295e76101464d1a5d286fe25a); agner.org publishes only the latest revision at that URL and re-paginates it on every update, so the pages cited here will not match a differently-dated copy"
     ],
     "latencies": {
         "architecture": "sse2",

--- a/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_uops_info_ice_lake.json
+++ b/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_uops_info_ice_lake.json
@@ -1,7 +1,8 @@
 {
     "notes": [
         "Data from uops.info/table.html",
-        "Ice Lake - SSE - Measurements - Latency"
+        "Ice Lake - SSE - Measurements - Latency",
+        "VFMADD213SD is an FMA3 instruction and so falls outside the SSE view above; as for every entry, its value comes from the per-instruction measurement page linked in its note"
     ],
     "latencies": {
         "architecture": "sse2",
@@ -32,7 +33,7 @@
         },
         "UCOMISD": {
             "note": "https://uops.info/html-lat/ICL/UCOMISD_XMM_XMM-Measurements.html",
-            "min_cycles": 3,
+            "min_cycles": null,
             "max_cycles": 3
         },
         "MAXSD": {
@@ -63,7 +64,7 @@
         "DIVSD": {
             "note": "https://uops.info/html-lat/ICL/DIVSD_XMM_XMM-Measurements.html",
             "min_cycles": null,
-            "max_cycles": 15
+            "max_cycles": 13
         },
         "VFMADD213SD": {
             "note": "https://uops.info/html-lat/ICL/VFMADD213SD_XMM_XMM_XMM-Measurements.html",
@@ -73,7 +74,7 @@
         "SQRTSD": {
             "note": "https://uops.info/html-lat/ICL/SQRTSD_XMM_XMM-Measurements.html",
             "min_cycles": null,
-            "max_cycles": 19
+            "max_cycles": 13
         }
     }
 }

--- a/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_uops_info_tiger_lake.json
+++ b/src/counted_float/data/x86/intel/2019_sunny_cove_gen_10/other/analysis_uops_info_tiger_lake.json
@@ -1,7 +1,8 @@
 {
     "notes": [
         "Data from uops.info/table.html",
-        "Tiger Lake - SSE - Measurements - Latency"
+        "Tiger Lake - SSE - Measurements - Latency",
+        "VFMADD213SD is an FMA3 instruction and so falls outside the SSE view above; as for every entry, its value comes from the per-instruction measurement page linked in its note"
     ],
     "latencies": {
         "architecture": "sse2",
@@ -32,7 +33,7 @@
         },
         "UCOMISD": {
             "note": "https://uops.info/html-lat/TGL/UCOMISD_XMM_XMM-Measurements.html",
-            "min_cycles": 3,
+            "min_cycles": null,
             "max_cycles": 3
         },
         "MAXSD": {
@@ -63,7 +64,7 @@
         "DIVSD": {
             "note": "https://uops.info/html-lat/TGL/DIVSD_XMM_XMM-Measurements.html",
             "min_cycles": null,
-            "max_cycles": 15
+            "max_cycles": 13
         },
         "VFMADD213SD": {
             "note": "https://uops.info/html-lat/TGL/VFMADD213SD_XMM_XMM_XMM-Measurements.html",
@@ -73,7 +74,7 @@
         "SQRTSD": {
             "note": "https://uops.info/html-lat/TGL/SQRTSD_XMM_XMM-Measurements.html",
             "min_cycles": null,
-            "max_cycles": 19
+            "max_cycles": 13
         }
     }
 }

--- a/src/counted_float/data/x86/intel/2021_golden_cove_gen_12/other/analysis_uops_info_alder_lake_p.json
+++ b/src/counted_float/data/x86/intel/2021_golden_cove_gen_12/other/analysis_uops_info_alder_lake_p.json
@@ -1,7 +1,8 @@
 {
     "notes": [
         "Data from uops.info/table.html",
-        "Alder Lake-P - SSE - Measurements - Latency"
+        "Alder Lake-P - SSE - Measurements - Latency",
+        "VFMADD213SD is an FMA3 instruction and so falls outside the SSE view above; as for every entry, its value comes from the per-instruction measurement page linked in its note"
     ],
     "latencies": {
         "architecture": "sse2",
@@ -32,7 +33,7 @@
         },
         "UCOMISD": {
             "note": "https://uops.info/html-lat/ADL-P/UCOMISD_XMM_XMM-Measurements.html",
-            "min_cycles": 3,
+            "min_cycles": null,
             "max_cycles": 3
         },
         "MAXSD": {
@@ -48,12 +49,12 @@
         "ADDSD": {
             "note": "https://uops.info/html-lat/ADL-P/ADDSD_XMM_XMM-Measurements.html",
             "min_cycles": 2,
-            "max_cycles": 3
+            "max_cycles": 2
         },
         "SUBSD": {
             "note": "https://uops.info/html-lat/ADL-P/SUBSD_XMM_XMM-Measurements.html",
             "min_cycles": 2,
-            "max_cycles": 3
+            "max_cycles": 2
         },
         "MULSD": {
             "note": "https://uops.info/html-lat/ADL-P/MULSD_XMM_XMM-Measurements.html",
@@ -63,7 +64,7 @@
         "DIVSD": {
             "note": "https://uops.info/html-lat/ADL-P/DIVSD_XMM_XMM-Measurements.html",
             "min_cycles": null,
-            "max_cycles": 15
+            "max_cycles": 13
         },
         "VFMADD213SD": {
             "note": "https://uops.info/html-lat/ADL-P/VFMADD213SD_XMM_XMM_XMM-Measurements.html",
@@ -73,7 +74,7 @@
         "SQRTSD": {
             "note": "https://uops.info/html-lat/ADL-P/SQRTSD_XMM_XMM-Measurements.html",
             "min_cycles": null,
-            "max_cycles": 19
+            "max_cycles": 13
         }
     }
 }


### PR DESCRIPTION
A cross-check of all 392 latency values in the spec-sheet and third-party sources against
the tables they cite. 28 sources audited; 19 values were wrong. The 11 ARM optimization
guides, both AMD spreadsheets, all three Intel tables and the Agner Coffee Lake entry
reproduced perfectly — every defect is in the uops.info files (16) or Agner (3).

**Values read from the wrong row (uops.info).** These pages qualify their rows in prose
rather than in columns, which makes the wrong number easy to pick up:

- `DIVSD`/`SQRTSD` on Coffee Lake, Ice Lake, Tiger Lake and Alder Lake-P recorded ≤15 / ≤19,
  where every page states ≤13. The 19 came from the *experimental chain latency* rows, which
  measure a multi-instruction dependency chain rather than the instruction itself.
- `ADDSD`/`SUBSD` on Alder Lake-P recorded a 2–3 range; both operand paths are 2 and no 3
  appears on the page. This one mattered most: ADD normalizes every other weight in a source,
  so a 50%-high ADD deflated that source's entire weight vector by a third.
- `UCOMISD` on three sources recorded an exact 3 where the page gives the bound ≤3. These
  files already encode bounds as min=null elsewhere.
- `XORPD` on three Zen sources recorded min=0, taken from the rows qualified "with the same
  register for different operands" — the dependency-breaking zero idiom, not an
  operand-to-result path (both general paths are 1). It can never apply here anyway, since
  XORPD models negate against a *distinct* sign-mask register. Contrast ROUNDSD, whose min=0
  is an unqualified write-only-destination path and is correct.

**Agner's scalar-vs-packed suffixes, misread in both directions.**

- Ice Lake `MULSD` was null although page 379 carries `MULSS/D PS/D` at 4 — the `SS/D` names
  the scalar form. Coffee Lake has the identical row and was already populated.
- Zen 4 and Zen 5 `VFMADD213SD` were populated at 4 from rows reading `VFMADD...PS/PD` —
  packed only; no scalar row exists on those pages. They are now null, which also restores
  internal consistency: `MULSD` is null in those same files for exactly this reason. Where 4
  *is* justified the table says so explicitly — Coffee Lake and Ice Lake read
  "VFMADD... (all FMA instr.)", and Zen 3 adds "All other FMA3 instructions: same as above".

**Provenance kept truthful.** Each uops file's note claimed the whole file came from the
"SSE" view, which cannot be true of an FMA3 instruction; the note now records that
VFMADD213SD comes from its own linked measurement page, as every value here does. The FMA
entries in all five Agner files now state what the table names, and the `MULSD` nulls on
Zen 3/4/5 say why they are null — unannotated, that gap reads as an oversight and invites
re-investigation, which is what happened.

Weight impact is small, since the geo-mean across 47 sources dilutes single-source error:
SQRT −1.1%, FMA +0.8%, MUL +0.6%, everything else under 0.5%.

Base: #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
