### PR TITLE
fix: give the weights setter and the weights constructor honest contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `FlopWeights.from_abs_flop_costs()` raises a clear `ValueError` instead of a raw `KeyError` or `ZeroDivisionError`
+
 ### Deprecated
 
 ### Removed
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - a `FlopCountingContext` that is re-entered, or resumed outside its `with` block, no longer produces silently wrong counts
+- `set_active_flop_weights()` now stores a copy, so mutating the object you passed no longer changes the configured weights
 
 ### Security
 

--- a/src/counted_float/_core/counting/config/_config.py
+++ b/src/counted_float/_core/counting/config/_config.py
@@ -27,9 +27,13 @@ class Config:
         """Set the weights for the flops used in the package.
 
         These weights will be used in any calculation of weighted flops, going forward.
+
+        Stores a deep copy, so later mutating the passed instance does not reconfigure the
+        package -- the mirror image of the value semantics get_flop_weights() provides.
+
         :param weights: FlopWeights instance containing the weights.
         """
-        cls.__weights = weights
+        cls.__weights = weights.model_copy(deep=True)
 
     @classmethod
     def get_flop_weights(cls) -> FlopWeights:

--- a/src/counted_float/_core/models/_flop_weights.py
+++ b/src/counted_float/_core/models/_flop_weights.py
@@ -119,10 +119,29 @@ class FlopWeights(MyBaseModel):
         """Compute FlopWeights based on absolute costs (in clock cycles, nanoseconds, ...) of each flop type.
 
         As a reference duration, we take the cost of the ADD operation.
+
+        Args:
+            flop_costs: Absolute cost per flop type, in any unit; only their ratios matter.
+
+        Returns:
+            FlopWeights normalized so that the ADD cost becomes weight 1.0.
+
+        Raises:
+            ValueError: If `flop_costs` has no ADD entry, or its ADD cost is zero.
         """
         # step 1) compute reference duration based on 1 simple flop type
         #         (SUB, MUL and a few others are usually very close)
+        if FlopType.ADD not in flop_costs:
+            raise ValueError(
+                f"flop_costs must contain a {FlopType.ADD!r} entry: it is the reference operation "
+                f"every other cost is normalized against."
+            )
         ref_cost = flop_costs[FlopType.ADD]
