### PR TITLE
feat: add a thread-local flop counter module alongside the global one

### DIFF
--- a/src/counted_float/_core/counting/_thread_counter.py
+++ b/src/counted_float/_core/counting/_thread_counter.py
@@ -1,0 +1,335 @@
+"""Thread-local flop-counting state.
+
+Each OS thread owns two FlopCounts objects, created lazily on its first counted operation
+(or first cold-path access):
+
+  - ``live``    : the thread's real counts (what contexts snapshot and diff)
+  - ``discard`` : a sink used while counting is paused
+
+``counts`` is an alias pointing at one of the two.  The hot path is therefore unconditionally
+``_TLS.counts.<FIELD> += 1`` — branch-free whether paused or not (successor of the global
+counter's 0/1 increment multiplier, minus one attribute load and the method call).
+pause()/resume() just swap the alias.
+
+Hot paths (CountedFloat dunders, math.* replacements) inline the increment and MUST NOT call
+methods on THREAD_COUNTER, which is a cold-path facade only.  State lives on ``_TLS``; the
+facade itself is stateless, so a single module instance is safe to share across threads.
+
+Robustness note: ``contextvars`` measured faster per increment but was rejected — new threads
+start with an empty context and asyncio runs callbacks in context *copies*, so lazily-set
+state can fail to escape ``Context.run()``, making count attribution depend on task-creation
+order (and context propagation into worker threads would share mutable state across threads).
+threading.local has exactly one unambiguous semantic: one state per OS thread.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from counted_float._core.models import FlopCounts
+
+# bare threading.local on purpose: CPython's local_getattro has a fast path for the exact
+# _thread._local type; subclasses take the slower generic route
+_TLS = threading.local()
+
+
+def _init_thread_state() -> FlopCounts:
+    """Create this thread's counting state; returns the active ``counts`` target.
+
+    Called from hot-path ``except AttributeError`` handlers (first counted op on a thread)
+    and from the facade's ensure-step.  Threads start unpaused.
+    """
+    live = FlopCounts()
+    _TLS.live = live
+    _TLS.discard = FlopCounts()
+    _TLS.counts = live
+    return live
+
+
+class ThreadLocalFlopCounter:
+    """Cold-path facade over the *calling thread's* counting state.
+
+    API-compatible with the previous process-global counter (pause/resume/reset/is_active/
+    flop_counts/total_count/field shorthand/incr_*), but every method operates on the calling
+    thread only.  The incr_* methods exist for tests and cold call sites; hot paths inline
+    the increment instead.
+    """
+
+    # -------------------------------------------------------------------------
+    #  Pause / Resume / Status API
+    # -------------------------------------------------------------------------
+    @staticmethod
+    def _ensure() -> None:
+        """Initialize the calling thread's state if this is its first access."""
+        try:
+            _TLS.counts  # noqa: B018 -- attribute probe: raises AttributeError on first access
+        except AttributeError:
+            _init_thread_state()
+
+    def pause(self) -> None:
+        self._ensure()
+        _TLS.counts = _TLS.discard
+
+    def resume(self) -> None:
+        self._ensure()
+        _TLS.counts = _TLS.live
+
+    def reset(self) -> None:
+        self._ensure()
+        _TLS.live.reset()
+        _TLS.counts = _TLS.live  # reset also resumes, matching prior behavior
+
+    def is_active(self) -> bool:
+        self._ensure()
+        return _TLS.counts is _TLS.live
+
+    def flop_counts(self) -> FlopCounts:
+        self._ensure()
+        return _TLS.live.copy()  # single-owner mutation, so the copy is never torn
+
+    def total_count(self) -> int:
+        """Shorthand for self.flop_counts().total_count()."""
+        self._ensure()
+        return _TLS.live.total_count()
+
+    def __getattr__(self, item: str) -> int:
+        # provide shorthand access to the counts
+        if item in FlopCounts.field_names():
+            self._ensure()
+            return getattr(_TLS.live, item)
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{item}'")
+
+    # -------------------------------------------------------------------------
+    #  Incrementing counts
+    # -------------------------------------------------------------------------
+    def incr_abs(self) -> None:
+        try:
+            _TLS.counts.ABS += 1
+        except AttributeError:
+            _init_thread_state().ABS += 1
+
+    def incr_minus(self) -> None:
+        try:
+            _TLS.counts.MINUS += 1
+        except AttributeError:
+            _init_thread_state().MINUS += 1
+
+    def incr_copysign(self) -> None:
+        try:
+            _TLS.counts.COPYSIGN += 1
+        except AttributeError:
+            _init_thread_state().COPYSIGN += 1
+
+    def incr_comp(self) -> None:
+        try:
+            _TLS.counts.COMP += 1
+        except AttributeError:
+            _init_thread_state().COMP += 1
+
+    def incr_rnd(self) -> None:
+        try:
+            _TLS.counts.RND += 1
+        except AttributeError:
+            _init_thread_state().RND += 1
+
+    def incr_f2i(self) -> None:
+        try:
+            _TLS.counts.F2I += 1
+        except AttributeError:
+            _init_thread_state().F2I += 1
+
+    def incr_i2f(self) -> None:
+        try:
+            _TLS.counts.I2F += 1
+        except AttributeError:
+            _init_thread_state().I2F += 1
+
+    def incr_add(self) -> None:
+        try:
+            _TLS.counts.ADD += 1
+        except AttributeError:
+            _init_thread_state().ADD += 1
+
+    def incr_sub(self) -> None:
+        try:
+            _TLS.counts.SUB += 1
+        except AttributeError:
+            _init_thread_state().SUB += 1
+
+    def incr_mul(self) -> None:
+        try:
+            _TLS.counts.MUL += 1
+        except AttributeError:
+            _init_thread_state().MUL += 1
+
+    def incr_div(self) -> None:
+        try:
+            _TLS.counts.DIV += 1
+        except AttributeError:
+            _init_thread_state().DIV += 1
+
+    def incr_fma(self) -> None:
+        try:
+            _TLS.counts.FMA += 1
+        except AttributeError:
+            _init_thread_state().FMA += 1
+
+    def incr_sqrt(self) -> None:
+        try:
+            _TLS.counts.SQRT += 1
+        except AttributeError:
+            _init_thread_state().SQRT += 1
+
+    def incr_cbrt(self) -> None:
+        try:
+            _TLS.counts.CBRT += 1
+        except AttributeError:
+            _init_thread_state().CBRT += 1
+
+    def incr_exp(self) -> None:
+        try:
+            _TLS.counts.EXP += 1
+        except AttributeError:
+            _init_thread_state().EXP += 1
+
+    def incr_exp2(self) -> None:
+        try:
+            _TLS.counts.EXP2 += 1
+        except AttributeError:
+            _init_thread_state().EXP2 += 1
+
+    def incr_exp10(self) -> None:
+        try:
+            _TLS.counts.EXP10 += 1
+        except AttributeError:
+            _init_thread_state().EXP10 += 1
+
+    def incr_log(self) -> None:
+        try:
+            _TLS.counts.LOG += 1
+        except AttributeError:
+            _init_thread_state().LOG += 1
+
+    def incr_log2(self) -> None:
+        try:
+            _TLS.counts.LOG2 += 1
+        except AttributeError:
+            _init_thread_state().LOG2 += 1
+
+    def incr_log10(self) -> None:
+        try:
+            _TLS.counts.LOG10 += 1
+        except AttributeError:
+            _init_thread_state().LOG10 += 1
+
+    def incr_pow(self) -> None:
+        try:
+            _TLS.counts.POW += 1
+        except AttributeError:
+            _init_thread_state().POW += 1
+
+    def incr_sin(self) -> None:
+        try:
+            _TLS.counts.SIN += 1
+        except AttributeError:
+            _init_thread_state().SIN += 1
+
+    def incr_cos(self) -> None:
+        try:
+            _TLS.counts.COS += 1
+        except AttributeError:
+            _init_thread_state().COS += 1
+
+    def incr_tan(self) -> None:
+        try:
+            _TLS.counts.TAN += 1
+        except AttributeError:
+            _init_thread_state().TAN += 1
+
+    def incr_asin(self) -> None:
+        try:
+            _TLS.counts.ASIN += 1
+        except AttributeError:
+            _init_thread_state().ASIN += 1
+
+    def incr_acos(self) -> None:
+        try:
+            _TLS.counts.ACOS += 1
+        except AttributeError:
+            _init_thread_state().ACOS += 1
+
+    def incr_atan(self) -> None:
+        try:
+            _TLS.counts.ATAN += 1
+        except AttributeError:
+            _init_thread_state().ATAN += 1
+
+    def incr_atan2(self) -> None:
+        try:
+            _TLS.counts.ATAN2 += 1
+        except AttributeError:
+            _init_thread_state().ATAN2 += 1
+
+    def incr_hypot(self) -> None:
+        try:
+            _TLS.counts.HYPOT += 1
+        except AttributeError:
+            _init_thread_state().HYPOT += 1
+
+    def incr_expm1(self) -> None:
+        try:
+            _TLS.counts.EXPM1 += 1
+        except AttributeError:
+            _init_thread_state().EXPM1 += 1
+
+    def incr_log1p(self) -> None:
+        try:
+            _TLS.counts.LOG1P += 1
+        except AttributeError:
+            _init_thread_state().LOG1P += 1
+
+    def incr_fmod(self) -> None:
+        try:
+            _TLS.counts.FMOD += 1
+        except AttributeError:
+            _init_thread_state().FMOD += 1
+
+    def incr_sinh(self) -> None:
+        try:
+            _TLS.counts.SINH += 1
+        except AttributeError:
+            _init_thread_state().SINH += 1
+
+    def incr_cosh(self) -> None:
+        try:
+            _TLS.counts.COSH += 1
+        except AttributeError:
+            _init_thread_state().COSH += 1
+
+    def incr_tanh(self) -> None:
+        try:
+            _TLS.counts.TANH += 1
+        except AttributeError:
+            _init_thread_state().TANH += 1
+
+    def incr_asinh(self) -> None:
+        try:
+            _TLS.counts.ASINH += 1
+        except AttributeError:
+            _init_thread_state().ASINH += 1
+
+    def incr_acosh(self) -> None:
+        try:
+            _TLS.counts.ACOSH += 1
+        except AttributeError:
+            _init_thread_state().ACOSH += 1
+
+    def incr_atanh(self) -> None:
+        try:
+            _TLS.counts.ATANH += 1
+        except AttributeError:
+            _init_thread_state().ATANH += 1
+
+
+# --- module-level instance through which cold paths access the calling thread's counter ---
+THREAD_COUNTER = ThreadLocalFlopCounter()

