### PR TITLE
docs: regenerate the flop-weight samples from actual output

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -9,52 +9,53 @@ the ability to micro-benchmark floating point operations as follows:
 >>> from counted_float.benchmarking import run_flops_benchmark
 >>> results = run_flops_benchmark()
 
-Running FLOPS benchmarks using counted-float 1.4.2 ...
-(Expected duration: ~171 seconds, plus jit compilation & calibration)
+Running FLOPS benchmarks using counted-float 1.6.0 ...
+(Expected duration: ~179 seconds, plus jit compilation & calibration)
 
-setup     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 42/42   0:00:00
-jit       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 42/42   0:00:09
+setup     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 44/44   0:00:00
+jit       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 44/44   0:00:09
 calibrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 10/10   0:00:04
 warmup    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3/3     0:00:03
-measure   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 200/200 0:02:48
+measure   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 200/200 0:02:56
 
 >>> results.flop_weights().show()
 
 {
-    FlopType.ABS        [abs(x)]        :   0.90066
-    FlopType.MINUS      [-x]            :   0.90185
+    FlopType.ABS        [abs(x)]        :   0.90086
+    FlopType.MINUS      [-x]            :   0.90128
+    FlopType.SUB        [x-y]           :   0.99924
     FlopType.ADD        [x+y]           :   1.00000
-    FlopType.SUB        [x-y]           :   1.00006
-    FlopType.RND        [round]         :   1.23318
-    FlopType.MUL        [x*y]           :   1.49293
-    FlopType.COMP       [x<=y]          :   1.65702
-    FlopType.DIV        [x/y]           :   3.96976
-    FlopType.SQRT       [sqrt(x)]       :   5.08313
-    FlopType.FMOD       [fmod(x,y)]     :   6.19209
-    FlopType.HYPOT      [hypot(x,y)]    :  15.12720
-    FlopType.EXP2       [2^x]           :  16.32379
-    FlopType.EXP        [e^x]           :  16.97535
-    FlopType.LOG10      [log10(x)]      :  16.98483
-    FlopType.LOG        [log(x)]        :  17.25491
-    FlopType.LOG2       [log2(x)]       :  17.68443
-    FlopType.ACOSH      [acosh(x)]      :  18.82279
-    FlopType.COSH       [cosh(x)]       :  18.95751
-    FlopType.EXP10      [10^x]          :  19.91439
-    FlopType.SINH       [sinh(x)]       :  20.30701
-    FlopType.EXPM1      [expm1(x)]      :  20.57782
-    FlopType.CBRT       [cbrt(x)]       :  20.74467
-    FlopType.LOG1P      [log1p(x)]      :  20.92068
-    FlopType.ASINH      [asinh(x)]      :  22.12902
-    FlopType.ACOS       [acos(x)]       :  24.64399
-    FlopType.TANH       [tanh(x)]       :  26.17544
-    FlopType.ASIN       [asin(x)]       :  27.77200
-    FlopType.ATAN       [atan(x)]       :  27.95380
-    FlopType.SIN        [sin(x)]        :  28.04906
-    FlopType.COS        [cos(x)]        :  28.43823
-    FlopType.ATAN2      [atan2(y,x)]    :  29.67176
-    FlopType.ATANH      [atanh(x)]      :  31.47494
-    FlopType.TAN        [tan(x)]        :  31.53547
-    FlopType.POW        [x^y]           :  37.44672
+    FlopType.RND        [round]         :   1.23358
+    FlopType.FMA        [x*y+z]         :   1.49364
+    FlopType.MUL        [x*y]           :   1.49670
+    FlopType.COMP       [x<=y]          :   1.65971
+    FlopType.DIV        [x/y]           :   3.96720
+    FlopType.SQRT       [sqrt(x)]       :   5.08079
+    FlopType.FMOD       [fmod(x,y)]     :   6.24736
+    FlopType.HYPOT      [hypot(x,y)]    :  15.14849
+    FlopType.EXP2       [2^x]           :  16.33827
+    FlopType.EXP        [e^x]           :  16.93635
+    FlopType.LOG10      [log10(x)]      :  17.01702
+    FlopType.LOG        [log(x)]        :  17.34751
+    FlopType.LOG2       [log2(x)]       :  17.73992
+    FlopType.COSH       [cosh(x)]       :  18.84562
+    FlopType.ACOSH      [acosh(x)]      :  19.00542
+    FlopType.SINH       [sinh(x)]       :  20.24303
+    FlopType.EXP10      [10^x]          :  20.32107
+    FlopType.EXPM1      [expm1(x)]      :  20.54583
+    FlopType.CBRT       [cbrt(x)]       :  20.77356
+    FlopType.LOG1P      [log1p(x)]      :  20.99742
+    FlopType.ASINH      [asinh(x)]      :  22.27093
+    FlopType.ACOS       [acos(x)]       :  24.68559
+    FlopType.TANH       [tanh(x)]       :  26.20514
+    FlopType.ASIN       [asin(x)]       :  27.88059
+    FlopType.SIN        [sin(x)]        :  28.08448
+    FlopType.ATAN       [atan(x)]       :  28.12979
+    FlopType.COS        [cos(x)]        :  28.49190
+    FlopType.ATAN2      [atan2(y,x)]    :  29.74369
+    FlopType.TAN        [tan(x)]        :  31.64899
+    FlopType.ATANH      [atanh(x)]      :  31.65176
+    FlopType.POW        [x^y]           :  37.55957
     FlopType.F2I        [float->int]    :       nan
     FlopType.I2F        [int->float]    :       nan
 }