+        if ref_cost == 0:
+            raise ValueError(
+                f"the {FlopType.ADD!r} cost in flop_costs must be non-zero: it is the reference "
+                f"operation every other cost is divided by."
+            )
 
         # step 2) normalize and construct FlopWeights object
         return FlopWeights(

--- a/src/counted_float/_core/models/_flop_weights.py
+++ b/src/counted_float/_core/models/_flop_weights.py
@@ -127,7 +127,8 @@ class FlopWeights(MyBaseModel):
             FlopWeights normalized so that the ADD cost becomes weight 1.0.
 
         Raises:
-            ValueError: If `flop_costs` has no ADD entry, or its ADD cost is zero.
+            ValueError: If `flop_costs` has no ADD entry, or its ADD cost is not finite and
+                positive.
         """
         # step 1) compute reference duration based on 1 simple flop type
         #         (SUB, MUL and a few others are usually very close)
@@ -137,10 +138,12 @@ class FlopWeights(MyBaseModel):
                 f"every other cost is normalized against."
             )
         ref_cost = flop_costs[FlopType.ADD]
-        if ref_cost == 0:
+        # a zero reference raises on division, but a negative one silently inverts the sign of every
+        # other weight while normalizing itself to 1.0 -- so the result looks valid and is not
+        if not math.isfinite(ref_cost) or ref_cost <= 0:
             raise ValueError(
-                f"the {FlopType.ADD!r} cost in flop_costs must be non-zero: it is the reference "
-                f"operation every other cost is divided by."
+                f"the {FlopType.ADD!r} cost in flop_costs must be finite and positive, got {ref_cost}: "
+                f"it is the reference operation every other cost is divided by."
             )
 
         # step 2) normalize and construct FlopWeights object

--- a/tests/counting/config/test_config.py
+++ b/tests/counting/config/test_config.py
@@ -68,7 +68,7 @@ def test_bare_import_does_not_parse_builtin_data():
 
 def test_set_active_flop_weights_stores_a_copy():
     # --- arrange -----------------------------------------
-    weights = FlopWeights(weights={flop_type: 1.0 for flop_type in FlopType})
+    weights = FlopWeights(weights=dict.fromkeys(FlopType, 1.0))
 
     # --- act ---------------------------------------------
     set_active_flop_weights(weights)

--- a/tests/counting/config/test_config.py
+++ b/tests/counting/config/test_config.py
@@ -64,3 +64,15 @@ def test_bare_import_does_not_parse_builtin_data():
     )
     result = subprocess.run([sys.executable, "-c", code], check=False)  # noqa: S603 -- fixed args, no user input
     assert result.returncode == 0, "importing counted_float opened built-in data files"
+
+
+def test_set_active_flop_weights_stores_a_copy():
+    # --- arrange -----------------------------------------
+    weights = FlopWeights(weights={flop_type: 1.0 for flop_type in FlopType})
+
+    # --- act ---------------------------------------------
+    set_active_flop_weights(weights)
+    weights.weights[FlopType.ADD] = 999.0  # mutate the caller's instance after configuring
+
+    # --- assert ------------------------------------------
+    assert get_active_flop_weights().weights[FlopType.ADD] == 1.0

--- a/tests/models/test_flop_weights.py
+++ b/tests/models/test_flop_weights.py
@@ -145,10 +145,12 @@ def test_from_abs_flop_costs_without_add_raises_value_error():
         FlopWeights.from_abs_flop_costs(flop_costs)
 
 
-def test_from_abs_flop_costs_with_zero_add_raises_value_error():
+@pytest.mark.parametrize("ref_cost", [0.0, -2.0, math.nan, math.inf])
+def test_from_abs_flop_costs_with_unusable_add_raises_value_error(ref_cost: float):
     # --- arrange -----------------------------------------
-    flop_costs = dict.fromkeys(FlopType, 0.0)
+    flop_costs = dict.fromkeys(FlopType, 1.0)
+    flop_costs[FlopType.ADD] = ref_cost
 
     # --- act / assert ------------------------------------
-    with pytest.raises(ValueError, match="non-zero"):
+    with pytest.raises(ValueError, match="finite and positive"):
         FlopWeights.from_abs_flop_costs(flop_costs)

--- a/tests/models/test_flop_weights.py
+++ b/tests/models/test_flop_weights.py
@@ -134,3 +134,21 @@ def test_flop_weights_show(key_filter: str, rounding_mode: None | str):
 
     # --- act & assert ------------------------------------
     flop_weights.show()
+
+
+def test_from_abs_flop_costs_without_add_raises_value_error():
+    # --- arrange -----------------------------------------
+    flop_costs = {FlopType.MUL: 1.0}
+
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match="reference operation"):
+        FlopWeights.from_abs_flop_costs(flop_costs)
+
+
+def test_from_abs_flop_costs_with_zero_add_raises_value_error():
+    # --- arrange -----------------------------------------
+    flop_costs = {flop_type: 0.0 for flop_type in FlopType}
+
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match="non-zero"):
+        FlopWeights.from_abs_flop_costs(flop_costs)

--- a/tests/models/test_flop_weights.py
+++ b/tests/models/test_flop_weights.py
@@ -147,7 +147,7 @@ def test_from_abs_flop_costs_without_add_raises_value_error():
 
 def test_from_abs_flop_costs_with_zero_add_raises_value_error():
     # --- arrange -----------------------------------------
-    flop_costs = {flop_type: 0.0 for flop_type in FlopType}
+    flop_costs = dict.fromkeys(FlopType, 0.0)
 
     # --- act / assert ------------------------------------
     with pytest.raises(ValueError, match="non-zero"):


### PR DESCRIPTION
`set_active_flop_weights()` stores a deep copy, mirroring the value semantics the getter already provides, so mutating the instance you passed no longer silently reconfigures the package through a reference you still hold.

`FlopWeights.from_abs_flop_costs()` validates its reference operation up front and raises `ValueError` naming it and why it must be non-zero, instead of leaking a `KeyError` or `ZeroDivisionError` out of the normalization step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)