### PR TITLE
fix: read a missing flop weight back from JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- flop weights with missing data can be read back from JSON again; every built-in per-source weight set previously serialized to a document the library rejected
+
 ### Security
 
 ## 1.6.1 (2026-07-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- flop weights with missing data can be read back from JSON again; every built-in per-source weight set previously serialized to a document the library rejected
+- fix issue where NaN-valued flop weights would break a serialization round-trip
 
 ### Security
 

--- a/src/counted_float/_core/models/_flop_weights.py
+++ b/src/counted_float/_core/models/_flop_weights.py
@@ -59,6 +59,19 @@ class FlopWeights(MyBaseModel):
     # -------------------------------------------------------------------------
     #  Validation
     # -------------------------------------------------------------------------
+    @field_validator("weights", mode="before")
+    @classmethod
+    def accept_null_as_missing_weight(cls, v: object) -> object:
+        """Read a JSON `null` back as a missing (NaN) weight.
+
+        A missing weight is NaN in memory and serializes to `null` -- valid JSON, and what a strict
+        reader expects. Without this, the field type rejects that `null` on the way back in, so a
+        weights model with missing data could be written and never restored.
+        """
+        if isinstance(v, dict):
+            return {key: (math.nan if weight is None else weight) for key, weight in v.items()}
+        return v
+
     @field_validator("weights")
     @classmethod
     def ensure_all_flop_types_present(cls, v: dict[FlopType, float | int]) -> dict[FlopType, float | int]:

--- a/src/counted_float/_core/models/_flop_weights.py
+++ b/src/counted_float/_core/models/_flop_weights.py
@@ -65,8 +65,8 @@ class FlopWeights(MyBaseModel):
         """Read a JSON `null` back as a missing (NaN) weight.
 
         A missing weight is NaN in memory and serializes to `null` -- valid JSON, and what a strict
-        reader expects. Without this, the field type rejects that `null` on the way back in, so a
-        weights model with missing data could be written and never restored.
+        reader expects. This maps it back on the way in, so that weights with missing data survive a
+        serialization round-trip; the field type alone accepts only numbers.
         """
         if isinstance(v, dict):
             return {key: (math.nan if weight is None else weight) for key, weight in v.items()}

--- a/tests/models/test_flop_weights.py
+++ b/tests/models/test_flop_weights.py
@@ -2,6 +2,7 @@ import math
 
 import pytest
 
+from counted_float._core.counting import BuiltInData
 from counted_float._core.counting.config import get_builtin_flop_weights
 from counted_float._core.models import FlopType, FlopWeights
 
@@ -154,3 +155,31 @@ def test_from_abs_flop_costs_with_unusable_add_raises_value_error(ref_cost: floa
     # --- act / assert ------------------------------------
     with pytest.raises(ValueError, match="finite and positive"):
         FlopWeights.from_abs_flop_costs(flop_costs)
+
+
+def test_weights_with_missing_data_survive_a_json_round_trip():
+    # --- arrange -----------------------------------------
+    weights = FlopWeights(weights={FlopType.ADD: 1.0, FlopType.MUL: math.nan})
+
+    # --- act ---------------------------------------------
+    restored = FlopWeights.model_validate_json(weights.model_dump_json())
+
+    # --- assert ------------------------------------------
+    assert restored.weights[FlopType.ADD] == 1.0
+    assert math.isnan(restored.weights[FlopType.MUL])  # missing must stay missing, not become a number
+
+
+def test_every_builtin_source_survives_a_json_round_trip():
+    """Every built-in per-source weight set has missing data; none of them could be read back."""
+    # --- arrange -----------------------------------------
+    per_source_weights = BuiltInData.get_flop_weights_dict()
+
+    # --- act / assert ------------------------------------
+    for key, weights in per_source_weights.items():
+        restored = FlopWeights.model_validate_json(weights.model_dump_json())
+        for flop_type, weight in weights.weights.items():
+            restored_weight = restored.weights[flop_type]
+            if math.isnan(weight):
+                assert math.isnan(restored_weight), f"{key}: {flop_type.name} lost its missing marker"
+            else:
+                assert restored_weight == weight, f"{key}: {flop_type.name} changed value"

--- a/tests/models/test_flop_weights.py
+++ b/tests/models/test_flop_weights.py
@@ -170,7 +170,7 @@ def test_weights_with_missing_data_survive_a_json_round_trip():
 
 
 def test_every_builtin_source_survives_a_json_round_trip():
-    """Every built-in per-source weight set has missing data; none of them could be read back."""
+    """Every built-in per-source weight set has missing data, so all of them exercise the null path."""
     # --- arrange -----------------------------------------
     per_source_weights = BuiltInData.get_flop_weights_dict()
 


### PR DESCRIPTION
A missing weight is `NaN` in memory and serializes to JSON `null` — valid JSON, and what a strict reader expects. The field type accepts only numbers, so that `null` needs mapping back to `NaN` on the way in for weights with missing data to survive a round-trip.

This matters for real data: **every one of the 47 built-in per-source weight sets has missing data** (spec sheets don't list transcendentals; benchmarks don't cover conversions), and the public accessor returns all of them. Only the aggregated consensus avoids it, because imputation fills its gaps.

Handled on the reading side — the writer's output is already valid, already strict, and already what those 47 sources emit, so changing it would mean fighting the library's own format for something the reader can absorb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)