### PR TITLE
test: pin the micro-benchmark loop against a fake clock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ dev = [
     "pre-commit>=4.0",
     "pytest>=8.0",
     "pytest-cov>=6.0",
-    "pytest-rerunfailures>=15.0",
     "pytest-xdist>=3.5.0",
     # exact tool versions are pinned by the tracked uv.lock (used by pre-commit,
     # `make lint`, and CI); these ranges just set the floor.

--- a/tests/benchmarking/micro/test_micro_benchmark.py
+++ b/tests/benchmarking/micro/test_micro_benchmark.py
@@ -1,3 +1,13 @@
+"""MicroBenchmark.run_many's control logic: adaptive sizing, the warmup split, and quantile stats.
+
+The subject is a feedback controller -- each run rescales n_executions from the previous run's
+Timer reading toward the per-run time target. Timing enters only through time.perf_counter_ns(),
+so most of these tests drive a fake clock that only the benchmark's simulated work advances:
+every assertion is exact and immune to a loaded runner. One test at the bottom does exercise the
+real clock, asserting only a floor, so faking cannot hide a benchmark loop that never times
+anything.
+"""
+
 import time
 
 import pytest
@@ -5,84 +15,181 @@ import pytest
 from counted_float._core.benchmarking._output import output_quiet
 from counted_float._core.benchmarking.micro import MicroBenchmark
 from counted_float._core.models import MicroBenchmarkResult
-from counted_float._core.utils import Timer
 
 
-class DummyMicroBenchmark(MicroBenchmark):
-    """Dummy benchmark for testing purposes."""
+# =================================================================================================
+#  Fake clock & simulated benchmarks
+# =================================================================================================
+class FakeClock:
+    """perf_counter_ns() stand-in that only moves when simulated work advances it."""
 
-    def __init__(self, nsecs_per_execution: float):
-        super().__init__(name="dummy")
-        self.__nsecs_per_execution = nsecs_per_execution
-        self.n_calls_prepare_benchmark = 0
-        self.n_calls_run_benchmark = 0
+    def __init__(self) -> None:
+        self.now_ns = 1_000_000
+
+    def advance(self, nsecs: float) -> None:
+        self.now_ns += int(nsecs)
+
+    def read(self) -> int:
+        return self.now_ns
+
+
+@pytest.fixture
+def fake_clock(monkeypatch) -> FakeClock:
+    """Route every Timer reading to a FakeClock and return it."""
+    clock = FakeClock()
+    monkeypatch.setattr(time, "perf_counter_ns", clock.read)
+    return clock
+
+
+class ClockAdvancingBenchmark(MicroBenchmark):
+    """Simulates nsecs_per_execution of work per execution by advancing the fake clock."""
+
+    def __init__(self, clock: FakeClock, nsecs_per_execution: float):
+        super().__init__(name="fake")
+        self.nsecs_per_execution = nsecs_per_execution
+        self.n_executions_per_run: list[int] = []  # doubles as the _prepare_benchmark call log
+        self._clock = clock
         self._n_executions = 1
 
     def _prepare_benchmark(self, n_executions: int):
-        self.n_calls_prepare_benchmark += 1
+        self._n_executions = n_executions
+        self.n_executions_per_run.append(n_executions)
+
+    def _run_benchmark(self):
+        self._clock.advance(self.nsecs_per_execution * self._n_executions)
+
+
+class BusyWaitBenchmark(MicroBenchmark):
+    """Performs real work: busy-waits nsecs_per_execution of real wall-clock time per execution."""
+
+    def __init__(self, nsecs_per_execution: float):
+        super().__init__(name="busy-wait")
+        self.nsecs_per_execution = nsecs_per_execution
+        self._n_executions = 1
+
+    def _prepare_benchmark(self, n_executions: int):
         self._n_executions = n_executions
 
     def _run_benchmark(self):
-        self.n_calls_run_benchmark += 1
-        self.__sleep(self.__nsecs_per_execution * self._n_executions)  # simulate some work based on n_executions
-
-    @staticmethod
-    def __sleep(t_sleep_ns: float):
-        # more accurate implementation that time.sleep(...)
         t_start = time.perf_counter_ns()
-        while (time.perf_counter_ns() - t_start) < t_sleep_ns:
+        while (time.perf_counter_ns() - t_start) < self.nsecs_per_execution * self._n_executions:
             pass
 
 
-@pytest.mark.flaky(reruns=5)  # wall-clock assertions can drift on a loaded CI runner
-@pytest.mark.parametrize(
-    ("n_runs_total", "n_runs_warmup", "n_seconds_per_run_target"),
-    [
-        (20, 10, 0.01),
-        (20, 5, 0.01),
-        (15, 5, 0.02),
-        (10, 5, 0.03),
-    ],
-)
-def test_micro_benchmark(n_runs_total: int, n_runs_warmup: int, n_seconds_per_run_target: float):
+# =================================================================================================
+#  Adaptive sizing of n_executions
+# =================================================================================================
+def test_run_many_ramps_n_executions_to_the_target(fake_clock):
+    """Growth is clamped to MAX_N_EXECUTIONS_FACTOR per step, then holds at the converged size."""
     # --- arrange -----------------------------------------
-    nsec_per_exec = 1_000
-    benchmark = DummyMicroBenchmark(nsecs_per_execution=nsec_per_exec)
-
-    expected_run_time_range = [
-        0.75 * n_seconds_per_run_target * (n_runs_total - n_runs_warmup),  # minimum expected time
-        1.25 * n_seconds_per_run_target * n_runs_total,  # maximum expected time
-    ]
+    benchmark = ClockAdvancingBenchmark(fake_clock, nsecs_per_execution=1_000)
 
     # --- act ---------------------------------------------
-    with Timer() as t:
-        results = benchmark.run_many(
-            n_runs_total=n_runs_total,
-            n_runs_warmup=n_runs_warmup,
-            n_seconds_per_run_target=n_seconds_per_run_target,
-        )
-
-    t_elapsed = t.t_elapsed_sec()
+    benchmark.run_many(n_runs_total=20, n_runs_warmup=5, n_seconds_per_run_target=0.01)
 
     # --- assert ------------------------------------------
-    assert benchmark.n_calls_prepare_benchmark == n_runs_total
-    assert benchmark.n_calls_run_benchmark == n_runs_total
-    assert expected_run_time_range[0] < t_elapsed < expected_run_time_range[1], "expected run time mismatch"
+    # 0.01 s target / 1 us per execution converges at 10_000; the ramp toward it is bounded
+    # by the 10x per-step growth clamp
+    assert benchmark.n_executions_per_run == [1, 10, 100, 1_000] + [10_000] * 16
+
+
+def test_run_many_shrinks_n_executions_when_the_cost_jumps(fake_clock):
+    """A run overshooting the target shrinks the next run, clamped to the same factor."""
+
+    # --- arrange -----------------------------------------
+    class CostJumpBenchmark(ClockAdvancingBenchmark):
+        """Cost per execution jumps 1000x from the seventh run onward."""
+
+        def _prepare_benchmark(self, n_executions: int):
+            if len(self.n_executions_per_run) == 6:
+                self.nsecs_per_execution = 1_000_000
+            super()._prepare_benchmark(n_executions)
+
+    benchmark = CostJumpBenchmark(fake_clock, nsecs_per_execution=1_000)
+
+    # --- act ---------------------------------------------
+    benchmark.run_many(n_runs_total=12, n_runs_warmup=5, n_seconds_per_run_target=0.01)
+
+    # --- assert ------------------------------------------
+    # up-ramp as before; the 1000x cost jump at run 6 overshoots the target 1000x, and the
+    # controller walks back down 10x per step until it re-converges at 10
+    assert benchmark.n_executions_per_run == [1, 10, 100, 1_000, 10_000, 10_000, 10_000, 1_000, 100, 10, 10, 10]
+
+
+def test_run_many_flat_runtime_respects_the_cap(fake_clock):
+    """A runtime that stays flat as n_executions grows (dead-code-eliminated kernel) drives
+    unbounded growth, which must stop at MAX_N_EXECUTIONS."""
+
+    # --- arrange -----------------------------------------
+    class FlatRuntimeBenchmark(ClockAdvancingBenchmark):
+        """Takes 1 ns per run regardless of n_executions."""
+
+        def _run_benchmark(self):
+            self._clock.advance(1)
+
+    benchmark = FlatRuntimeBenchmark(fake_clock, nsecs_per_execution=0)
+
+    # --- act ---------------------------------------------
+    benchmark.run_many(n_runs_total=15, n_runs_warmup=5, n_seconds_per_run_target=0.1)
+
+    # --- assert ------------------------------------------
+    assert benchmark.n_executions_per_run == [10 ** min(i, 12) for i in range(15)]
+    assert max(benchmark.n_executions_per_run) == MicroBenchmark.MAX_N_EXECUTIONS
+
+
+# =================================================================================================
+#  Warmup split & quantile stats
+# =================================================================================================
+@pytest.mark.parametrize(
+    ("n_runs_total", "n_runs_warmup"),
+    [
+        (20, 10),
+        (20, 5),
+        (10, 3),
+    ],
+)
+def test_run_many_splits_warmup_from_benchmark_runs(fake_clock, n_runs_total: int, n_runs_warmup: int):
+    # --- arrange -----------------------------------------
+    benchmark = ClockAdvancingBenchmark(fake_clock, nsecs_per_execution=1_000)
+
+    # --- act ---------------------------------------------
+    results = benchmark.run_many(
+        n_runs_total=n_runs_total,
+        n_runs_warmup=n_runs_warmup,
+        n_seconds_per_run_target=0.01,
+    )
+
+    # --- assert ------------------------------------------
     assert isinstance(results, MicroBenchmarkResult)
-    assert len(results.benchmark_runs) == n_runs_total - n_runs_warmup
+    assert len(benchmark.n_executions_per_run) == n_runs_total
     assert len(results.warmup_runs) == n_runs_warmup
-    assert results.summary_stats_nsecs_per_exec().q25 < 1.1 * nsec_per_exec, (
-        "estimated time range should approx. enclose actual time"
-    )
-    assert results.summary_stats_nsecs_per_exec().q75 > 0.9 * nsec_per_exec, (
-        "estimated time range should approx. enclose actual time"
-    )
+    assert len(results.benchmark_runs) == n_runs_total - n_runs_warmup
+    # the warmup runs are the *first* runs, in order
+    assert [r.n_executions for r in results.warmup_runs] == benchmark.n_executions_per_run[:n_runs_warmup]
+    assert [r.n_executions for r in results.benchmark_runs] == benchmark.n_executions_per_run[n_runs_warmup:]
 
 
-def test_micro_benchmark_run_many_console_verbosity(capsys):
+def test_run_many_stats_recover_the_cost_per_execution(fake_clock):
+    # --- arrange -----------------------------------------
+    nsecs_per_execution = 1_000
+    benchmark = ClockAdvancingBenchmark(fake_clock, nsecs_per_execution=nsecs_per_execution)
+
+    # --- act ---------------------------------------------
+    results = benchmark.run_many(n_runs_total=20, n_runs_warmup=5, n_seconds_per_run_target=0.01)
+
+    # --- assert ------------------------------------------
+    # every run measures exactly nsecs_per_execution per execution, so all quantiles equal it
+    stats = results.summary_stats_nsecs_per_exec()
+    assert stats.q25 == stats.q50 == stats.q75 == nsecs_per_execution
+
+
+# =================================================================================================
+#  Console output
+# =================================================================================================
+def test_run_many_console_verbosity(capsys):
     """run_many prints per-run progress by default and is fully silent under output_quiet."""
     # --- arrange ----------------------
-    benchmark = DummyMicroBenchmark(nsecs_per_execution=1_000)
+    benchmark = BusyWaitBenchmark(nsecs_per_execution=1_000)
 
     # --- act / assert -----------------
     benchmark.run_many(n_runs_total=4, n_runs_warmup=1, n_seconds_per_run_target=0.001)
@@ -93,29 +200,22 @@ def test_micro_benchmark_run_many_console_verbosity(capsys):
     assert capsys.readouterr().out == ""  # silenced: nothing reaches stdout
 
 
-class FlatRuntimeMicroBenchmark(MicroBenchmark):
-    """Benchmark whose runtime does not scale with n_executions, mimicking a dead-code-eliminated kernel."""
+# =================================================================================================
+#  Against the real clock
+# =================================================================================================
+def test_run_many_measures_the_real_clock():
+    """Insurance against the fake clock hiding a benchmark loop that never times anything.
 
-    def __init__(self):
-        super().__init__(name="flat")
-        self.max_n_executions_seen = 0
-
-    def _prepare_benchmark(self, n_executions: int):
-        self.max_n_executions_seen = max(self.max_n_executions_seen, n_executions)
-
-    def _run_benchmark(self):
-        pass
-
-
-def test_micro_benchmark_flat_runtime_respects_cap():
+    Asserts only a floor: the busy-wait guarantees a minimum of real elapsed time per execution,
+    never a maximum, and how far a loaded runner overshoots is not something run_many promises
+    anything about.
+    """
     # --- arrange -----------------------------------------
-    benchmark = FlatRuntimeMicroBenchmark()
+    nsecs_per_execution = 1_000
+    benchmark = BusyWaitBenchmark(nsecs_per_execution=nsecs_per_execution)
 
     # --- act ---------------------------------------------
-    # default-like parameters; a flat runtime makes the adaptive sizing grow n_executions
-    # by MAX_N_EXECUTIONS_FACTOR every run, which must stop at MAX_N_EXECUTIONS
-    results = benchmark.run_many(n_runs_total=40, n_runs_warmup=15, n_seconds_per_run_target=0.1)
+    results = benchmark.run_many(n_runs_total=5, n_runs_warmup=2, n_seconds_per_run_target=0.001)
 
     # --- assert ------------------------------------------
-    assert isinstance(results, MicroBenchmarkResult)
-    assert benchmark.max_n_executions_seen == MicroBenchmark.MAX_N_EXECUTIONS
+    assert results.summary_stats_nsecs_per_exec().q25 >= nsecs_per_execution

--- a/uv.lock
+++ b/uv.lock
@@ -227,7 +227,6 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-rerunfailures" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
@@ -266,7 +265,6 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=6.0" },
-    { name = "pytest-rerunfailures", specifier = ">=15.0" },
     { name = "pytest-xdist", specifier = ">=3.5.0" },
     { name = "ruff", specifier = ">=0.15.11" },
     { name = "ty", specifier = ">=0.0.56" },
@@ -1350,19 +1348,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
-]
-
-[[package]]
-name = "pytest-rerunfailures"
-version = "16.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/47/60/a90ca1cc6cffcb97b4260ed0ad2b7934b999d7c48abe4ea0840344862a3b/pytest_rerunfailures-16.4.tar.gz", hash = "sha256:8222d17c37eb7b9e4d6fc96a3c724ff4e1a5c97a5cc7cbb2c19e9282cfd21a11", size = 36635, upload-time = "2026-07-01T06:30:56.813Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/93/3cdcc4033444e822e01b573414b03fd37fd5533070c750477b8f5fa5224b/pytest_rerunfailures-16.4-py3-none-any.whl", hash = "sha256:f69b5beb39622c90d1e44bd945d826eff6db545dcf0b68f52b7e4ad15eaf6d6c", size = 16955, upload-time = "2026-07-01T06:30:55.333Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-up to #217, which flagged this file as the same class of landmine: a `flaky(reruns=5)` mark guarding wall-clock assertions on a runner where a single deschedule was measured at 137 ms against bounds with ~89 ms of slack.

