### PR TITLE
docs: document the show-data options and correct the Fraction limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix issue where NaN-valued flop weights would break a serialization round-trip
 - the flop-weight display no longer scatters missing weights among the measured ones
 - `FlopWeights.from_abs_flop_costs()` rejects a negative flop cost instead of silently producing a negative weight
+- the docs now list the `show-data` options and state the `Fraction` limitation accurately (it holds only with the `Fraction` on the right)
 
 ### Security
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,8 +39,14 @@ this way can be inspected, shared, or compared against the built-in entries.
 ## Show built-in data
 
 `show-data` renders the full weight hierarchy: every data source, aggregated
-bottom-up, across all 36 flop-type columns. That table is wide — an abbreviated
+bottom-up, with one column per flop type. That table is wide — an abbreviated
 slice (the ARM subtree, leading columns only) is shown here:
+
+Options:
+
+| Option | Description |
+|---|---|
+| `--key-filter TEXT` | Show only the sources whose key contains `TEXT` — e.g. `--key-filter arm` for the ARM subtree, or `--key-filter benchmarks` for measured sources only. Defaults to showing everything. `--key_filter` is accepted as well. |
 
 ```
 [~] counted_float show-data

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -18,10 +18,13 @@
   interpreters, where `math.fma` does not exist
 - mixed operations with non-float numeric types are outside the counting
   model: `CountedFloat` delegates to the other operand exactly like `float`
-  does, so e.g. a `fractions.Fraction` operand generally yields a correct but
-  plain — and uncounted — `float` result (downstream counting stops), while a
-  `decimal.Decimal` operand raises `TypeError` just as with plain `float`.
-  Numerical algorithms should use `float`/`CountedFloat` values throughout.
+  does, so e.g. `CountedFloat(x) * Fraction(1, 2)` yields a correct but plain —
+  and uncounted — `float` result (downstream counting stops). The reverse order
+  counts normally: `Fraction` hands the operation back, and the `CountedFloat`
+  performs it. A `decimal.Decimal` operand raises `TypeError` just as with plain
+  `float`, in either order. Numerical algorithms should use
+  `float`/`CountedFloat` values throughout, rather than relying on which side an
+  operand happens to sit.
 - counting state is process-global and **not thread-safe or async-safe**:
   concurrent counted computations interfere with each other's counts (and on
   free-threaded Python builds concurrent increments can be lost), so run one


### PR DESCRIPTION
Three documentation inaccuracies.

**The CLI page documented `show-data` but none of its options**, so its key filter — which exists, is tested, and accepts two spellings — appeared nowhere a reader would look for it.

**The `Fraction` limitation was stated as unconditional.** It holds with the `Fraction` on the right (`CountedFloat * Fraction` -> plain, uncounted `float`), but with it on the left the operation counts normally, because `Fraction` hands it back. So the documented limitation was true of half the cases and false of the other half. Verified all four combinations against real behavior, including that `Decimal` raises in *either* order.

The behavior itself is untouched: making both directions agree changes counts, which a patch cannot do.

**A stale count**: the page claimed the table spans "all 36 flop-type columns"; there are 37 since `FMA` landed. Dropped rather than corrected — the enum is the count, and restating it is what let it drift in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)