### PR TITLE
chore: run the unit tests on macOS and Windows too

### DIFF
--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -8,25 +8,28 @@ permissions:
 
 jobs:
   core:
-    name: py${{ matrix.python }} / ${{ matrix.resolution }} / numba-${{ matrix.all_extras }}
-    runs-on: ubuntu-latest
+    name: py${{ matrix.python }} / ${{ matrix.resolution }} / numba-${{ matrix.all_extras }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        # ubuntu-only: OS-dependent paths (CPU-freq detection, numba JIT) are
-        # exercised by the manual benchmark workflows on real hardware; core
-        # flop-counting is pure Python. Strategic combos cover every axis
-        # (all four Pythons, both resolution ends, numba on/off at the extremes)
-        # rather than their full product.
+        # Core flop-counting is pure Python, so most combos run on ubuntu. But the CPU-freq
+        # detection (psutil) and system-info collection (cpuinfo) paths are OS-dependent, and a
+        # dependency bump can change their behavior on macOS or Windows -- so one leg on each keeps
+        # those paths on the pull-request gate rather than only in the manual benchmark workflows.
+        # Combos cover every axis (all four Pythons, both resolution ends, numba on/off, all three
+        # OSes) strategically rather than as a full product.
         include:
-          - { python: "3.11", resolution: highest,       all_extras: "true"  }
-          - { python: "3.12", resolution: highest,       all_extras: "true"  }
-          - { python: "3.13", resolution: highest,       all_extras: "true"  }
-          - { python: "3.14", resolution: highest,       all_extras: "true"  }
-          - { python: "3.11", resolution: lowest-direct, all_extras: "true"  }
-          - { python: "3.14", resolution: lowest-direct, all_extras: "true"  }
-          - { python: "3.11", resolution: highest,       all_extras: "false" }  # numba-absent shim
-          - { python: "3.14", resolution: highest,       all_extras: "false" }  # numba-absent shim
+          - { os: ubuntu-latest,  python: "3.11", resolution: highest,       all_extras: "true"  }
+          - { os: ubuntu-latest,  python: "3.12", resolution: highest,       all_extras: "true"  }
+          - { os: ubuntu-latest,  python: "3.13", resolution: highest,       all_extras: "true"  }
+          - { os: ubuntu-latest,  python: "3.14", resolution: highest,       all_extras: "true"  }
+          - { os: ubuntu-latest,  python: "3.11", resolution: lowest-direct, all_extras: "true"  }
+          - { os: ubuntu-latest,  python: "3.14", resolution: lowest-direct, all_extras: "true"  }
+          - { os: ubuntu-latest,  python: "3.11", resolution: highest,       all_extras: "false" }  # numba-absent shim
+          - { os: ubuntu-latest,  python: "3.14", resolution: highest,       all_extras: "false" }  # numba-absent shim
+          - { os: macos-latest,   python: "3.13", resolution: highest,       all_extras: "true"  }  # OS-dependent CPU paths
+          - { os: windows-latest, python: "3.13", resolution: highest,       all_extras: "true"  }  # OS-dependent CPU paths
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
The OS-dependent paths — CPU-frequency detection through psutil, system-info collection through cpuinfo — were only ever verified against Linux behavior on a pull request. Their behavior elsewhere ran only in the manual benchmark workflows, so a dependency bump that changed psutil on macOS or Windows sat undetected until someone dispatched a benchmark there.

One macOS leg and one Windows leg, each at a single Python, put those paths on the PR gate. Following the matrix's existing principle — strategic combinations, not a full product — the gap is OS-dependent, not version-dependent, so one version per added OS covers it. Standard runners are free on a public repo, so the cost is wall-clock on the gate rather than budget.

No test changes: the existing tests already assert the right shape for machine-dependent readings (each frequency absent or positive, min not exceeding max) and drive the real psutil and cpuinfo paths. The legs run those assertions where the libraries behave differently. The matrix comment, which had justified ubuntu-only on exactly these grounds, is rewritten to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)