### PR TITLE
feat: support free-threaded Python builds officially

### DIFF
--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -30,6 +30,12 @@ jobs:
           - { os: ubuntu-latest,  python: "3.14", resolution: highest,       all_extras: "false" }  # numba-absent shim
           - { os: macos-latest,   python: "3.13", resolution: highest,       all_extras: "true"  }  # OS-dependent CPU paths
           - { os: windows-latest, python: "3.13", resolution: highest,       all_extras: "true"  }  # OS-dependent CPU paths
+          # Free-threaded build: counting state is per-thread, so this leg is where the
+          # concurrency tests can actually fail for the reason they were written -- without the
+          # GIL serializing the increments they guard. `highest` resolution is required: the
+          # numba floor for 3.14 predates free-threaded wheels (first shipped in numba 0.65),
+          # and no PEP 508 marker can raise that floor for free-threaded builds only.
+          - { os: ubuntu-latest,  python: "3.14t", resolution: highest,      all_extras: "true"  }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - the flops benchmark now measures how `math.hypot` / `math.dist` latency scales with the number of coordinates, via new `HYPOT_XARG`, `DIST`, and `DIST_XARG` flop types
 - the flops benchmark now measures `math.gamma`, `math.lgamma`, `math.erf` and `math.erfc`
 - using a `FlopCountingContext` from a thread other than the one that opened it now raises instead of silently mixing state
+- free-threaded Python builds (3.14t) are now officially supported and CI-tested; the `numba` extra needs numba 0.65 or newer there
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Three facts worth knowing:
 
 - counting state is **per-thread**: a `FlopCountingContext` measures only the
   thread that opened it (open one context per worker thread to measure
-  multi-threaded code, and sum the results);
+  multi-threaded code, and sum the results). Free-threaded builds (3.14t) are
+  supported and CI-tested;
 - the overhead is inherent and `PauseFlopCounting` does **not** reduce it
   (the instrumented operators still execute; only count registration stops) —
   the escape hatch for hot uncounted regions is converting back via

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -68,7 +68,11 @@ counted region.
   is no per-task isolation. Note that while *any* thread has a context open,
   all threads see the patched `math.*` functions (patching is inherently
   process-wide); plain-float calls still take the fast path, and counts always
-  land in the thread performing the operation
+  land in the thread performing the operation. Free-threaded builds (3.14t) are
+  supported and covered by CI; counting there needs no lock, since each thread
+  mutates only its own state. Note that the `numba` extra requires **numba
+  0.65 or newer** on a free-threaded build — earlier versions ship no
+  free-threaded wheels
 - dict/set membership of `CountedFloat` keys inflates `COMP`: hash-bucket
   equality checks count as comparisons. This is consistent with the model
   (those comparisons really execute) but can surprise when a dict is used as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    # counting state is per-thread, so nothing is shared to race on a free-threaded build
+    "Programming Language :: Python :: Free Threading :: 3 - Stable",
     "Topic :: Scientific/Engineering",
 ]
 


### PR DESCRIPTION
Adds a required free-threaded (`3.14t`) leg to the unit-test matrix and documents the support.

The per-thread counting rework removed the shared mutable counter that made free-threaded builds lose increments, but nothing in CI could demonstrate that: under the GIL, the concurrency tests cannot fail for the reason they were written. This leg runs them where the increments genuinely race, which is what turns "correct by construction" into a checked claim.

The leg carries the `numba` extra rather than skipping it — numba has shipped free-threaded wheels since 0.65, as have llvmlite, numpy, pydantic-core and psutil, so the whole stack installs from wheels and the jitted benchmark kernels compile in nopython mode exactly as they do under the GIL. It pins `highest` resolution because the 3.14 numba floor predates those wheels and no PEP 508 marker can raise a floor for free-threaded builds only; that requirement is documented instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)