### PR TITLE
feat: key flop-weight JSON on stable identifiers, not display labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- flop-weight JSON files now key on stable identifiers instead of display labels; pre-2.0.0 label-keyed files (including your own saved benchmark results) still load, but an unrecognized key now raises instead of silently degrading to a missing weight
+
 ### Deprecated
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,10 @@ dependencies = [
     "numpy>=1.26.0; python_version == '3.12'",
     "numpy>=2.1.0; python_version == '3.13'",
     "numpy>=2.3.2; python_version >= '3.14'",
-    # pydantic floor is a code requirement (auto model-rebuild of cross-module forward
-    # refs, from 2.6), raised further where a newer CPython needs a newer pydantic-core wheel.
-    "pydantic>=2.6; python_version < '3.13'",
+    # pydantic floor is a code requirement (auto model-rebuild of cross-module forward refs, from
+    # 2.6; serialization `context` for the display-vs-stored key rendering, from 2.7), raised
+    # further where a newer CPython needs a newer pydantic-core wheel.
+    "pydantic>=2.7; python_version < '3.13'",
     "pydantic>=2.9; python_version == '3.13'",
     "pydantic>=2.12; python_version >= '3.14'",
     "psutil>=5.9.4; python_version < '3.13'",

--- a/src/counted_float/_core/models/_base.py
+++ b/src/counted_float/_core/models/_base.py
@@ -12,7 +12,9 @@ class JsonReprModel(BaseModel):
         return str(self)
 
     def __str__(self) -> str:
-        return self.model_dump_json(indent=4)
+        # the display context makes FlopType-keyed dicts render with human labels rather than the
+        # stable on-disk names; models without such a field simply ignore it
+        return self.model_dump_json(indent=4, context={"display": True})
 
     def show(self) -> None:
-        print(self.model_dump_json(indent=4))
+        print(self.model_dump_json(indent=4, context={"display": True}))

--- a/src/counted_float/_core/models/_flop_type.py
+++ b/src/counted_float/_core/models/_flop_type.py
@@ -1,51 +1,176 @@
+from __future__ import annotations
+
+import math
 from enum import StrEnum
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from pydantic import FieldSerializationInfo
+
+_V = TypeVar("_V")
 
 
 class FlopType(StrEnum):
     """Enum describing the different types of floating-point operations.
 
-    Each of these are counted separately and can potentially have different weights.
+    Each of these is counted separately and can potentially have a different weight.
     --> See: /docs/analysis_methodology.md.
+
+    The member *value* is a stable identifier equal to the member name (e.g. ``"ADD"``); it is
+    what serializes as the JSON key of every weight file, so it must not change once shipped. The
+    human-readable label (``"x+y"``) is a separate presentation concern -- see ``label``.
     """
 
-    ABS = "abs(x)"
-    MINUS = "-x"
-    COPYSIGN = "copysign(x,y)"  # sign-bit transfer; same instruction class as ABS/MINUS, but 1-3 ops depending on arch
-    COMP = "x<=y"  # includes x>=y, x==y, x<y, x>y, as well as comparison to 0
-    RND = "round"  # round float -> float
-    F2I = "float->int"  # float -> int, also includes round(x), math.floor(x), math.ceil(x)
-    I2F = "int->float"  # int -> float
-    ADD = "x+y"
-    SUB = "x-y"
-    MUL = "x*y"
-    DIV = "x/y"
-    FMA = "x*y+z"  # fused multiply-add: one instruction, one rounding
-    SQRT = "sqrt(x)"
-    CBRT = "cbrt(x)"
-    EXP = "e^x"
-    EXP2 = "2^x"
-    EXP10 = "10^x"
-    LOG = "log(x)"
-    LOG2 = "log2(x)"
-    LOG10 = "log10(x)"
-    POW = "x^y"
-    SIN = "sin(x)"
-    COS = "cos(x)"
-    TAN = "tan(x)"
-    ASIN = "asin(x)"
-    ACOS = "acos(x)"
-    ATAN = "atan(x)"
-    ATAN2 = "atan2(y,x)"
-    HYPOT = "hypot(x,y)"
-    EXPM1 = "expm1(x)"
-    LOG1P = "log1p(x)"
-    FMOD = "fmod(x,y)"
-    SINH = "sinh(x)"
-    COSH = "cosh(x)"
-    TANH = "tanh(x)"
-    ASINH = "asinh(x)"
-    ACOSH = "acosh(x)"
-    ATANH = "atanh(x)"
+    ABS = "ABS"
+    MINUS = "MINUS"
+    COPYSIGN = "COPYSIGN"
+    COMP = "COMP"
+    RND = "RND"
+    F2I = "F2I"
+    I2F = "I2F"
+    ADD = "ADD"
+    SUB = "SUB"
+    MUL = "MUL"
+    DIV = "DIV"
+    FMA = "FMA"
+    SQRT = "SQRT"
+    CBRT = "CBRT"
+    EXP = "EXP"
+    EXP2 = "EXP2"
+    EXP10 = "EXP10"
+    LOG = "LOG"
+    LOG2 = "LOG2"
+    LOG10 = "LOG10"
+    POW = "POW"
+    SIN = "SIN"
+    COS = "COS"
+    TAN = "TAN"
+    ASIN = "ASIN"
+    ACOS = "ACOS"
+    ATAN = "ATAN"
+    ATAN2 = "ATAN2"
+    HYPOT = "HYPOT"
+    EXPM1 = "EXPM1"
+    LOG1P = "LOG1P"
+    FMOD = "FMOD"
+    SINH = "SINH"
+    COSH = "COSH"
+    TANH = "TANH"
+    ASINH = "ASINH"
+    ACOSH = "ACOSH"
+    ATANH = "ATANH"
+
+    @property
+    def label(self) -> str:
+        """Human-readable display label (e.g. ``"x+y"``), decoupled from the on-disk key."""
+        return _LABELS[self]
 
     def long_name(self) -> str:
-        return f"FlopType.{self.name:<9}  [{self.value}]"
+        """Return a display string combining the stable name and the human-readable label."""
+        return f"FlopType.{self.name:<9}  [{self.label}]"
+
+    @classmethod
+    def from_serialized_key(cls, key: str) -> FlopType:
+        """Resolve a serialized weight-dict key to a member.
+
+        Accepts the current stable name and, for backward compatibility, the legacy display
+        label a pre-2.0.0 file used as its key.
+
+        Raises:
+            ValueError: If the key matches neither a current name nor a legacy label -- a loud
+                failure, rather than silently degrading into a missing (NaN) weight.
+        """
+        try:
+            return cls[key]
+        except KeyError:
+            member = _LABEL_TO_MEMBER.get(key)
+            if member is None:
+                raise ValueError(
+                    f"unrecognized flop-type key {key!r}: not a FlopType name, nor a known legacy label"
+                ) from None
+            return member
+
+
+# =================================================================================================
+#  Display labels + serialized-key handling
+# =================================================================================================
+# The label is the human-facing spelling; it may change freely without touching any on-disk file,
+# because the JSON key is the stable name (member value) instead.
+_LABELS: dict[FlopType, str] = {
+    FlopType.ABS: "abs(x)",
+    FlopType.MINUS: "-x",
+    FlopType.COPYSIGN: "copysign(x,y)",
+    FlopType.COMP: "x<=y",
+    FlopType.RND: "round",
+    FlopType.F2I: "float->int",
+    FlopType.I2F: "int->float",
+    FlopType.ADD: "x+y",
+    FlopType.SUB: "x-y",
+    FlopType.MUL: "x*y",
+    FlopType.DIV: "x/y",
+    FlopType.FMA: "x*y+z",
+    FlopType.SQRT: "sqrt(x)",
+    FlopType.CBRT: "cbrt(x)",
+    FlopType.EXP: "e^x",
+    FlopType.EXP2: "2^x",
+    FlopType.EXP10: "10^x",
+    FlopType.LOG: "log(x)",
+    FlopType.LOG2: "log2(x)",
+    FlopType.LOG10: "log10(x)",
+    FlopType.POW: "x^y",
+    FlopType.SIN: "sin(x)",
+    FlopType.COS: "cos(x)",
+    FlopType.TAN: "tan(x)",
+    FlopType.ASIN: "asin(x)",
+    FlopType.ACOS: "acos(x)",
+    FlopType.ATAN: "atan(x)",
+    FlopType.ATAN2: "atan2(y,x)",
+    FlopType.HYPOT: "hypot(x,y)",
+    FlopType.EXPM1: "expm1(x)",
+    FlopType.LOG1P: "log1p(x)",
+    FlopType.FMOD: "fmod(x,y)",
+    FlopType.SINH: "sinh(x)",
+    FlopType.COSH: "cosh(x)",
+    FlopType.TANH: "tanh(x)",
+    FlopType.ASINH: "asinh(x)",
+    FlopType.ACOSH: "acosh(x)",
+    FlopType.ATANH: "atanh(x)",
+}
+# legacy files keyed weight dicts on the display label; map those back to members on read
+_LABEL_TO_MEMBER: dict[str, FlopType] = {label: flop_type for flop_type, label in _LABELS.items()}
+
+
+def normalize_flop_type_keyed_dict(v: object, *, null_to_nan: bool) -> object:
+    """Resolve the string keys of a serialized FlopType-keyed dict to members.
+
+    Shared by the ``mode="before"`` validators of every model that stores a ``dict[FlopType, ...]``.
+    Legacy label keys map to their member; unrecognized keys raise (via ``from_serialized_key``);
+    already-resolved ``FlopType`` keys pass through. Non-dict input is returned untouched so
+    pydantic can raise its own type error.
+
+    Args:
+        v: The raw validator input -- a dict with string (or already-resolved member) keys when it
+            comes from JSON; anything else is passed through untouched.
+        null_to_nan: When True, a JSON ``null`` value becomes ``math.nan`` -- how the weight
+            models mark missing data. Latency-style dicts pass False (no missing markers).
+    """
+    if not isinstance(v, dict):
+        return v
+    resolved: dict[FlopType, object] = {}
+    for key, value in v.items():
+        member = key if isinstance(key, FlopType) else FlopType.from_serialized_key(str(key))
+        resolved[member] = math.nan if (null_to_nan and value is None) else value
+    return resolved
+
+
+def serialize_flop_type_keyed_dict(d: Mapping[FlopType, _V], info: FieldSerializationInfo) -> dict[str, _V]:
+    """Serialize a FlopType-keyed dict, keying on the stable name by default.
+
+    A ``{"display": True}`` serialization context switches the keys to the human-readable labels,
+    which is what the pretty ``__str__`` / ``show()`` paths pass. On-disk writes pass no context,
+    so files always carry the stable names.
+    """
+    display = bool((info.context or {}).get("display"))
+    return {(flop_type.label if display else flop_type.name): value for flop_type, value in d.items()}

--- a/src/counted_float/_core/models/_flop_weights.py
+++ b/src/counted_float/_core/models/_flop_weights.py
@@ -9,10 +9,12 @@ from pydantic import field_serializer, field_validator
 from counted_float._core.utils import geo_mean, impute_missing_data, round_number
 
 from ._base import JsonReprModel
-from ._flop_type import FlopType
+from ._flop_type import FlopType, normalize_flop_type_keyed_dict, serialize_flop_type_keyed_dict
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
+
+    from pydantic import FieldSerializationInfo
 
 
 class FlopWeights(JsonReprModel):
@@ -56,7 +58,7 @@ class FlopWeights(JsonReprModel):
             key=lambda ft: (
                 math.isnan(self.weights[ft]),
                 0.0 if math.isnan(self.weights[ft]) else self.weights[ft],
-                ft.value,
+                ft.name,
             ),
         )
 