## Why faking is sound here too

#217 left this test alone on the theory that its subject genuinely *is* wall-clock behavior. It isn't: `run_many`'s logic is a feedback controller — each run rescales `n_executions` from the previous run's `Timer` reading toward the per-run time target. That's arithmetic on a clock *reading*; the wall-clock-ness lived entirely in the old test's busy-wait dummy, which was a test choice, not a property of the subject.

The scripted-list clock from #217 doesn't fit (Timers nest across `run_many`/`run_once`, so the number of reads is an implementation detail), so this uses a **stateful fake clock that only the simulated work advances** — immune to how many reads happen.

## What the tests now assert

Exactly, instantly, and unconditionally: the full sizing ramp including the 10x per-step growth clamp, the shrink clamp after a mid-run cost jump, the `MAX_N_EXECUTIONS` cap under a flat runtime, the warmup/benchmark split (including that warmup runs are the *first* runs), and quantile stats recovering the true per-execution cost. The old bounds were weaker than they looked — the busy-wait guaranteed a minimum, so the `q75` floor could never fail from slowness, and the ramp was never checked at all.

One floor-only real-clock test remains, in #217's spirit, so faking can't hide a benchmark loop that never times anything.

Verified by mutation: removing the growth/shrink clamp, an off-by-one warmup boundary, removing the cap, and ignoring the elapsed reading are each caught. Total runtime drops from ~600 ms of real waiting to milliseconds.

The deleted `flaky` mark was the suite's last, so `pytest-rerunfailures` leaves the dev dependencies with it.

## Flagged, not fixed

Writing the flat-runtime test surfaced a latent crash: when every benchmark run measures exactly 0 ns (a dead-code-eliminated kernel on a coarse-resolution clock — Windows ticks at ~100 ns, and CI runs Windows since #216), `run_many`'s closing stats display divides by `q50 == 0` in `Quantiles.format_uncertainty()` and raises `ZeroDivisionError`. The controller itself is protected by its 1e-9 floor; the display is not. That's a behavior fix, so it doesn't ride along in a test-only PR — the cap test here uses a flat-but-nonzero runtime to stay off that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)