--- a/docs/flop_weights.md
+++ b/docs/flop_weights.md
@@ -21,22 +21,37 @@ of data sources and methodology, and
     FlopType.COMP       [x<=y]          :   1.00000
     FlopType.SUB        [x-y]           :   1.00000
     FlopType.MUL        [x*y]           :   1.40000
+    FlopType.FMA        [x*y+z]         :   1.80000
     FlopType.RND        [round]         :   1.80000
     FlopType.F2I        [float->int]    :   2.00000
     FlopType.I2F        [int->float]    :   2.00000
     FlopType.DIV        [x/y]           :   5.50000
-    FlopType.SQRT       [sqrt(x)]       :   7.50000
-    FlopType.EXP2       [2^x]           :  16.00000
-    FlopType.EXP        [e^x]           :  18.00000
+    FlopType.FMOD       [fmod(x,y)]     :   6.00000
+    FlopType.SQRT       [sqrt(x)]       :   7.00000
+    FlopType.EXP2       [2^x]           :  14.00000
+    FlopType.EXP        [e^x]           :  16.00000
+    FlopType.HYPOT      [hypot(x,y)]    :  18.00000
     FlopType.LOG        [log(x)]        :  18.00000
-    FlopType.EXP10      [10^x]          :  22.00000
+    FlopType.COSH       [cosh(x)]       :  20.00000
+    FlopType.EXP10      [10^x]          :  20.00000
+    FlopType.SINH       [sinh(x)]       :  20.00000
+    FlopType.ACOSH      [acosh(x)]      :  22.00000
+    FlopType.ASINH      [asinh(x)]      :  22.00000
     FlopType.LOG2       [log2(x)]       :  22.00000
-    FlopType.LOG10      [log10(x)]      :  24.00000
+    FlopType.ACOS       [acos(x)]       :  27.00000
+    FlopType.ASIN       [asin(x)]       :  27.00000
+    FlopType.ATAN       [atan(x)]       :  27.00000
+    FlopType.LOG10      [log10(x)]      :  27.00000
     FlopType.COS        [cos(x)]        :  30.00000
+    FlopType.LOG1P      [log1p(x)]      :  30.00000
     FlopType.SIN        [sin(x)]        :  30.00000
+    FlopType.ATAN2      [atan2(y,x)]    :  36.00000
+    FlopType.EXPM1      [expm1(x)]      :  36.00000
+    FlopType.CBRT       [cbrt(x)]       :  40.00000
     FlopType.POW        [x^y]           :  40.00000
     FlopType.TAN        [tan(x)]        :  40.00000
