### PR TITLE
test: pin Timer against a scripted clock instead of a sleep

### DIFF
--- a/tests/utils/test_timer.py
+++ b/tests/utils/test_timer.py
@@ -1,37 +1,112 @@
+"""Timer's own logic: two clock readings, their difference, and the conversion to seconds.
+
+Most of these drive a scripted clock rather than sleeping. Timer reads the wall clock through
+time.perf_counter_ns(), so feeding it known readings pins its arithmetic exactly -- and keeps the
+suite from asserting on how promptly the OS reschedules a sleeping thread, which no library
+controls and which a saturated CI runner readily breaks. One test at the bottom does exercise the
+real clock, so that faking cannot hide a Timer that never reads one.
+"""
+
 import time
 
 import pytest
 
 from counted_float._core.utils import Timer
 
+_START_NS = 1_000_000
 
-@pytest.mark.flaky(reruns=5)  # wall-clock assertions can drift on a loaded CI runner
-def test_timer():
+
+@pytest.fixture
+def scripted_clock(monkeypatch) -> list[int]:
+    """Make perf_counter_ns() return each value appended to the returned list, in order."""
+    readings: list[int] = []
+    values = iter(readings)
+    monkeypatch.setattr(time, "perf_counter_ns", lambda: next(values))
+    return readings
+
+
+# =================================================================================================
+#  Elapsed time
+# =================================================================================================
+@pytest.mark.parametrize(
+    ("elapsed_ns", "expected_sec"),
+    [
+        (250_000_000, 0.25),
+        (1_000_000_000, 1.0),
+        (1, 1e-9),
+        (0, 0.0),
+    ],
+)
+def test_elapsed_is_the_difference_between_the_readings(scripted_clock, elapsed_ns: int, expected_sec: float):
+    # --- arrange -----------------------------------------
+    scripted_clock += [_START_NS, _START_NS + elapsed_ns]
+    timer = Timer()
+
+    # --- act ---------------------------------------------
+    with timer:
+        pass
+
+    # --- assert ------------------------------------------
+    assert timer.t_elapsed_nsec() == elapsed_ns
+    assert timer.t_elapsed_sec() == expected_sec  # exact: seconds are nanoseconds / 1e9
+
+
+def test_elapsed_is_frozen_once_the_block_exits(scripted_clock):
+    # --- arrange -----------------------------------------
+    scripted_clock += [_START_NS, _START_NS + 500_000_000, _START_NS + 9_000_000_000]
+    timer = Timer()
+
+    # --- act ---------------------------------------------
+    with timer:
+        pass
+    later_reading = timer.t_elapsed_nsec()  # clock has moved on by 9s; the timer must not follow
+
+    # --- assert ------------------------------------------
+    assert later_reading == 500_000_000
+
+
+def test_a_running_timer_tracks_the_clock(scripted_clock):
+    # --- arrange -----------------------------------------
+    scripted_clock += [_START_NS, _START_NS + 200_000_000, _START_NS + 700_000_000, _START_NS + 700_000_000]
+    timer = Timer()
+
+    # --- act ---------------------------------------------
+    with timer:
+        while_running = [timer.t_elapsed_nsec(), timer.t_elapsed_nsec()]
+
+    # --- assert ------------------------------------------
+    assert while_running == [200_000_000, 700_000_000]
+
+
+def test_reading_a_timer_that_never_started_raises():
     # --- arrange -----------------------------------------
     timer = Timer()
 
-    # --- assert 1 ----------------------------------------
-    with pytest.raises(RuntimeError):
+    # --- act / assert ------------------------------------
+    with pytest.raises(RuntimeError, match="not been started"):
+        timer.t_elapsed_nsec()
+
+    with pytest.raises(RuntimeError, match="not been started"):
         timer.t_elapsed_sec()
 
-    # --- act ---------------------------------------------
-    with timer:
-        time.sleep(0.1)
 
-    # --- assert ------------------------------------------
-    assert 0.05 < timer.t_elapsed_sec() < 0.15, "t_elapsed_sec() result incorrect."
-    assert 50_000_000 < timer.t_elapsed_nsec() < 150_000_000, "t_elapsed_nsec() result incorrect."
+# =================================================================================================
+#  Against the real clock
+# =================================================================================================
+def test_timer_measures_the_real_clock():
+    """Insurance against the scripted clock hiding a Timer that reads no clock at all.
 
-
-def test_timer_running():
+    Asserts only a floor: sleep() guarantees a minimum, never a maximum, and how long the OS takes
+    to reschedule the woken thread is not something Timer promises anything about.
+    """
     # --- arrange -----------------------------------------
     timer = Timer()
 
     # --- act ---------------------------------------------
     with timer:
-        t_before = timer.t_elapsed_sec()
-        time.sleep(0.1)
-        t_after = timer.t_elapsed_sec()
+        time.sleep(0.01)
 
     # --- assert ------------------------------------------
-    assert t_after >= t_before + 0.05, "t_elapsed_sec() did not increase while timer was running."
+    assert timer.t_elapsed_sec() >= 0.01
+    assert timer.t_elapsed_nsec() >= 10_000_000
+    assert timer.t_elapsed_nsec() == pytest.approx(timer.t_elapsed_sec() * 1e9)


### PR DESCRIPTION
Fixes the red `main`: `test_timer` failed on the macOS leg with `assert 0.236904458 < 0.15`.

## Why it broke, and why macOS specifically

Not a slow runner — the two runs' timing profiles are near-identical (9.59s vs 9.63s on the heaviest test). It's core saturation:

```
macOS:  created: 3/3 workers   <- 3 workers on 3 physical cores, no SMT  = zero headroom
ubuntu: created: 2/2 workers   <- 2 workers on 2 physical cores, 4 logical = 2x headroom
```

`addopts = "-n auto"` gives one xdist worker per *physical* core. On the M1 all three cores are saturated, so when `sleep(0.1)` expires the woken thread queues behind sibling workers mid-numba-JIT — long, CPU-bound bursts. 137 ms late. On ubuntu there's a free hyperthread to land on.

That explains the intermittency (`--dist worksteal` shuffles which tests share a worker window), why only this test broke (it's the only one measuring wall-clock across a *scheduling* boundary — everything else measures CPU-bound work, equally fast under saturation), and why all five reruns burned (they fire inside the same contention window).

## The fix

The old upper bound asserted on the OS scheduler, which the library neither controls nor promises. `Timer`'s actual logic is two clock reads, a subtraction, a divide by 1e9, and a not-started guard.

So the tests now script the clock via `perf_counter_ns` and assert **exactly**, instantly, and unconditionally. That also covers two behaviors the sleep version never tested: that the value **freezes** on exit, and that a **running** timer tracks the clock.

One real-clock test remains, so faking can't hide a `Timer` that reads no clock — asserting only a floor, since `sleep` guarantees a minimum and never a maximum. The `flaky(reruns=5)` mark is deleted rather than raised: no amount of load can move these bounds.

Verified by mutation — wrong unit conversion, non-freezing `__exit__`, reversed subtraction, and a removed guard are each caught. The old test caught only the first two.

## Flagged, not fixed here

`tests/benchmarking/micro/test_micro_benchmark.py` carries the same `flaky(reruns=5)` mark and the same comment, and asserts `t_elapsed < 1.25 * target` plus two quantile bounds on measured per-exec times. It is the same class of landmine on the same runner. It's a harder problem — that test's subject genuinely *is* wall-clock behavior — so it wants its own think rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)