### PR TITLE
feat: refuse numpy's ufunc protocol so the numpy boundary is loud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- mixing `CountedFloat` with numpy arrays (or non-double numpy scalars) now raises `TypeError` instead of silently returning uncounted results; `np.float64` scalar operations now count correctly from either side. numpy counting is documented as an explicit non-goal.
+
 ### Deprecated
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Two facts worth knowing:
 This makes `CountedFloat` a tool for research and prototyping code, not
 production hot loops.
 
-**numpy counting is an explicit non-goal**: `np.float64` scalars work and count
-correctly, but mixing `CountedFloat` with numpy arrays raises `TypeError` rather
+**numpy counting is an explicit non-goal**: `np.float64` (`float` subclass) scalars
+work and count correctly, but mixing `CountedFloat` with numpy arrays raises `TypeError` rather
 than silently returning uncounted results — see
 [Known limitations](https://counted-float.readthedocs.io/en/latest/known_limitations/)
 for the full boundary.

--- a/README.md
+++ b/README.md
@@ -99,15 +99,11 @@ Two facts worth knowing:
 This makes `CountedFloat` a tool for research and prototyping code, not
 production hot loops.
 
-## numpy: an explicit non-goal
-
-The counting model prices scalar code as a compiled port would execute it;
-counting numpy operations is deliberately out of scope. `np.float64` scalars
-work and count correctly on either side of an operator (they are plain C
-doubles subclassing `float`), but mixing `CountedFloat` with numpy arrays or
-non-double numpy scalars raises `TypeError` rather than silently returning
-uncounted results. Details in
-[Known limitations](https://counted-float.readthedocs.io/en/latest/known_limitations/).
+**numpy counting is an explicit non-goal**: `np.float64` scalars work and count
+correctly, but mixing `CountedFloat` with numpy arrays raises `TypeError` rather
+than silently returning uncounted results — see
+[Known limitations](https://counted-float.readthedocs.io/en/latest/known_limitations/)
+for the full boundary.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ Two facts worth knowing:
 This makes `CountedFloat` a tool for research and prototyping code, not
 production hot loops.
 
+## numpy: an explicit non-goal
+
+The counting model prices scalar code as a compiled port would execute it;
+counting numpy operations is deliberately out of scope. `np.float64` scalars
+work and count correctly on either side of an operator (they are plain C
+doubles subclassing `float`), but mixing `CountedFloat` with numpy arrays or
+non-double numpy scalars raises `TypeError` rather than silently returning
+uncounted results. Details in
+[Known limitations](https://counted-float.readthedocs.io/en/latest/known_limitations/).
+
 ## Documentation
 
 The [documentation site](https://counted-float.readthedocs.io/) covers the rest:

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -1,7 +1,29 @@
 # Known limitations
 
-- currently any non-Python-built-in math operations are not counted (e.g.
-  `numpy`)
+## numpy counting is an explicit non-goal
+
+The counting model prices scalar code as a compiled port would execute it;
+array operations are bulk kernels outside that model, and no part of numpy's
+semantics is adopted. Concretely:
+
+- `np.float64` scalars work and count correctly on **either** side of an
+  operator — not because numpy is supported, but because `np.float64` is a
+  plain C double subclassing `float`, so it flows through the ordinary float
+  path.
+- mixing `CountedFloat` with numpy **arrays**, or with numpy scalar dtypes
+  that do not subclass `float` (`np.float32`, `np.int64`, ...), raises
+  `TypeError`. `CountedFloat` refuses numpy's ufunc protocol
+  (`__array_ufunc__ = None`) on purpose: the alternative is an operation that
+  silently returns an *uncounted* result whose type may later recover to
+  `CountedFloat`, hiding that flops went missing — the loud boundary is the
+  honest one.
+
+Keep counted algorithms in scalar `float`/`CountedFloat` code; hand values to
+numpy only after converting to plain `float` (e.g. `float(x)`), outside the
+counted region.
+
+## Other limitations
+
 - a few Python built-in math operations remain uncounted — notably
   `math.copysign`; see the
   [`math` coverage table](math_patching.md#coverage-of-the-math-module) for

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -57,6 +57,15 @@ def count_pow_with_constant_base(base: float) -> None:
 
 
 class CountedFloat(float):
+    # numpy counting is an explicit non-goal; refusing numpy's ufunc protocol makes the boundary
+    # loud instead of silently uncounted. With the protocol refused, numpy's scalar operators
+    # return NotImplemented and Python falls back to this class's reflected methods — np.float64
+    # (a plain C double subclassing float) then counts correctly from either side without any
+    # numpy semantics being adopted. ndarrays and numpy scalar dtypes that do not subclass float
+    # (np.float32, np.int64, ...) raise TypeError instead of producing uncounted results whose
+    # type may later recover to CountedFloat and mask the missing flops.
+    __array_ufunc__ = None
+
     # -------------------------------------------------------------------------
     #  CONSTRUCTOR
     # -------------------------------------------------------------------------

--- a/tests/counting/test_count_parity_property.py
+++ b/tests/counting/test_count_parity_property.py
@@ -1,0 +1,74 @@
+"""Property-based test: an operation counts the same regardless of which side the counted value
+sits on.
+
+This is the property whose absence let the numpy scalar under-count survive: with a numpy scalar
+on the left, the flops silently vanished while the result type recovered downstream. It is
+asserted over the operand types the counting model deliberately supports — ``float``, ``int``,
+and ``np.float64`` (a plain C double flowing through the ordinary float path). ``Fraction`` is
+deliberately absent: its asymmetry is a documented boundary of the model, not a target.
+"""
+
+import operator
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from counted_float import CountedFloat, FlopCountingContext, FlopCounts
+
+# --- strategies ----------------------------------------------------------------------------------
+_nonzero_finite = st.floats(allow_nan=False, allow_infinity=False, width=64).filter(lambda v: v != 0.0)
+
+_ARITHMETIC = [operator.add, operator.sub, operator.mul, operator.truediv]
+_OPERAND_CONVERTERS: list[tuple[str, Callable[[float], object]]] = [
+    ("float", float),
+    ("int", lambda v: int(v) or 1),  # keep nonzero so division stays legal
+    ("np.float64", np.float64),
+]
+
+
+def _counts_of(op: Callable, left: object, right: object) -> FlopCounts:
+    """Flop counts of a single ``op(left, right)`` evaluation."""
+    with FlopCountingContext() as fcc:
+        op(left, right)
+    return fcc.flop_counts()
+
+
+@pytest.mark.parametrize("op", _ARITHMETIC)
+@pytest.mark.parametrize(("operand_type", "convert"), _OPERAND_CONVERTERS, ids=[t[0] for t in _OPERAND_CONVERTERS])
+@settings(deadline=None)
+@given(x=_nonzero_finite, y=_nonzero_finite)
+def test_operand_side_does_not_change_the_count(
+    op: Callable, operand_type: str, convert: Callable[[float], object], x: float, y: float
+) -> None:
+    # --- arrange -----------------------------------------
+    counted = CountedFloat(x)
+    other = convert(y)
+
+    # --- act ---------------------------------------------
+    counts_counted_left = _counts_of(op, counted, other)
+    counts_counted_right = _counts_of(op, other, counted)
+
+    # --- assert ------------------------------------------
+    assert counts_counted_left == counts_counted_right, (
+        f"{op.__name__} with a {operand_type} operand counts differently per side"
+    )
+    assert counts_counted_left.total_count() == 1
+
+
+@pytest.mark.parametrize("op", _ARITHMETIC)
+@pytest.mark.parametrize(("operand_type", "convert"), _OPERAND_CONVERTERS, ids=[t[0] for t in _OPERAND_CONVERTERS])
+@settings(deadline=None)
+@given(x=_nonzero_finite, y=_nonzero_finite)
+def test_operand_side_does_not_change_the_result_type(
+    op: Callable, operand_type: str, convert: Callable[[float], object], x: float, y: float
+) -> None:
+    # --- arrange -----------------------------------------
+    counted = CountedFloat(x)
+    other = convert(y)
+
+    # --- act / assert ------------------------------------
+    assert isinstance(op(counted, other), CountedFloat)
+    assert isinstance(op(other, counted), CountedFloat)

--- a/tests/counting/test_numpy_interop.py
+++ b/tests/counting/test_numpy_interop.py
@@ -1,11 +1,10 @@
-"""Interop with numpy scalars, for the direction whose counting semantics are settled.
+"""Interop with numpy: scalar doubles count from either side; everything else refuses loudly.
 
-``np.float64`` subclasses ``float``, so with a ``CountedFloat`` on the left the operator is
-handled here: the flop is counted and the result stays a ``CountedFloat``. These tests pin that
-direction.
-
-With a numpy scalar on the left, numpy handles the operation instead and nothing is counted.
-That is a known gap rather than a contract, so it is deliberately not pinned here.
+numpy counting is an explicit non-goal. CountedFloat refuses numpy's ufunc protocol
+(``__array_ufunc__ = None``), so numpy's operators return NotImplemented and Python falls back to
+CountedFloat's reflected methods: ``np.float64`` — a plain C double subclassing ``float`` — counts
+correctly regardless of which side it sits on. ndarrays and numpy scalar dtypes that do not
+subclass ``float`` raise ``TypeError`` instead of silently producing uncounted results.
 """
 
 import operator
@@ -16,16 +15,18 @@ import pytest
 
 from counted_float import CountedFloat, FlopCountingContext
 
+_ARITHMETIC_OPS = [
+    (operator.add, "ADD"),
+    (operator.sub, "SUB"),
+    (operator.mul, "MUL"),
+    (operator.truediv, "DIV"),
+]
 
-@pytest.mark.parametrize(
-    ("op", "flop_type_name"),
-    [
-        (operator.add, "ADD"),
-        (operator.sub, "SUB"),
-        (operator.mul, "MUL"),
-        (operator.truediv, "DIV"),
-    ],
-)
+
+# =================================================================================================
+#  np.float64 scalars: counted from either side
+# =================================================================================================
+@pytest.mark.parametrize(("op", "flop_type_name"), _ARITHMETIC_OPS)
 def test_counted_float_on_the_left_of_a_numpy_scalar_counts_and_stays_counted(
     op: Callable[[object, object], object], flop_type_name: str
 ):
@@ -43,14 +44,52 @@ def test_counted_float_on_the_left_of_a_numpy_scalar_counts_and_stays_counted(
     assert fcc.flop_counts().total_count() == 1
 
 
-def test_counted_float_compared_against_a_numpy_scalar_counts():
+@pytest.mark.parametrize(("op", "flop_type_name"), _ARITHMETIC_OPS)
+def test_counted_float_on_the_right_of_a_numpy_scalar_counts_and_stays_counted(
+    op: Callable[[object, object], object], flop_type_name: str
+):
+    # --- arrange -----------------------------------------
+    counted = CountedFloat(6.0)
+    numpy_scalar = np.float64(3.0)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext() as fcc:
+        result = op(numpy_scalar, counted)
+
+    # --- assert ------------------------------------------
+    assert isinstance(result, CountedFloat)
+    assert getattr(fcc.flop_counts(), flop_type_name) == 1
+    assert fcc.flop_counts().total_count() == 1
+
+
+def test_weighted_sum_with_numpy_weights_counts_every_flop():
+    """The motivating defect: numpy weights on the left used to swallow every multiply while the
+    running total recovered the CountedFloat type, so the loss was invisible."""
+    # --- arrange -----------------------------------------
+    weights = [np.float64(0.5), np.float64(0.25)]
+    values = [CountedFloat(1.0), CountedFloat(2.0)]
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext() as fcc:
+        total = CountedFloat(0.0)
+        for weight, value in zip(weights, values, strict=True):
+            total = total + weight * value
+
+    # --- assert ------------------------------------------
+    assert isinstance(total, CountedFloat)
+    assert fcc.flop_counts().MUL == 2
+    assert fcc.flop_counts().ADD == 2
+
+
+@pytest.mark.parametrize("order", ["counted_left", "counted_right"])
+def test_counted_float_compared_against_a_numpy_scalar_counts(order: str):
     # --- arrange -----------------------------------------
     counted = CountedFloat(1.0)
     numpy_scalar = np.float64(2.0)
 
     # --- act ---------------------------------------------
     with FlopCountingContext() as fcc:
-        result = counted < numpy_scalar
+        result = counted < numpy_scalar if order == "counted_left" else numpy_scalar > counted
 
     # --- assert ------------------------------------------
     assert result is True
@@ -67,3 +106,34 @@ def test_counted_float_on_the_left_of_a_numpy_scalar_keeps_the_value_right():
 
     # --- assert ------------------------------------------
     assert quotient == 2.0
+
+
+# =================================================================================================
+#  Everything else numpy: a loud boundary
+# =================================================================================================
+@pytest.mark.parametrize(("op", "flop_type_name"), _ARITHMETIC_OPS)
+@pytest.mark.parametrize("counted_side", ["left", "right"])
+def test_mixing_with_a_numpy_array_raises(
+    op: Callable[[object, object], object], flop_type_name: str, counted_side: str
+):
+    # --- arrange -----------------------------------------
+    counted = CountedFloat(2.0)
+    array = np.array([1.0, 2.0])
+
+    # --- act / assert ------------------------------------
+    with pytest.raises(TypeError):
+        op(counted, array) if counted_side == "left" else op(array, counted)
+
+
+@pytest.mark.parametrize("scalar_type", [np.float32, np.int64], ids=["float32", "int64"])
+def test_mixing_with_a_non_double_numpy_scalar_raises(scalar_type: type):
+    """Only np.float64 subclasses float; other numpy scalar dtypes hit the same loud boundary."""
+    # --- arrange -----------------------------------------
+    counted = CountedFloat(2.0)
+    scalar = scalar_type(3)
+
+    # --- act / assert ------------------------------------
+    with pytest.raises(TypeError):
+        counted * scalar
+    with pytest.raises(TypeError):
+        scalar * counted


### PR DESCRIPTION
Fixes the most damaging defect in the counting model: a numpy scalar on the **left** of an operator handled the operation itself and counted nothing, while the next operation recovered the `CountedFloat` type — so a weighted sum with `np.float64` weights silently lost every multiply and still returned a counted result.

The fix is a scope statement in code, not numpy support: `__array_ufunc__ = None`. numpy's operators then return `NotImplemented` and Python falls back to `CountedFloat`'s reflected methods — `np.float64`, a plain C double subclassing `float`, counts correctly from either side without any numpy semantics being adopted. Arrays and non-double numpy scalar dtypes (`np.float32`, `np.int64`, ...) now raise `TypeError` instead of silently producing uncounted results. Breaking: array mixing that previously worked (uncounted) now refuses.

Also included:

- a count-parity property (hypothesis): every arithmetic operation counts identically whichever side the `CountedFloat` sits on, over `float`, `int` and `np.float64` operands — the test that would have caught this defect. `Fraction` stays a documented boundary, deliberately outside the property.
- docs: a "numpy counting is an explicit non-goal" section (README + known limitations), stating the rationale and the resulting behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)