### PR TITLE
test: add property coverage for the geo-mean and imputation helpers

### DIFF
--- a/tests/utils/test_geo_mean.py
+++ b/tests/utils/test_geo_mean.py
@@ -1,6 +1,8 @@
 import math
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from counted_float._core.utils import geo_mean
 
@@ -35,3 +37,51 @@ def test_geo_mean_rejects_degenerate_input(values: list):
     # --- act & assert ------------------------------------
     with pytest.raises(ValueError, match="geo_mean"):
         geo_mean(values)
+
+
+# =================================================================================================
+#  Property-based coverage
+# =================================================================================================
+_positive = st.floats(min_value=1e-6, max_value=1e12, allow_nan=False, allow_infinity=False)
+
+
+@given(values=st.lists(_positive, min_size=1, max_size=20))
+def test_geo_mean_lies_between_the_min_and_max(values: list[float]):
+    # --- act ---------------------------------------------
+    result = geo_mean(values)
+
+    # --- assert ------------------------------------------
+    assert min(values) <= result <= max(values) or math.isclose(result, min(values), rel_tol=1e-9)
+
+
+@given(value=_positive, n=st.integers(min_value=1, max_value=20))
+def test_geo_mean_of_a_constant_list_is_that_constant(value: float, n: int):
+    # --- act / assert ------------------------------------
+    assert math.isclose(geo_mean([value] * n), value, rel_tol=1e-9)
+
+
+@given(values=st.lists(_positive, min_size=1, max_size=15), factor=_positive)
+def test_geo_mean_scales_with_its_inputs(values: list[float], factor: float):
+    """geo_mean(k*x) == k*geo_mean(x): a homogeneity the weighting relies on."""
+    # --- act ---------------------------------------------
+    scaled = geo_mean([factor * v for v in values])
+
+    # --- assert ------------------------------------------
+    assert math.isclose(scaled, factor * geo_mean(values), rel_tol=1e-9)
+
+
+@given(values=st.lists(_positive, min_size=1, max_size=20))
+def test_geo_mean_does_not_exceed_the_arithmetic_mean(values: list[float]):
+    """The AM-GM inequality: a basic sanity bound the log-space form must still respect."""
+    # --- act ---------------------------------------------
+    arithmetic_mean = sum(values) / len(values)
+
+    # --- assert ------------------------------------------
+    # relative slack: at large magnitudes the two means differ only in float-noise digits
+    assert geo_mean(values) <= arithmetic_mean * (1 + 1e-9)
+
+
+@given(values=st.lists(_positive, min_size=1, max_size=10))
+def test_a_single_zero_makes_the_geo_mean_zero(values: list[float]):
+    # --- act / assert ------------------------------------
+    assert geo_mean([*values, 0.0]) == 0.0

--- a/tests/utils/test_missing_data.py
+++ b/tests/utils/test_missing_data.py
@@ -1,6 +1,8 @@
 import math
 
 import numpy as np
+from hypothesis import given
+from hypothesis import strategies as st
 
 from counted_float._core.utils import impute_missing_data
 
@@ -112,3 +114,82 @@ def test_impute_missing_data_mixed_case():
 
     # --- assert ------------------------------------------
     assert np.allclose(filled_data, expected, rtol=1e-10, atol=1e-10, equal_nan=True)
+
+
+# =================================================================================================
+#  Property-based coverage
+# =================================================================================================
+# a filled cell has no ground truth to check against, so these pin structural invariants rather than
+# values: what the imputation must never do, and the one case where it must reproduce the input.
+_finite = st.floats(min_value=0.01, max_value=1e6, allow_nan=False, allow_infinity=False)
+
+
+@st.composite
+def _rank1_matrices(draw):
+    """A strictly-positive rank-1 matrix (outer product of two positive vectors)."""
+    n_rows = draw(st.integers(min_value=1, max_value=6))
+    n_cols = draw(st.integers(min_value=1, max_value=6))
+    rows = np.array(draw(st.lists(_finite, min_size=n_rows, max_size=n_rows)))
+    cols = np.array(draw(st.lists(_finite, min_size=n_cols, max_size=n_cols)))
+    return np.outer(rows, cols)
+
+
+@given(matrix=_rank1_matrices(), mask=st.data())
+def test_an_exactly_rank1_matrix_is_recovered(matrix: np.ndarray, mask):
+    """The model is rank-1, so a rank-1 input must be reproduced at its missing cells."""
+    # --- arrange -----------------------------------------
+    holed = matrix.copy()
+    n_rows, n_cols = matrix.shape
+    # knock out one interior cell, leaving its row and col with evidence so it is fillable
+    if n_rows >= 2 and n_cols >= 2:
+        i = mask.draw(st.integers(min_value=0, max_value=n_rows - 1))
+        j = mask.draw(st.integers(min_value=0, max_value=n_cols - 1))
+        holed[i, j] = np.nan
+
+        # --- act -----------------------------------------
+        filled = impute_missing_data(holed)
+
+        # --- assert --------------------------------------
+        assert math.isclose(filled[i, j], matrix[i, j], rel_tol=1e-6)
+
+
+@given(matrix=_rank1_matrices())
+def test_present_values_are_left_untouched(matrix: np.ndarray):
+    # --- arrange -----------------------------------------
+    holed = matrix.copy()
+    if matrix.size >= 2:
+        holed.flat[0] = np.nan
+
+    # --- act ---------------------------------------------
+    filled = impute_missing_data(holed)
+
+    # --- assert ------------------------------------------
+    present = ~np.isnan(holed)
+    assert np.allclose(filled[present], matrix[present])
+
+
+@given(matrix=_rank1_matrices())
+def test_fills_are_never_negative(matrix: np.ndarray):
+    # --- arrange -----------------------------------------
+    holed = matrix.copy()
+    if matrix.size >= 2:
+        holed.flat[0] = np.nan
+
+    # --- act ---------------------------------------------
+    filled = impute_missing_data(holed)
+
+    # --- assert ------------------------------------------
+    filled_cells = filled[~np.isnan(filled)]
+    assert np.all(filled_cells >= 0)
+
+
+def test_a_cell_with_no_row_or_column_evidence_stays_missing():
+    # --- arrange -----------------------------------------
+    # the whole first row is missing, so its cells have no row evidence to lean on
+    data = np.array([[np.nan, np.nan], [3.0, 6.0]])
+
+    # --- act ---------------------------------------------
+    filled = impute_missing_data(data)
+
+    # --- assert ------------------------------------------
+    assert np.all(np.isnan(filled[0, :]))  # unfillable cells are left as-is, not invented


### PR DESCRIPTION
The two genuinely numerical functions in the package — the geometric mean and the rank-1 missing-data imputation — were covered only point-by-point, and they are exactly the two whose edge behavior is entirely arithmetic.

`geo_mean` is pinned by its mathematical invariants: the result lies between the min and max, a constant list returns that constant, it is homogeneous under scaling (`geo_mean(k·x) == k·geo_mean(x)`), it never exceeds the arithmetic mean, and a single zero zeroes it.

The imputation is pinned **structurally**, because a filled cell has no ground truth to compare against: a matrix that is already exactly rank-1 must be recovered, present values must be left untouched, fills must never go negative, and a cell whose row or column carries no evidence must stay missing rather than be invented.

Writing these surfaced one genuine subtlety — the AM-GM property needs a relative tolerance, since at large magnitudes the two means differ only in float-noise digits. Caught by hypothesis, not by me. 1003 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)