### PR TITLE
fix: export BuiltInData and correct four documentation inaccuracies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `BuiltInData` is now exported from the package root, so star imports and strict type checkers recognize it
 - a `FlopCountingContext` that is re-entered, or resumed outside its `with` block, no longer produces silently wrong counts
 - `set_active_flop_weights()` now stores a copy, so mutating the object you passed no longer changes the configured weights
 

--- a/docs/math_patching.md
+++ b/docs/math_patching.md
@@ -70,10 +70,16 @@ Every commonly used `math` function, and how it participates in counting:
 | **Instrumented** (patched, counts its FlopType) | `sqrt`, `cbrt`, `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `pow`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `hypot`, `fmod`, `fabs`, `fma` (Python 3.13+) |
 | **Counted via dunder** (no patch needed — do not expect these in the patch list) | `math.floor` / `math.ceil` / `math.trunc` → F2I through `__floor__`/`__ceil__`/`__trunc__`; the builtins `abs()` → ABS and `round()` → RND/F2I likewise count through their dunders |
 | **Not instrumented** (returns a plain, uncounted `float`) | `copysign`, `remainder`, `frexp`, `ldexp`, `modf`, `degrees`, `radians`, `dist`, `fsum`, `prod`, `gamma`, `lgamma`, `erf`, `erfc`, `nextafter`, `ulp` |
+| **Predicates** (uncounted, return a `bool`) | `isnan`, `isinf`, `isfinite`, `isclose` |
 
 The not-instrumented set breaks contagion: the plain-`float` result silently
 stops all downstream counting, so convert back with `CountedFloat(...)` if a
 result of these feeds counted computation.
+
+The predicates return a `bool` rather than a number, so contagion does not apply
+to them — but they are uncounted all the same. `math.isclose` is the one where
+that matters: it performs real arithmetic (a difference, absolute values, and a
+scaled tolerance comparison) and none of it is counted.
 
 `math.fma(x, y, z)` exists only from Python 3.13 on, and is patched exactly where
 it exists — on older interpreters there is no such function to call, and a

--- a/src/counted_float/__init__.py
+++ b/src/counted_float/__init__.py
@@ -14,6 +14,7 @@ from ._core.counting import BuiltInData, CountedFloat, FlopCountingContext, Paus
 from ._core.models import FlopCounts, FlopType, FlopWeights, Quantiles, SystemInfo
 
 __all__ = [
+    "BuiltInData",
     "CountedFloat",
     "FlopCountingContext",
     "FlopCounts",

--- a/src/counted_float/_core/counting/config/_config.py
+++ b/src/counted_float/_core/counting/config/_config.py
@@ -15,8 +15,9 @@ class Config:
 
     # these are the weights that are used to calculate weighted flop counts; update with
     # set_flop_weights(...).  None means "not initialized yet": the default consensus weights
-    # are computed lazily on first access, since deriving them parses every built-in data file
-    # (~0.8 s) — far too expensive to pay at import time for a feature many importers never use.
+    # are computed lazily on first access, since deriving them parses and aggregates every
+    # built-in data file — far too expensive to pay at import time for a feature many
+    # importers never use.
     __weights: FlopWeights | None = None
 
     # -------------------------------------------------------------------------

--- a/src/counted_float/_core/counting/config/_config.py
+++ b/src/counted_float/_core/counting/config/_config.py
@@ -16,8 +16,8 @@ class Config:
     # these are the weights that are used to calculate weighted flop counts; update with
     # set_flop_weights(...).  None means "not initialized yet": the default consensus weights
     # are computed lazily on first access, since deriving them parses and aggregates every
-    # built-in data file — far too expensive to pay at import time for a feature many
-    # importers never use.
+    # built-in data file — far too expensive to pay at import time for a feature some users
+    # might not have a need for.
     __weights: FlopWeights | None = None
 
     # -------------------------------------------------------------------------

--- a/src/counted_float/_core/models/_flop_counts.py
+++ b/src/counted_float/_core/models/_flop_counts.py
@@ -63,6 +63,8 @@ class FlopCounts:
         return FlopCounts(**{attr: getattr(self, attr) + getattr(other, attr) for attr in _FIELD_NAMES})
 
     def __sub__(self, other: FlopCounts) -> FlopCounts:
+        # raw element-wise difference: subtracting larger counts yields negative ones, which are
+        # meaningless as counts but are how a context derives its own total from two snapshots
         return FlopCounts(**{attr: getattr(self, attr) - getattr(other, attr) for attr in _FIELD_NAMES})
 
     # --- extract info ------------------------------------
@@ -80,7 +82,7 @@ class FlopCounts:
         Uses the provided weights in the computations.
         When omitted, the currently configured weights (see Config class) will be used.
         """
-        if not weights:
+        if weights is None:
             from counted_float._core.counting.config import get_active_flop_weights
 
             weights = get_active_flop_weights()

--- a/tests/counting/config/test_config.py
+++ b/tests/counting/config/test_config.py
@@ -48,8 +48,8 @@ def test_flop_weight_getters_return_defensive_copies(getter):
 
 
 def test_bare_import_does_not_parse_builtin_data():
-    # default consensus weights derive from every built-in data file (~0.8 s); that work
-    # must happen lazily on first weights access, not at import time
+    # default consensus weights derive from every built-in data file, which is far too
+    # expensive to pay at import time; that work must happen lazily on first weights access
     code = textwrap.dedent(
         """
         import sys

--- a/tests/shared/test_imports.py
+++ b/tests/shared/test_imports.py
@@ -1,25 +1,71 @@
+"""The public export surface of each importable module: everything ours is advertised, and resolves."""
+
 import importlib
+import json
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+PACKAGE = "counted_float"
+PUBLIC_MODULE_NAMES = [PACKAGE, f"{PACKAGE}.config", f"{PACKAGE}.benchmarking"]
+
+# Discovers the public names a module binds from our own package. Runs in a fresh interpreter on
+# purpose: importing any submodule anywhere in a process injects it as an attribute of its parent,
+# so in a shared process this would report submodules the module never imported itself.
+_DISCOVER_PUBLIC_NAMES = textwrap.dedent(
+    """
+    import importlib, json, sys
+
+    def defining_module(obj):
+        # where a class/function was defined, or a module's own name
+        return getattr(obj, "__module__", None) or getattr(obj, "__name__", "") or ""
+
+    module = importlib.import_module(sys.argv[1])
+    print(json.dumps({
+        "bound": sorted(
+            name for name, obj in vars(module).items()
+            if not name.startswith("_") and defining_module(obj).startswith("counted_float")
+        ),
+        "advertised": sorted(module.__all__),
+    }))
+    """
+)
 
 
-def test_import_all_counted_float():
-    """Check if importing all elements of __all__ from counted_float always works."""
-    from counted_float import __all__ as public_names
+@pytest.mark.parametrize("module_name", PUBLIC_MODULE_NAMES)
+def test_every_name_in_all_resolves(module_name: str):
+    # --- arrange -----------------------------------------
+    module = importlib.import_module(module_name)
 
-    for item in public_names:
-        _ = getattr(importlib.import_module("counted_float"), item)
-
-
-def test_import_all_counted_float_config():
-    """Check if importing all elements of __all__ from counted_float.config always works."""
-    from counted_float.config import __all__ as public_names
-
-    for item in public_names:
-        _ = getattr(importlib.import_module("counted_float.config"), item)
+    # --- act / assert ------------------------------------
+    for name in module.__all__:
+        assert getattr(module, name, None) is not None, f"{module_name}.__all__ advertises unresolvable '{name}'"
 
 
-def test_import_all_counted_float_benchmarking():
-    """Check if importing all elements of __all__ from counted_float.benchmarking always works."""
-    from counted_float.benchmarking import __all__ as public_names
+@pytest.mark.parametrize("module_name", PUBLIC_MODULE_NAMES)
+def test_every_public_name_from_this_package_is_advertised(module_name: str):
+    """Anything public a module imports from our own package must appear in its __all__.
 
-    for item in public_names:
-        _ = getattr(importlib.import_module("counted_float.benchmarking"), item)
+    The counterpart of the test above: that one catches an __all__ entry that no longer resolves,
+    this one catches a name that resolves but was never advertised. Importing such a name works
+    either way, so only star imports and re-export-strict type checkers would ever notice.
+
+    Names imported from outside the package (stdlib, third-party) are excluded -- re-exporting
+    those is not this package's business.
+    """
+    # --- arrange -----------------------------------------
+    result = subprocess.run(  # noqa: S603 -- fixed args, no user input
+        [sys.executable, "-c", _DISCOVER_PUBLIC_NAMES, module_name],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    surface = json.loads(result.stdout)
+
+    # --- act ---------------------------------------------
+    unadvertised = set(surface["bound"]) - set(surface["advertised"])
+
+    # --- assert ------------------------------------------
+    assert not unadvertised, f"{module_name} exposes {sorted(unadvertised)} but does not list them in __all__"


### PR DESCRIPTION
`BuiltInData` was imported at the package root and documented as public API on a published docs page, but was missing from `__all__` — so star imports skipped it and re-export-strict type checkers treated it as private.

Three doc corrections alongside it:

- The `math` coverage table gained a **Predicates** row. `isnan` / `isinf` / `isfinite` / `isclose` return `bool`, so they fitted neither existing row and were absent entirely — and `isclose` performs real arithmetic that goes uncounted, which a reader would want stated.
- `FlopCounts.__sub__` now says it is a raw element-wise difference that can go negative, rather than leaving that to be discovered.
- The comment justifying lazy weight derivation quoted a cost figure that had drifted by roughly a factor of three. It now describes the work instead of timing it, so it cannot rot again.

Also tightens a falsy-check on an optional argument to the `is None` test it actually means — correct today only because the model happens to define neither `__bool__` nor `__len__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)