-    FlopType.CBRT       [cbrt(x)]       :  45.00000
+    FlopType.ATANH      [atanh(x)]      :  45.00000
+    FlopType.TANH       [tanh(x)]       :  50.00000
 }
 ```
 
@@ -101,28 +116,43 @@ from counted_float.config import get_default_consensus_flop_weights
 >>> get_default_consensus_flop_weights(rounding_mode=None).show()
 
 {
-    FlopType.MINUS      [-x]            :   0.43688
-    FlopType.ABS        [abs(x)]        :   0.71585
-    FlopType.COMP       [x<=y]          :   0.97866
-    FlopType.SUB        [x-y]           :   0.99565
+    FlopType.MINUS      [-x]            :   0.43855
+    FlopType.ABS        [abs(x)]        :   0.70166
+    FlopType.COMP       [x<=y]          :   0.97607
     FlopType.ADD        [x+y]           :   1.00000
-    FlopType.MUL        [x*y]           :   1.39506
-    FlopType.RND        [round]         :   1.78130
-    FlopType.F2I        [float->int]    :   1.91125
-    FlopType.I2F        [int->float]    :   1.91839
-    FlopType.DIV        [x/y]           :   5.53385
-    FlopType.SQRT       [sqrt(x)]       :   7.37309
-    FlopType.EXP2       [2^x]           :  15.79616
-    FlopType.EXP        [e^x]           :  17.45201
-    FlopType.LOG        [log(x)]        :  18.93143
-    FlopType.LOG2       [log2(x)]       :  22.29433
-    FlopType.EXP10      [10^x]          :  22.93876
-    FlopType.LOG10      [log10(x)]      :  24.56277
-    FlopType.SIN        [sin(x)]        :  30.28970
-    FlopType.COS        [cos(x)]        :  31.27413
-    FlopType.POW        [x^y]           :  41.65022
-    FlopType.TAN        [tan(x)]        :  41.99495
-    FlopType.CBRT       [cbrt(x)]       :  44.15405
+    FlopType.SUB        [x-y]           :   1.00124
+    FlopType.MUL        [x*y]           :   1.40176
+    FlopType.FMA        [x*y+z]         :   1.73026
+    FlopType.RND        [round]         :   1.79792
+    FlopType.F2I        [float->int]    :   1.92300
+    FlopType.I2F        [int->float]    :   1.93018
+    FlopType.DIV        [x/y]           :   5.55496
+    FlopType.FMOD       [fmod(x,y)]     :   6.06353
+    FlopType.SQRT       [sqrt(x)]       :   7.10208
+    FlopType.EXP2       [2^x]           :  13.72677
+    FlopType.EXP        [e^x]           :  16.23268
+    FlopType.HYPOT      [hypot(x,y)]    :  18.35777
+    FlopType.LOG        [log(x)]        :  18.56192
+    FlopType.SINH       [sinh(x)]       :  19.39838
+    FlopType.COSH       [cosh(x)]       :  19.58566
+    FlopType.EXP10      [10^x]          :  20.84660
+    FlopType.LOG2       [log2(x)]       :  21.09550
+    FlopType.ACOSH      [acosh(x)]      :  21.09759
+    FlopType.ASINH      [asinh(x)]      :  22.47387
+    FlopType.LOG10      [log10(x)]      :  25.84923
+    FlopType.ATAN       [atan(x)]       :  26.17745
+    FlopType.ACOS       [acos(x)]       :  27.26683
+    FlopType.ASIN       [asin(x)]       :  27.93187
+    FlopType.LOG1P      [log1p(x)]      :  29.62005
+    FlopType.SIN        [sin(x)]        :  29.80200
+    FlopType.COS        [cos(x)]        :  30.67662
+    FlopType.EXPM1      [expm1(x)]      :  37.67467
+    FlopType.ATAN2      [atan2(y,x)]    :  37.69857
+    FlopType.POW        [x^y]           :  39.13194
+    FlopType.CBRT       [cbrt(x)]       :  39.18450
+    FlopType.TAN        [tan(x)]        :  41.88987
+    FlopType.ATANH      [atanh(x)]      :  43.59323
+    FlopType.TANH       [tanh(x)]       :  48.60487
 }
 ```
 
