### PR TITLE
fix: keep counts correct when a context is re-entered or resumed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- a `FlopCountingContext` that is re-entered, or resumed outside its `with` block, no longer produces silently wrong counts
+
 ### Security
 
 ## 1.6.0 (2026-07-15)

--- a/src/counted_float/_core/counting/_context_managers.py
+++ b/src/counted_float/_core/counting/_context_managers.py
@@ -35,6 +35,10 @@ class FlopCountingContext:
         #   - current count == GLOBAL_COUNTER - self.__cnt_start_snapshot
         self.__active: bool = False
 
+        # Number of with-blocks currently open on this instance.  Only the outermost one drives
+        # counting, so re-entering the same instance yields a single, unbroken count.
+        self.__depth: int = 0
+
         # flop count bookkeeping
         self.__cnt_subtotal: FlopCounts = FlopCounts()
         self.__cnt_start_snapshot: FlopCounts = FlopCounts()
@@ -55,16 +59,55 @@ class FlopCountingContext:
     #  Pause/Resume
     # -------------------------------------------------------------------------
     def pause(self) -> None:
-        if self.__active:
-            self.__cnt_subtotal = self.flop_counts()
-            self.__cnt_start_snapshot = FlopCounts()
-            self.__active = False
+        """Stop registering counts on this context until resume() is called.
+
+        Raises:
+            RuntimeError: If this context has no with-block open.
+        """
+        self.__require_open("pause")
+        self.__deactivate()
 
     def resume(self) -> None:
+        """Resume registering counts on this context after a pause().
+
+        Raises:
+            RuntimeError: If this context has no with-block open.
+        """
+        self.__require_open("resume")
+        self.__activate()
+
+    # -------------------------------------------------------------------------
+    #  Internal state transitions
+    # -------------------------------------------------------------------------
+    def __require_open(self, action: str) -> None:
+        """Reject a pause/resume attempted outside this context's with-block.
+
+        Outside the block the math module is no longer patched, so registering counts there
+        would silently blend instrumented operator semantics with un-instrumented `math.*`
+        ones into a single count.
+
+        Args:
+            action: Name of the attempted operation, used in the error message.
+
+        Raises:
+            RuntimeError: If this context has no with-block open.
+        """
+        if self.__depth == 0:
+            raise RuntimeError(f"cannot {action}() a FlopCountingContext outside its 'with' block")
+
+    def __activate(self) -> None:
+        """Start attributing global counts to this context, preserving any earlier subtotal."""
         if not self.__active:
             self.__cnt_start_snapshot = GLOBAL_COUNTER.flop_counts() - self.__cnt_subtotal
             self.__cnt_subtotal = FlopCounts()
             self.__active = True
+
+    def __deactivate(self) -> None:
+        """Freeze the running count into the subtotal and stop attributing global counts."""
+        if self.__active:
+            self.__cnt_subtotal = self.flop_counts()
+            self.__cnt_start_snapshot = FlopCounts()
+            self.__active = False
 
     # -------------------------------------------------------------------------
     #  Context manager interface
@@ -73,7 +116,9 @@ class FlopCountingContext:
         # patching the math module is tied to the with-block lifetime (not to pause()/resume(),
         # which only control whether counts are registered)
         apply_math_patches()
