### PR TITLE
feat: drop the benchmarking re-export from the package root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- `counted_float.benchmarking` is no longer re-exported from the package root; import it directly. `import counted_float` is roughly 1.7x faster as a result, and no longer loads numba.
+- `counted_float.benchmarking` is no longer re-exported from the package root; import it directly. `import counted_float` is roughly 1.7x faster as a result, and no longer loads numba eagerly.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `counted_float.benchmarking` is no longer re-exported from the package root; import it directly. `import counted_float` is roughly 1.7x faster as a result, and no longer loads numba.
+
 ### Fixed
 
 ### Security

--- a/src/counted_float/__init__.py
+++ b/src/counted_float/__init__.py
@@ -2,7 +2,6 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-import counted_float.benchmarking as benchmarking
 import counted_float.config as config
 
 try:
@@ -24,6 +23,5 @@ __all__ = [
     "Quantiles",
     "SystemInfo",
     "__version__",
-    "benchmarking",
     "config",
 ]

--- a/tests/shared/test_imports.py
+++ b/tests/shared/test_imports.py
@@ -69,3 +69,33 @@ def test_every_public_name_from_this_package_is_advertised(module_name: str):
 
     # --- assert ------------------------------------------
     assert not unadvertised, f"{module_name} exposes {sorted(unadvertised)} but does not list them in __all__"
+
+
+def test_bare_import_stays_free_of_the_benchmarking_stack():
+    """A bare `import counted_float` must not load the benchmarking subpackage or its heavy deps.
+
+    The counting core never touches numba or llvmlite; only the benchmarking subpackage does, and
+    it is reachable by importing it directly. Runs in a fresh interpreter on purpose: in a shared
+    process, other tests' imports would already have populated sys.modules.
+    """
+    # --- arrange -----------------------------------------
+    discover_loaded = textwrap.dedent(
+        """
+        import json, sys
+        import counted_float
+        watched = ("counted_float.benchmarking", "numba", "llvmlite")
+        print(json.dumps([name for name in watched if name in sys.modules]))
+        """
+    )
+
+    # --- act ---------------------------------------------
+    result = subprocess.run(  # noqa: S603 -- fixed args, no user input
+        [sys.executable, "-c", discover_loaded],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    loaded = json.loads(result.stdout)
+
+    # --- assert ------------------------------------------
+    assert loaded == [], f"bare import loaded {loaded}"


### PR DESCRIPTION
Importing the package cost ~190 ms, the large majority of it the benchmarking subpackage eagerly re-exported from the root — pulling in numba (the single largest contributor) and rich, which the counting core never touches. The docs have always taught `from counted_float.benchmarking import ...`, which works without any re-export.

This deletes the eager import and the `__all__` entry rather than making the re-export lazy: a module-level `__getattr__` was prototyped and works, but it would exist only to preserve an attribute-access pattern (`counted_float.benchmarking` after a bare `import counted_float`) that no documentation teaches and nothing in the tree uses. Breaking by the letter, since the name leaves `__all__`.

A fresh-interpreter test pins that a bare import loads neither `counted_float.benchmarking`, `numba`, nor `llvmlite`, so the win cannot quietly regress. Measured: ~190 ms → ~98 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)