@@ -150,27 +180,42 @@ from counted_float.config import get_builtin_flop_weights
 
 {
     FlopType.COMP       [x<=y]          :   0.65000
-    FlopType.MINUS      [-x]            :   0.90000
+    FlopType.MINUS      [-x]            :   0.80000
+    FlopType.ABS        [abs(x)]        :   1.00000
     FlopType.ADD        [x+y]           :   1.00000
     FlopType.SUB        [x-y]           :   1.00000
-    FlopType.ABS        [abs(x)]        :   1.10000
     FlopType.F2I        [float->int]    :   1.50000
     FlopType.MUL        [x*y]           :   1.50000
     FlopType.I2F        [int->float]    :   1.60000
     FlopType.RND        [round]         :   1.60000
+    FlopType.FMA        [x*y+z]         :   2.00000
     FlopType.DIV        [x/y]           :   6.00000
+    FlopType.FMOD       [fmod(x,y)]     :   7.50000
     FlopType.SQRT       [sqrt(x)]       :   7.50000
-    FlopType.EXP2       [2^x]           :  16.00000
+    FlopType.EXP2       [2^x]           :  15.00000
     FlopType.EXP        [e^x]           :  18.00000
-    FlopType.LOG        [log(x)]        :  20.00000
+    FlopType.LOG        [log(x)]        :  18.00000
+    FlopType.HYPOT      [hypot(x,y)]    :  20.00000
     FlopType.LOG2       [log2(x)]       :  20.00000
-    FlopType.EXP10      [10^x]          :  24.00000
+    FlopType.ACOSH      [acosh(x)]      :  22.00000
+    FlopType.COSH       [cosh(x)]       :  22.00000
+    FlopType.EXP10      [10^x]          :  22.00000
+    FlopType.SINH       [sinh(x)]       :  22.00000
+    FlopType.ASINH      [asinh(x)]      :  24.00000
     FlopType.LOG10      [log10(x)]      :  24.00000
+    FlopType.ACOS       [acos(x)]       :  27.00000
+    FlopType.ASIN       [asin(x)]       :  30.00000
+    FlopType.ATAN       [atan(x)]       :  30.00000
+    FlopType.LOG1P      [log1p(x)]      :  30.00000
+    FlopType.SIN        [sin(x)]        :  30.00000
     FlopType.COS        [cos(x)]        :  33.00000
-    FlopType.SIN        [sin(x)]        :  33.00000
+    FlopType.CBRT       [cbrt(x)]       :  36.00000
+    FlopType.EXPM1      [expm1(x)]      :  36.00000
+    FlopType.ATAN2      [atan2(y,x)]    :  40.00000
     FlopType.POW        [x^y]           :  40.00000
-    FlopType.CBRT       [cbrt(x)]       :  45.00000
+    FlopType.ATANH      [atanh(x)]      :  45.00000
     FlopType.TAN        [tan(x)]        :  45.00000
+    FlopType.TANH       [tanh(x)]       :  45.00000
 }
 ```
 


### PR DESCRIPTION
The weights tables in `flop_weights.md` and `benchmarking.md` are presented as literal output of `get_active_flop_weights()`, `get_default_consensus_flop_weights()` and `get_builtin_flop_weights()` — but no longer matched what those functions print.

**They listed 22 of the 37 flop types.** The samples predate `asin`/`acos`/`atan`/`atan2`/`hypot`/`expm1`/`log1p`/`fmod` and all six hyperbolics, so they had been stale for several versions — 21 of 22 consensus values were already wrong on `main` before this stack. This version would have added a 16th omission, `FMA`, while `flop_types.md` simultaneously declared it a flop type.

**The benchmarking transcript also claimed 42 kernels / ~171 seconds**; the FMA pair makes it 44 / ~179 s, both derived deterministically by the code.

All four samples are now byte-identical to real output — verified by regenerating and comparing, not by hand-pasting, since hand-pasting is how they drifted in the first place.

**Root cause worth noting**: any doc that pastes computed output drifts silently on every data refresh, and nothing catches it. This PR fixes today's instance; it does not prevent the next one. Options — a test pinning docs to output, or marking the tables illustrative — are a separate decision.

Base: #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)