### PR TITLE
test: guard the patch-table sync and numpy scalar counting

### DIFF
--- a/tests/counting/test_math_patching.py
+++ b/tests/counting/test_math_patching.py
@@ -534,3 +534,23 @@ def test_unbalanced_remove_math_patches_does_not_clobber_a_later_patch():
 
     # --- assert ------------------------------------------
     assert survived
+
+
+def test_capture_originals_keeps_both_original_tables_in_sync():
+    """Every patched function's delegation global must match its restoration entry.
+
+    The originals are captured twice over: a module global per function, which the counting
+    replacements delegate to, and a dict used to restore the module afterwards. Adding a patch
+    while forgetting its global leaves restoration working while delegation silently calls a
+    stale import-time reference, so nothing downstream would notice.
+    """
+    # --- act ---------------------------------------------
+    _math_patching._capture_originals()
+
+    # --- assert ------------------------------------------
+    for name in _math_patching._PATCHES:
+        delegation_target = getattr(_math_patching, f"original_math_{name}", None)
+        assert delegation_target is not None, f"no original_math_{name} global for patched '{name}'"
+        assert delegation_target is _math_patching._saved_originals[name], (
+            f"original_math_{name} does not match the restoration snapshot for '{name}'"
+        )

--- a/tests/counting/test_numpy_interop.py
+++ b/tests/counting/test_numpy_interop.py
@@ -1,0 +1,69 @@
+"""Interop with numpy scalars, for the direction whose counting semantics are settled.
+
+``np.float64`` subclasses ``float``, so with a ``CountedFloat`` on the left the operator is
+handled here: the flop is counted and the result stays a ``CountedFloat``. These tests pin that
+direction.
+
+With a numpy scalar on the left, numpy handles the operation instead and nothing is counted.
+That is a known gap rather than a contract, so it is deliberately not pinned here.
+"""
+
+import operator
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+from counted_float import CountedFloat, FlopCountingContext
+
+
+@pytest.mark.parametrize(
+    ("op", "flop_type_name"),
+    [
+        (operator.add, "ADD"),
+        (operator.sub, "SUB"),
+        (operator.mul, "MUL"),
+        (operator.truediv, "DIV"),
+    ],
+)
+def test_counted_float_on_the_left_of_a_numpy_scalar_counts_and_stays_counted(
+    op: Callable[[object, object], object], flop_type_name: str
+):
+    # --- arrange -----------------------------------------
+    counted = CountedFloat(6.0)
+    numpy_scalar = np.float64(3.0)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext() as fcc:
+        result = op(counted, numpy_scalar)
+
+    # --- assert ------------------------------------------
+    assert isinstance(result, CountedFloat)
+    assert getattr(fcc.flop_counts(), flop_type_name) == 1
+    assert fcc.flop_counts().total_count() == 1
+
+
+def test_counted_float_compared_against_a_numpy_scalar_counts():
+    # --- arrange -----------------------------------------
+    counted = CountedFloat(1.0)
+    numpy_scalar = np.float64(2.0)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext() as fcc:
+        result = counted < numpy_scalar
+
+    # --- assert ------------------------------------------
+    assert result is True
+    assert fcc.flop_counts().COMP == 1
+
+
+def test_counted_float_on_the_left_of_a_numpy_scalar_keeps_the_value_right():
+    # --- arrange -----------------------------------------
+    counted = CountedFloat(6.0)
+    numpy_scalar = np.float64(3.0)
+
+    # --- act ---------------------------------------------
+    quotient = counted / numpy_scalar
+
+    # --- assert ------------------------------------------
+    assert quotient == 2.0


### PR DESCRIPTION
Two invariants that hold today but that nothing enforces.

The math patching module captures each original twice — a module global per function, which the counting replacements delegate to, and a dict used to restore the module afterwards. Registering a patch while forgetting its global would leave restoration working while delegation silently called a stale import-time reference. The `fma` patch happened to get this right; nothing would have caught it if it hadn't. The test fails on either a forgotten global or a desynced entry (verified against both).

Also adds the package's first numpy interop tests. `np.float64` subclasses `float`, so with a `CountedFloat` on the left the flop is counted and the result stays counted — that direction is pinned here. The reflected direction is a known gap rather than a contract, and is deliberately left unpinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)