--- a/tests/counting/test_thread_counter.py
+++ b/tests/counting/test_thread_counter.py
@@ -1,0 +1,243 @@
+import threading
+
+import pytest
+
+from counted_float._core.counting._thread_counter import THREAD_COUNTER, ThreadLocalFlopCounter
+from counted_float._core.models import FlopCounts
+
+
+@pytest.fixture
+def thread_counter() -> ThreadLocalFlopCounter:
+    """Fixture giving access to the calling thread's flop counter, reset BEFORE & AFTER each test."""
+
+    # prepare
+    THREAD_COUNTER.reset()
+
+    # yield
+    yield THREAD_COUNTER
+
+    # cleanup
+    THREAD_COUNTER.reset()
+
+
+# ==================================================================================================
+#  Facade parity (ported from the process-global counter's test suite)
+# ==================================================================================================
+def test_thread_counter_fixture(thread_counter):
+    # --- assert 1 ----------------------------------------
+
+    # check correct type and instance
+    assert isinstance(thread_counter, ThreadLocalFlopCounter)
+    assert thread_counter is THREAD_COUNTER, "The thread_counter fixture should be the same object as THREAD_COUNTER."
+
+    # check correctly initialized
+    assert thread_counter.flop_counts() == FlopCounts(), "The thread_counter fixture should be initialized to zero."
+    assert thread_counter.is_active(), "The thread_counter fixture should be active."
+
+    # --- act ---------------------------------------------
+    thread_counter.incr_div()
+
+    # --- assert 2 ----------------------------------------
+    assert thread_counter.flop_counts().total_count() == 1
+    assert thread_counter.flop_counts().DIV == 1
+    assert THREAD_COUNTER.flop_counts() == thread_counter.flop_counts()
+
+
+def test_thread_counter_total_count(thread_counter):
+    # --- arrange -----------------------------------------
+    thread_counter.incr_add()
+    thread_counter.incr_mul()
+
+    # --- act ---------------------------------------------
+    total_count = thread_counter.total_count()
+
+    # --- assert ------------------------------------------
+    assert total_count == thread_counter.flop_counts().total_count()
+
+
+def test_thread_counter_count_attributes(thread_counter):
+    # --- arrange -----------------------------------------
+    thread_counter.incr_add()
+    thread_counter.incr_mul()
+
+    # --- act & assert ------------------------------------
+    assert thread_counter.ADD == 1, "ADD count is incorrect"
+    assert thread_counter.MUL == 1, "MUL count is incorrect"
+    for attr in FlopCounts.field_names():
+        _ = getattr(thread_counter, attr)  # check the rest if we can access all attributes
+
+
+def test_thread_counter_unknown_attribute_raises(thread_counter):
+    # --- act & assert ------------------------------------
+    with pytest.raises(AttributeError):
+        _ = thread_counter.NOT_A_FLOP_TYPE
+
+
+def test_thread_counter_counts(thread_counter):
+    # --- act ---------------------------------------------
+    thread_counter.incr_add()
+    thread_counter.incr_add()
+    thread_counter.incr_mul()
+
+    # --- assert ------------------------------------------
+    assert thread_counter.flop_counts().total_count() == 3
+    assert thread_counter.flop_counts().ADD == 2
+    assert thread_counter.flop_counts().MUL == 1
+
+
+def test_thread_counter_reset(thread_counter):
+    # --- arrange -----------------------------------------
+    thread_counter.incr_add()
+    thread_counter.incr_mul()
+    thread_counter.pause()
+
+    # --- act ---------------------------------------------
+    thread_counter.reset()
+
+    # --- assert ------------------------------------------
+    assert thread_counter.is_active(), "reset() should also resume counting."
+    assert thread_counter.flop_counts() == FlopCounts(), "After reset, the thread counter should be zero."
+
+
+def test_thread_counter_pause_resume(thread_counter):
+    # --- act 1 -------------------------------------------
+    thread_counter.incr_mul()
+    thread_counter.pause()
+
+    # --- assert 1 ----------------------------------------
+    assert thread_counter.flop_counts().total_count() == 1
+    assert thread_counter.flop_counts().MUL == 1
+    assert not thread_counter.is_active()
+
+    # --- act 2 -------------------------------------------
+    thread_counter.incr_sqrt()
+    thread_counter.resume()
+    thread_counter.incr_div()
+
+    # --- assert 2 ----------------------------------------
+    assert thread_counter.flop_counts().total_count() == 2
+    assert thread_counter.flop_counts().MUL == 1
+    assert thread_counter.flop_counts().DIV == 1
+    assert thread_counter.is_active()
+
+    # --- act 3 -------------------------------------------
+    thread_counter.resume()  # again
+    thread_counter.incr_div()
+    thread_counter.pause()
+    thread_counter.incr_rnd()
+    thread_counter.pause()
+    thread_counter.incr_rnd()
+    thread_counter.resume()
+    thread_counter.resume()
+    thread_counter.incr_exp2()
+
+    # --- assert 3 ----------------------------------------
+    assert thread_counter.flop_counts().total_count() == 4
+    assert thread_counter.flop_counts().MUL == 1
+    assert thread_counter.flop_counts().DIV == 2
+    assert thread_counter.flop_counts().EXP2 == 1
+    assert thread_counter.is_active()
+
+
+def test_thread_counter_all_incr_methods(thread_counter):
+    # --- arrange -----------------------------------------
+    incr_methods = [name for name in dir(ThreadLocalFlopCounter) if name.startswith("incr_")]
+
+    # --- act ---------------------------------------------
+    for name in incr_methods:
+        getattr(thread_counter, name)()
+
+    # --- assert ------------------------------------------
+    # each incr_* method increments exactly one field, and no two share a field
+    counts = thread_counter.flop_counts()
+    assert counts.total_count() == len(incr_methods)
+    for name in incr_methods:
+        field = name.removeprefix("incr_").upper()
+        assert getattr(counts, field) == 1, f"{name} should increment {field} by exactly 1"
+
+
+# ==================================================================================================
+#  Pause-swap invariant
+# ==================================================================================================
+def test_pause_swap_keeps_live_untouched(thread_counter):
+    # --- arrange -----------------------------------------
+    thread_counter.incr_add()
+    snapshot = thread_counter.flop_counts()
+
+    # --- act ---------------------------------------------
+    thread_counter.pause()
+    for _ in range(5):
+        thread_counter.incr_mul()  # lands in the discard sink
+
+    # --- assert ------------------------------------------
+    # live counts unchanged during pause; the discard sink never leaks into flop_counts()
+    assert thread_counter.flop_counts() == snapshot
+    assert not thread_counter.is_active()
+
+    thread_counter.resume()
+    assert thread_counter.flop_counts() == snapshot
+    assert thread_counter.is_active()
+
+
+# ==================================================================================================
+#  Per-thread semantics
+# ==================================================================================================
+def test_lazy_init_on_fresh_thread(thread_counter):
+    # --- arrange -----------------------------------------
+    result: dict[str, FlopCounts | bool] = {}
+
+    def worker() -> None:
+        # very first counter access on this thread: nothing pre-touched
+        THREAD_COUNTER.incr_add()
+        result["counts"] = THREAD_COUNTER.flop_counts()
+        result["active"] = THREAD_COUNTER.is_active()
+
+    # --- act ---------------------------------------------
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    # --- assert ------------------------------------------
+    assert result["counts"].ADD == 1, "the first counted op on a fresh thread must itself be counted"
+    assert result["counts"].total_count() == 1
+    assert result["active"] is True, "threads start unpaused"
+
+
+def test_threads_have_isolated_counts(thread_counter):
+    # --- arrange -----------------------------------------
+    thread_counter.incr_add()  # main thread: 1 ADD
+    observed: dict[str, FlopCounts] = {}
+
+    def worker() -> None:
+        for _ in range(3):
+            THREAD_COUNTER.incr_mul()
+        observed["worker"] = THREAD_COUNTER.flop_counts()
+
+    # --- act ---------------------------------------------
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    # --- assert ------------------------------------------
+    assert observed["worker"] == FlopCounts(MUL=3), "worker thread must see only its own counts"
+    assert thread_counter.flop_counts() == FlopCounts(ADD=1), "main thread must not see the worker's counts"
+
+
+def test_pause_is_per_thread(thread_counter):
+    # --- arrange -----------------------------------------
+    thread_counter.pause()  # pause the main thread only
+    observed: dict[str, FlopCounts] = {}
+
+    def worker() -> None:
+        THREAD_COUNTER.incr_mul()
+        observed["worker"] = THREAD_COUNTER.flop_counts()
+
+    # --- act ---------------------------------------------
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+    thread_counter.incr_add()  # main thread is paused: not counted
+
+    # --- assert ------------------------------------------
+    assert observed["worker"] == FlopCounts(MUL=1), "a paused main thread must not pause other threads"
+    assert thread_counter.flop_counts() == FlopCounts()


### PR DESCRIPTION
First step of the thread-local counting migration: a new `_thread_counter` module holding per-thread counting state on a bare `threading.local` (live counts + a discard sink, with pause implemented as an alias swap so the hot path stays branch-free), fronted by a cold-path facade that mirrors the global counter's API. Nothing is wired up yet — counting still runs through the process-global counter; hot-path call sites migrate next by inlining increments against the thread-local state directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)