-        self.resume()
+        self.__depth += 1
+        if self.__depth == 1:
+            self.__activate()
         return self
 
     def __exit__(
@@ -82,7 +127,9 @@ class FlopCountingContext:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        self.pause()
+        self.__depth -= 1
+        if self.__depth == 0:
+            self.__deactivate()
         remove_math_patches()
 
 

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -460,9 +460,15 @@ def apply_math_patches() -> None:
 def remove_math_patches() -> None:
     """Undo apply_math_patches; the math module is restored once the last context exits."""
     global _active_context_count
-    _active_context_count = max(0, _active_context_count - 1)
+    if _active_context_count == 0:
+        # nothing is patched, so there is nothing to undo.  Restoring here would re-apply a
+        # snapshot taken before the last context exited, silently overwriting whatever has
+        # patched math since.
+        return
+    _active_context_count -= 1
     if _active_context_count == 0:
         # restore the snapshot unconditionally, assuming LIFO patching discipline of any other
         # patching packages (see module docstring for the exact contract)
         for name, saved in _saved_originals.items():
             setattr(math, name, saved)
+        _saved_originals.clear()

--- a/tests/counting/test_context_managers.py
+++ b/tests/counting/test_context_managers.py
@@ -1,3 +1,7 @@
+import math
+
+import pytest
+
 from counted_float._core.counting._context_managers import FlopCountingContext, PauseFlopCounting
 from counted_float._core.counting._counted_float import CountedFloat
 from counted_float._core.counting._global_counter import GLOBAL_COUNTER
@@ -230,3 +234,71 @@ def test_pause_flop_counting_restores_paused_state():
     flop_counts = fcc.flop_counts()
     assert flop_counts.ADD == 0
     assert flop_counts.MUL == 1
+
+
+def test_flop_counting_context_reentrant_same_instance():
+    # --- arrange -----------------------------------------
+    cf1 = CountedFloat(1.0)
+    cf2 = CountedFloat(2.0)
+    fcc = FlopCountingContext()
+
+    # --- act ---------------------------------------------
+    with fcc:
+        _ = cf1 + cf2
+        with fcc:  # re-entering the same instance
+            _ = cf1 + cf2
+        _ = cf1 + cf2  # still inside the outer block, so still counted
+
+    # --- assert ------------------------------------------
+    assert fcc.flop_counts().ADD == 3
+
+
+def test_flop_counting_context_reentrant_keeps_math_patched_until_outermost_exit():
+    # --- arrange -----------------------------------------
+    cf1 = CountedFloat(4.0)
+    fcc = FlopCountingContext()
+
+    # --- act ---------------------------------------------
+    with fcc:
+        with fcc:
+            pass
+        _ = math.sqrt(cf1)  # the inner exit must not have unpatched math
+
+    # --- assert ------------------------------------------
+    # counting the sqrt at all proves math was still patched after the inner exit
+    assert fcc.flop_counts().SQRT == 1
+
+
+def test_flop_counting_context_sequential_reuse_accumulates_and_excludes_the_gap():
+    # --- arrange -----------------------------------------
+    cf1 = CountedFloat(1.0)
+    cf2 = CountedFloat(2.0)
+    fcc = FlopCountingContext()
+
+    # --- act ---------------------------------------------
+    with fcc:
+        _ = cf1 + cf2
+    _ = cf1 * cf2  # between the blocks: must not be counted
+    with fcc:
+        _ = cf1 + cf2
+
+    # --- assert ------------------------------------------
+    flop_counts = fcc.flop_counts()
+    assert flop_counts.ADD == 2
+    assert flop_counts.MUL == 0
+
+
+@pytest.mark.parametrize("action", ["pause", "resume"])
+def test_flop_counting_context_pause_resume_outside_with_block_raises(action: str):
+    # --- arrange -----------------------------------------
+    fcc = FlopCountingContext()
+
+    # --- act / assert ------------------------------------
+    with pytest.raises(RuntimeError, match=action):
+        getattr(fcc, action)()  # never entered
+
+    with fcc:
+        pass
+
+    with pytest.raises(RuntimeError, match=action):
+        getattr(fcc, action)()  # already exited

--- a/tests/counting/test_math_patching.py
+++ b/tests/counting/test_math_patching.py
@@ -511,3 +511,26 @@ def test_math_fma_domain_error_counts_nothing(global_counter):
         math.fma(math.inf, 0.0, cf)
 
     assert global_counter.total_count() == 0
+
+
+def test_unbalanced_remove_math_patches_does_not_clobber_a_later_patch():
+    """An unbalanced removal must not re-apply the snapshot over a third-party patch."""
+    # --- arrange -----------------------------------------
+    with FlopCountingContext():
+        pass  # patches applied and restored; the snapshot has served its purpose
+
+    def third_party_sqrt(x: float) -> float:
+        return x
+
+    original_sqrt = math.sqrt
+    math.sqrt = third_party_sqrt  # ty: ignore[invalid-assignment]
+
+    # --- act ---------------------------------------------
+    try:
+        _math_patching.remove_math_patches()  # unbalanced: no context is open
+        survived = math.sqrt is third_party_sqrt
+    finally:
+        math.sqrt = original_sqrt  # ty: ignore[invalid-assignment]
+
+    # --- assert ------------------------------------------
+    assert survived


### PR DESCRIPTION
A `FlopCountingContext` now tracks how many `with` blocks are open on it, so re-entering the same instance keeps one unbroken count instead of silently dropping everything after the inner block exits. Sequential reuse of an instance is unaffected and gains the test it never had.

`pause()` / `resume()` outside the block now raise instead of registering operator counts while `math.*` is unpatched — a window that could only ever yield a count mixing instrumented and un-instrumented semantics.

An unbalanced patch removal no longer re-applies a stale snapshot over whatever has patched `math` since the last context exited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)