@@ -65,16 +67,15 @@ class FlopWeights(JsonReprModel):
     # -------------------------------------------------------------------------
     @field_validator("weights", mode="before")
     @classmethod
-    def accept_null_as_missing_weight(cls, v: object) -> object:
-        """Read a JSON `null` back as a missing (NaN) weight.
+    def normalize_keys_and_missing_weights(cls, v: object) -> object:
+        """Resolve serialized keys to members and read JSON `null` back as a missing (NaN) weight.
 
-        A missing weight is NaN in memory and serializes to `null` -- valid JSON, and what a strict
-        reader expects. This maps it back on the way in, so that weights with missing data survive a
-        serialization round-trip; the field type alone accepts only numbers.
+        Legacy files keyed weights on the display label; those are mapped to the stable member,
+        and an unrecognized key raises rather than silently becoming missing data. A missing weight
+        is NaN in memory and serializes to `null` (valid JSON), so `null` is mapped back on the way
+        in -- both so weights with missing data survive a round-trip.
         """
-        if isinstance(v, dict):
-            return {key: (math.nan if weight is None else weight) for key, weight in v.items()}
-        return v
+        return normalize_flop_type_keyed_dict(v, null_to_nan=True)
 
     @field_validator("weights")
     @classmethod
@@ -86,9 +87,11 @@ class FlopWeights(JsonReprModel):
         return v
 
     @field_serializer("weights")
-    def serialize_weights(self, weights: dict[FlopType, float | int]) -> dict[str, float | int]:
-        # make sure we serialize using the enum values as keys
-        return {k.value: v for k, v in weights.items()}
+    def serialize_weights(
+        self, weights: dict[FlopType, float | int], info: FieldSerializationInfo
+    ) -> dict[str, float | int]:
+        # stable names on disk; human labels only under a {"display": True} context
+        return serialize_flop_type_keyed_dict(weights, info)
 
     # -------------------------------------------------------------------------
     #  Custom visualization

--- a/src/counted_float/_core/models/_flops_benchmark_result.py
+++ b/src/counted_float/_core/models/_flops_benchmark_result.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from pydantic import field_serializer, field_validator
+
 from ._base import JsonReprModel
-from ._flop_type import FlopType
+from ._flop_type import FlopType, normalize_flop_type_keyed_dict, serialize_flop_type_keyed_dict
 from ._flop_weights import FlopWeights
 from ._flops_benchmark_meta_data import BenchmarkSettings, SystemInfo
 from ._flops_benchmark_type import FlopsBenchmarkType
 from ._micro_benchmark_result import Quantiles
+
+if TYPE_CHECKING:
+    from pydantic import FieldSerializationInfo
 
 
 # =================================================================================================
@@ -19,6 +26,18 @@ class FlopsBenchmarkResults(JsonReprModel):
     # --- results ---
     n_cycles_per_op: dict[FlopsBenchmarkType, Quantiles]  # number of cpu cycles per element in array
     estimated_flop_latencies: dict[FlopType, float]  # number of cpu cycles per flop type
+
+    # --- serialization: same stable-name / legacy-label handling as FlopWeights ---
+    @field_validator("estimated_flop_latencies", mode="before")
+    @classmethod
+    def normalize_latency_keys(cls, v: object) -> object:
+        """Resolve serialized keys to members; legacy label keys map back, unknown keys raise."""
+        return normalize_flop_type_keyed_dict(v, null_to_nan=False)
+
+    @field_serializer("estimated_flop_latencies")
+    def serialize_latencies(self, latencies: dict[FlopType, float], info: FieldSerializationInfo) -> dict[str, float]:
+        # stable names on disk; human labels only under a {"display": True} context
+        return serialize_flop_type_keyed_dict(latencies, info)
 
     # --- helpers ---
     def flop_weights(self) -> FlopWeights:

--- a/tests/models/test_flop_type.py
+++ b/tests/models/test_flop_type.py
@@ -1,3 +1,5 @@
+import pytest
+
 from counted_float._core.models import FlopType
 
 
@@ -7,3 +9,30 @@ def test_flop_type_long_name():
 
     # --- assert ------------------------------------------
     assert len(all_long_names) == len(FlopType), "long names should be unique"
+
+
+def test_flop_type_value_is_the_stable_name():
+    # the serialized JSON key is the member value; keeping it equal to the name is what makes it a
+    # stable identifier, decoupled from the (freely-changeable) display label
+    assert all(ft.value == ft.name for ft in FlopType)
+
+
+def test_flop_type_labels_are_unique_and_present():
+    # --- act ---------------------------------------------
+    labels = [ft.label for ft in FlopType]
+
+    # --- assert ------------------------------------------
+    assert all(labels), "every flop type has a display label"
+    assert len(set(labels)) == len(FlopType), "labels should be unique"
+
+
+@pytest.mark.parametrize("flop_type", list(FlopType))
+def test_from_serialized_key_resolves_name_and_legacy_label(flop_type: FlopType):
+    # both the current stable name and the legacy display label resolve to the same member
+    assert FlopType.from_serialized_key(flop_type.name) is flop_type
+    assert FlopType.from_serialized_key(flop_type.label) is flop_type
+
+
+def test_from_serialized_key_raises_on_unknown_key():
+    with pytest.raises(ValueError, match="unrecognized flop-type key"):
+        FlopType.from_serialized_key("not-a-flop-type")

--- a/tests/models/test_flop_weights.py
+++ b/tests/models/test_flop_weights.py
@@ -1,6 +1,8 @@
+import json
 import math
 
 import pytest
+from pydantic import ValidationError
 
 from counted_float._core.counting import BuiltInData
 from counted_float._core.counting.config import get_builtin_flop_weights
@@ -15,7 +17,8 @@ def sample_flop_weights_dict_by_enum() -> dict[FlopType, int]:
 
 @pytest.fixture
 def sample_flop_weights_dict_by_str(sample_flop_weights_dict_by_enum) -> dict[str, int]:
-    return {k.value: v for k, v in sample_flop_weights_dict_by_enum.items()}
+    # serialized form keys on the stable name (== member value)
+    return {k.name: v for k, v in sample_flop_weights_dict_by_enum.items()}
 
 
 @pytest.mark.parametrize("use_dict_by_str", [True, False])
@@ -66,7 +69,7 @@ def test_get_sorted_flop_types_orders_by_weight_with_nan_last():
 
     assert finite == [FlopType.ADD, FlopType.MUL, FlopType.DIV]  # finite weights first, ascending
     assert ordered[: len(finite)] == finite  # ...and all before the NaN block
-    assert missing == sorted(missing, key=lambda ft: ft.value)  # NaN block is deterministically ordered
+    assert missing == sorted(missing, key=lambda ft: ft.name)  # NaN block is deterministically ordered
 
 
 def test_flop_weights_serialization(sample_flop_weights_dict_by_str):
@@ -79,6 +82,38 @@ def test_flop_weights_serialization(sample_flop_weights_dict_by_str):
     # --- assert ------------------------------------------
     assert result == {"weights": sample_flop_weights_dict_by_str}
     assert not any(isinstance(k, FlopType) for k in result["weights"]), "keys should be pure strings"
+
+
+def test_serialized_json_keys_on_stable_names_not_labels():
+    # --- arrange -----------------------------------------
+    flop_weights = FlopWeights(weights={FlopType.ADD: 1.0, FlopType.MUL: 2.0})
+
+    # --- act ---------------------------------------------
+    on_disk = json.loads(flop_weights.model_dump_json())["weights"]
+
+    # --- assert ------------------------------------------
+    assert on_disk["ADD"] == 1.0  # stable names, not "x+y" / "x*y"
+    assert on_disk["MUL"] == 2.0
+
+
+def test_str_renders_human_labels():
+    # the pretty (__str__/show) path passes a display context so a human sees the readable labels
+    rendered = json.loads(str(FlopWeights(weights={FlopType.ADD: 1.0})))["weights"]
+    assert "x+y" in rendered  # human label...
+    assert "ADD" not in rendered  # ...not the stable name
+
+
+def test_legacy_label_keyed_weights_still_load():
+    # a pre-2.0.0 file keyed weights on the display label; it must keep loading
+    restored = FlopWeights.model_validate_json('{"weights": {"x+y": 1.0, "x*y": 2.0}}')
+    assert restored.weights[FlopType.ADD] == 1.0
+    assert restored.weights[FlopType.MUL] == 2.0
+
+
+def test_unrecognized_weight_key_raises_instead_of_becoming_missing_data():
+    # a renamed/garbage key must fail loudly, not silently degrade into a NaN weight
+    with pytest.raises(ValidationError, match="unrecognized flop-type key"):
+        FlopWeights.model_validate_json('{"weights": {"not-a-flop-type": 1.0}}')
 
 
 @pytest.mark.parametrize("use_dict_by_str", [True, False])

--- a/tests/models/test_flops_benchmark_results.py
+++ b/tests/models/test_flops_benchmark_results.py
@@ -1,9 +1,7 @@
-from typing import TYPE_CHECKING
+import json
 
 from counted_float import BuiltInData
-
-if TYPE_CHECKING:
-    from counted_float._core.models import FlopsBenchmarkResults
+from counted_float._core.models import FlopsBenchmarkResults, FlopType
 
 
 def test_flops_benchmark_results_show():
@@ -16,3 +14,31 @@ def test_flops_benchmark_results_show():
     str(flops_benchmark_results)
     repr(flops_benchmark_results)
     flops_benchmark_results.show()
+
+
+def test_estimated_flop_latencies_serialize_on_stable_names():
+    # --- arrange -----------------------------------------
+    result = list(BuiltInData.benchmarks().values()).pop()
+
+    # --- act ---------------------------------------------
+    on_disk = json.loads(result.model_dump_json())["estimated_flop_latencies"]
+
+    # --- assert ------------------------------------------
+    assert "ADD" in on_disk  # stable name on disk...
+    assert "x+y" not in on_disk  # ...not the label
+
+
+def test_legacy_label_keyed_latencies_still_load():
+    # --- arrange -----------------------------------------
+    result = list(BuiltInData.benchmarks().values()).pop()
+    # rewrite this result's latency keys to the legacy display-label form a pre-2.0.0 file used
+    as_dict = json.loads(result.model_dump_json())
+    as_dict["estimated_flop_latencies"] = {
+        FlopType.from_serialized_key(key).label: value for key, value in as_dict["estimated_flop_latencies"].items()
+    }
+
+    # --- act ---------------------------------------------
+    restored = FlopsBenchmarkResults.model_validate_json(json.dumps(as_dict))
+
+    # --- assert ------------------------------------------
+    assert restored.estimated_flop_latencies == result.estimated_flop_latencies

--- a/uv.lock
+++ b/uv.lock
@@ -250,7 +250,7 @@ requires-dist = [
     { name = "psutil", marker = "python_full_version < '3.13'", specifier = ">=5.9.4" },
     { name = "psutil", marker = "python_full_version >= '3.13'", specifier = ">=7.1.2" },
     { name = "py-cpuinfo", specifier = ">=9.0.0" },
-    { name = "pydantic", marker = "python_full_version < '3.13'", specifier = ">=2.6" },
+    { name = "pydantic", marker = "python_full_version < '3.13'", specifier = ">=2.7" },
     { name = "pydantic", marker = "python_full_version == '3.13.*'", specifier = ">=2.9" },
     { name = "pydantic", marker = "python_full_version >= '3.14'", specifier = ">=2.12" },
     { name = "rich", specifier = ">=13.0.0" },


### PR DESCRIPTION
`FlopType` member values become stable identifiers (equal to the member name); the human-readable label (`x+y`, `abs(x)`, …) moves to a separate `label` property. This decouples the display spelling from the on-disk schema, so a label can be improved without breaking any published weight file.

Both FlopType-keyed serialized surfaces — `FlopWeights.weights` and `FlopsBenchmarkResults.estimated_flop_latencies` — now key on the stable name, read legacy label-keyed files through a compatibility shim, and raise on an unrecognized key rather than degrading it into a missing (NaN) weight. Pretty-printing (`str`/`show`) keeps the readable labels via a display serialization context.

Shipped data files stay label-keyed for now and load via the shim; migrating them to name keys is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)