### PR TITLE
feat: log every counted flop at verbosity INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - the flops benchmark now measures `math.gamma`, `math.lgamma`, `math.erf` and `math.erfc`
 - using a `FlopCountingContext` from a thread other than the one that opened it now raises instead of silently mixing state
 - free-threaded Python builds (3.14t) are now officially supported and CI-tested; the `numba` extra needs numba 0.65 or newer there
+- `FlopCountingContext(verbosity=...)` can log every flop as it is counted, with the source line that triggered it and why it was counted that way
 
 ### Changed
 

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -245,6 +245,51 @@ counts = ctx.flop_counts()   # {FlopType.MUL: 1, FlopType.SUB: 1}
 counts.total_count()         # 2
 ```
 
+### Watching flops as they are counted
+
+A context can also report each flop as it registers it, instead of only totalling
+them. This is the tool for answering "why is this count 14 and not 12?" on a small
+snippet: it shows what was counted, where, and — where the counting rule is not
+self-evident from the expression — why.
+
+**Example 5**: _verbose counting_
+
+```python
+import math
+from counted_float import CountedFloat, FlopCountingContext, Verbosity
+
+cf = CountedFloat(1.73)
+
+with FlopCountingContext(verbosity=Verbosity.INFO) as ctx:
+    _ = cf * cf
+    _ = cf**2
+    _ = math.log(cf, 2)
+```
+
+writes to `stderr`:
+
+```text
+INFO  MUL         +1                                               my_algo.py:7
+INFO  MUL         +1     const exponent -> square-and-multiply     my_algo.py:8
+INFO  LOG2        +1     const base 2 -> log2                      my_algo.py:9
+```
+
+Every line names the flop type, how many of them that one statement registered,
+the rationale where the library applied a rule you did not write out (here:
+`cf**2` strength-reduces to a multiply, and a constant base 2 makes `log` a
+`log2`), and the line of *your* code that triggered it — never the library
+internals that did the counting.
+
+Three things worth knowing:
+
+- **The level applies to the whole thread while the block is open.** A context
+  opened inside a verbose one takes over until it exits, whatever level it asks
+  for — so a plain `FlopCountingContext()` is how you mute a noisy stretch.
+- **Paused flops are not logged**, for the same reason they are not counted.
+- **One line per counted flop, with no deduplication.** A loop doing a million
+  operations logs a million lines: this is a microscope for small snippets, not a
+  profiler for a whole run.
+
 ## Performance overhead
 
 Counting adds overhead in two forms, measured on an Apple M3 Max (see the

--- a/src/counted_float/__init__.py
+++ b/src/counted_float/__init__.py
@@ -9,7 +9,7 @@ try:
 except PackageNotFoundError:  # source tree without installed package metadata
     __version__ = "0.0.0"
 
-from ._core.counting import BuiltInData, CountedFloat, FlopCountingContext, PauseFlopCounting
+from ._core.counting import BuiltInData, CountedFloat, FlopCountingContext, PauseFlopCounting, Verbosity
 from ._core.models import FlopCounts, FlopType, FlopWeights, Quantiles, SystemInfo
 
 __all__ = [
@@ -22,6 +22,7 @@ __all__ = [
     "PauseFlopCounting",
     "Quantiles",
     "SystemInfo",
+    "Verbosity",
     "__version__",
     "config",
 ]

--- a/src/counted_float/_core/counting/__init__.py
+++ b/src/counted_float/_core/counting/__init__.py
@@ -1,3 +1,4 @@
 from ._builtin_data import BuiltInData
 from ._context_managers import FlopCountingContext, PauseFlopCounting
 from ._counted_float import CountedFloat
+from .verbosity import Verbosity

--- a/src/counted_float/_core/counting/_context_managers.py
+++ b/src/counted_float/_core/counting/_context_managers.py
@@ -172,6 +172,9 @@ class FlopCountingContext:
         apply_math_patches()
         self.__depth += 1
         if self.__depth == 1:
+            # only the outermost entry switches the level, and only the matching exit restores it:
+            # re-entering this same context would otherwise overwrite the replaced level with its
+            # own, leaving the final exit to restore that instead of the level from before the block
             self.__replaced_verbosity = THREAD_COUNTER.set_verbosity(self.__verbosity)
             self.__activate()
         return self

--- a/src/counted_float/_core/counting/_context_managers.py
+++ b/src/counted_float/_core/counting/_context_managers.py
@@ -9,6 +9,7 @@ from typing import Self
 
 from counted_float._core.counting._math_patching import apply_math_patches, remove_math_patches
 from counted_float._core.counting._thread_counter import THREAD_COUNTER
+from counted_float._core.counting.verbosity import Verbosity
 from counted_float._core.models import FlopCounts
 
 _CROSS_THREAD_MESSAGE = (
@@ -29,6 +30,9 @@ class FlopCountingContext:
     a cross-thread call would silently read or pause the *caller's* thread state).  To measure a
     multi-threaded computation, open a separate context per worker thread and sum the results.
 
+    Pass a `verbosity` level to have the context report each flop as it is registered, instead of
+    only totalling them (see Verbosity).
+
     LIMITATIONS:
         - not _all_ floating-point operations are counted, see the docs for more details.
     """
@@ -36,7 +40,18 @@ class FlopCountingContext:
     # -------------------------------------------------------------------------
     #  Constructor
     # -------------------------------------------------------------------------
-    def __init__(self) -> None:
+    def __init__(self, verbosity: Verbosity = Verbosity.OFF) -> None:
+        """Create a counting context.
+
+        Args:
+            verbosity: What to report about the flops registered while this context's with-block
+                is open.  The level applies to the whole thread, so a context opened inside this
+                one takes over until it exits, whatever level it asks for.
+        """
+        # Verbosity requested by this context, and the thread level it replaced while open
+        self.__verbosity: Verbosity = verbosity
+        self.__replaced_verbosity: Verbosity = Verbosity.OFF
+
         # Active/inactive flag  (toggled by __enter__ and __exit__ + by pause() and resume() methods)
         # When inactive:
         #   - current count == self.__cnt_subtotal
@@ -157,6 +172,7 @@ class FlopCountingContext:
         apply_math_patches()
         self.__depth += 1
         if self.__depth == 1:
+            self.__replaced_verbosity = THREAD_COUNTER.set_verbosity(self.__verbosity)
             self.__activate()
         return self
 
@@ -170,6 +186,7 @@ class FlopCountingContext:
         self.__depth -= 1
         if self.__depth == 0:
             self.__deactivate()
+            THREAD_COUNTER.set_verbosity(self.__replaced_verbosity)
             self.__owner_ident = None
         remove_math_patches()
 

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, SupportsIndex
 from ._thread_counter import _TLS, _create_thread_state
 
 if TYPE_CHECKING:
-    from counted_float._core.models import FlopCounts
+    from ._thread_counter import CountsTarget
 
 
 def count_pow_with_constant_exponent(exponent: float) -> None:
@@ -25,24 +25,31 @@ def count_pow_with_constant_exponent(exponent: float) -> None:
     if value in (0.0, 1.0):
         return
     try:
-        cnt: FlopCounts = _TLS.flop_counts
+        cnt: CountsTarget = _TLS.flop_counts
     except AttributeError:  # first counted op on this thread
-        cnt: FlopCounts = _create_thread_state()
+        cnt: CountsTarget = _create_thread_state()
     if value == 0.5:
+        cnt.note("const exponent 0.5 -> sqrt")
         cnt.SQRT += 1
         return
     if value == -0.5:
+        cnt.note("const exponent -0.5 -> sqrt + reciprocal")
         cnt.SQRT += 1
         cnt.DIV += 1
         return
     if value == -1.0:
+        cnt.note("const exponent -1 -> reciprocal")
         cnt.DIV += 1
         return
     if value.is_integer() and 2 <= abs(value) <= 16:
         n = abs(int(value))
         n_muls = (n.bit_length() - 1) + bin(n).count("1") - 1  # square-and-multiply cost
+        # a constant string, like every rationale: the counting sites hand one over on every call,
+        # so building one costs even the runs that never render it
+        cnt.note("const exponent -> square-and-multiply")
         cnt.MUL += n_muls
         if value < 0:
+            cnt.note("negative exponent -> reciprocal")
             cnt.DIV += 1
         return
     cnt.POW += 1
@@ -55,12 +62,14 @@ def count_pow_with_constant_base(base: float) -> None:
     """
     value = float(base)
     try:
-        cnt: FlopCounts = _TLS.flop_counts
+        cnt: CountsTarget = _TLS.flop_counts
     except AttributeError:  # first counted op on this thread
-        cnt: FlopCounts = _create_thread_state()
+        cnt: CountsTarget = _create_thread_state()
     if value == 2.0:
+        cnt.note("const base 2 -> exp2")
         cnt.EXP2 += 1
     elif value == 10.0:
+        cnt.note("const base 10 -> exp10")
         cnt.EXP10 += 1
     else:
         cnt.POW += 1
@@ -346,9 +355,9 @@ class CountedFloat(float):
         if result is NotImplemented:
             return NotImplemented
         try:
-            cnt: FlopCounts = _TLS.flop_counts
+            cnt: CountsTarget = _TLS.flop_counts
         except AttributeError:  # first counted op on this thread
-            cnt: FlopCounts = _create_thread_state()
+            cnt: CountsTarget = _create_thread_state()
         cnt.DIV += 1
         cnt.RND += 1
         return float.__new__(CountedFloat, result)
@@ -359,9 +368,9 @@ class CountedFloat(float):
         if result is NotImplemented:
             return NotImplemented
         try:
-            cnt: FlopCounts = _TLS.flop_counts
+            cnt: CountsTarget = _TLS.flop_counts
         except AttributeError:  # first counted op on this thread
-            cnt: FlopCounts = _create_thread_state()
+            cnt: CountsTarget = _create_thread_state()
         cnt.DIV += 1
         cnt.RND += 1
         return float.__new__(CountedFloat, result)
@@ -376,9 +385,9 @@ class CountedFloat(float):
         if result is NotImplemented:
             return NotImplemented
         try:
-            cnt: FlopCounts = _TLS.flop_counts
+            cnt: CountsTarget = _TLS.flop_counts
         except AttributeError:  # first counted op on this thread
-            cnt: FlopCounts = _create_thread_state()
+            cnt: CountsTarget = _create_thread_state()
         cnt.DIV += 1
         cnt.RND += 1
         cnt.MUL += 1
@@ -391,9 +400,9 @@ class CountedFloat(float):
         if result is NotImplemented:
             return NotImplemented
         try:
-            cnt: FlopCounts = _TLS.flop_counts
+            cnt: CountsTarget = _TLS.flop_counts
         except AttributeError:  # first counted op on this thread
-            cnt: FlopCounts = _create_thread_state()
+            cnt: CountsTarget = _create_thread_state()
         cnt.DIV += 1
         cnt.RND += 1
         cnt.MUL += 1
@@ -410,9 +419,9 @@ class CountedFloat(float):
         if result is NotImplemented:
             return NotImplemented
         try:
-            cnt: FlopCounts = _TLS.flop_counts
+            cnt: CountsTarget = _TLS.flop_counts
         except AttributeError:  # first counted op on this thread
-            cnt: FlopCounts = _create_thread_state()
+            cnt: CountsTarget = _create_thread_state()
         cnt.DIV += 1
         cnt.RND += 1
         cnt.MUL += 1
@@ -426,9 +435,9 @@ class CountedFloat(float):
         if result is NotImplemented:
             return NotImplemented
         try:
-            cnt: FlopCounts = _TLS.flop_counts
+            cnt: CountsTarget = _TLS.flop_counts
         except AttributeError:  # first counted op on this thread
-            cnt: FlopCounts = _create_thread_state()
+            cnt: CountsTarget = _create_thread_state()
         cnt.DIV += 1
         cnt.RND += 1
         cnt.MUL += 1

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -30,7 +30,7 @@ from ._thread_counter import _TLS, _create_thread_state
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from counted_float._core.models import FlopCounts
+    from ._thread_counter import CountsTarget
 
 
 def _math_fma_unavailable(x: float, y: float, z: float) -> float:
@@ -142,22 +142,26 @@ def math_log(  # noqa: C901 -- branches mirror the per-log-variant counting rule
     # computed first: raises per stdlib contract before anything is counted
     result = original_math_log(x, base)
     try:
-        cnt: FlopCounts = _TLS.flop_counts
+        cnt: CountsTarget = _TLS.flop_counts
     except AttributeError:  # first counted op on this thread
-        cnt: FlopCounts = _create_thread_state()
+        cnt: CountsTarget = _create_thread_state()
     if isinstance(base, CountedFloat):
+        cnt.note("runtime base -> log(x)/log(base)")
         if isinstance(x, CountedFloat):
             cnt.LOG += 1
         cnt.LOG += 1
         cnt.DIV += 1
     elif float(base) == 2.0:
         if isinstance(x, CountedFloat):
+            cnt.note("const base 2 -> log2")
             cnt.LOG2 += 1
     elif float(base) == 10.0:
         if isinstance(x, CountedFloat):
+            cnt.note("const base 10 -> log10")
             cnt.LOG10 += 1
     else:
         if isinstance(x, CountedFloat):
+            cnt.note("const base -> log(x) * 1/log(base)")
             cnt.LOG += 1
             cnt.MUL += 1
     if isinstance(x, CountedFloat) or isinstance(base, CountedFloat):
@@ -359,9 +363,9 @@ def math_hypot(*coordinates: float) -> float | CountedFloat:
     result = original_math_hypot(*coordinates)
     n = len(coordinates)
     try:
-        cnt: FlopCounts = _TLS.flop_counts
+        cnt: CountsTarget = _TLS.flop_counts
     except AttributeError:  # first counted op on this thread
-        cnt: FlopCounts = _create_thread_state()
+        cnt: CountsTarget = _create_thread_state()
     if n == 1:
         cnt.ABS += 1
     elif n == 2:
@@ -516,9 +520,9 @@ def math_dist(p: Iterable[float], q: Iterable[float]) -> float | CountedFloat:
         return result
     n = len(p_seq)
     try:
-        cnt: FlopCounts = _TLS.flop_counts
+        cnt: CountsTarget = _TLS.flop_counts
     except AttributeError:  # first counted op on this thread
-        cnt: FlopCounts = _create_thread_state()
+        cnt: CountsTarget = _create_thread_state()
     cnt.SUB += n
     cnt.MUL += n
     cnt.ADD += n - 1

--- a/src/counted_float/_core/counting/_thread_counter.py
+++ b/src/counted_float/_core/counting/_thread_counter.py
@@ -12,14 +12,20 @@ the alias.  Because the alias always points at a valid counts object, an increme
 one unconditional statement — ``_TLS.flop_counts.<FIELD> += 1`` — whether counting is
 paused or not; pause() and resume() just repoint the alias.
 
-A verbose thread gets a third target, ``flop_counts_logging``: a stand-in that logs each
+A verbose thread points the alias at a third kind of target: a stand-in that logs each
 increment on its way into ``flop_counts_active`` (see the verbosity subpackage).  It is
 selected by the same repointing, so verbose counting costs the counting sites nothing —
 at level OFF the alias points at the plain counts, exactly as it would without the
-feature.  Consequently the alias target is only ever a counts-shaped object to write
-through: reading counts back goes to ``flop_counts_active`` directly, and "is counting
-paused?" is a comparison against ``flop_counts_inactive`` rather than against the active
-counts.
+feature.  Only the level itself (``verbosity``) is kept per thread; the stand-in is built
+when a target is chosen, which happens only when one changes.
+
+Two invariants follow from the alias having three possible targets, and both are pinned by
+tests:
+
+  - "is counting paused?" is ``flop_counts is flop_counts_inactive`` — never a comparison
+    against ``flop_counts_active``, which a logging thread does not point at;
+  - reading counts back goes to ``flop_counts_active`` directly, never through the alias,
+    whose target is only ever a counts-shaped object to write through.
 
 Two kinds of code interact with this state:
 
@@ -96,16 +102,13 @@ def _counting_target() -> CountsTarget:
 
     That is the thread's plain counts, unless its verbosity level asks for the flops to be
     logged as they are registered, in which case increments are routed through a logging
-    stand-in wrapping those same counts.  The stand-in is created on the thread's first
-    verbose context and reused afterwards.
+    stand-in wrapping those same counts.  The stand-in is built here rather than kept on the
+    thread: choosing a target happens only when one changes — a context entry or exit, a
+    pause, a resume, a reset — never per counted flop.
     """
     if _TLS.verbosity is not Verbosity.INFO:
         return _TLS.flop_counts_active
-    try:
-        return _TLS.flop_counts_logging
-    except AttributeError:  # first verbose context on this thread
-        _TLS.flop_counts_logging = LoggingFlopCounts(_TLS.flop_counts_active)
-        return _TLS.flop_counts_logging
+    return LoggingFlopCounts(_TLS.flop_counts_active)
 
 
 class ThreadLocalFlopCounter:

--- a/src/counted_float/_core/counting/_thread_counter.py
+++ b/src/counted_float/_core/counting/_thread_counter.py
@@ -98,13 +98,13 @@ def _create_thread_state() -> CountsTarget:
 
 
 def _counting_target() -> CountsTarget:
-    """Return what increments go to while the calling thread's counting is not paused.
+    """Return the object this thread's increments should go to while it is counting.
 
-    That is the thread's plain counts, unless its verbosity level asks for the flops to be
-    logged as they are registered, in which case increments are routed through a logging
-    stand-in wrapping those same counts.  The stand-in is built here rather than kept on the
-    thread: choosing a target happens only when one changes — a context entry or exit, a
-    pause, a resume, a reset — never per counted flop.
+    At verbosity OFF that is the thread's own FlopCounts.  At INFO it is a LoggingFlopCounts
+    wrapping those same counts, which logs each increment before applying it.
+
+    A fresh wrapper is built per call, which is cheap: this runs when the target changes — a
+    context entry or exit, a pause, a resume, a reset — never per counted flop.
     """
     if _TLS.verbosity is not Verbosity.INFO:
         return _TLS.flop_counts_active

--- a/src/counted_float/_core/counting/_thread_counter.py
+++ b/src/counted_float/_core/counting/_thread_counter.py
@@ -68,12 +68,12 @@ import threading
 
 from counted_float._core.models import FlopCounts
 
-from .verbosity import LoggingFlopCounts, Verbosity
+from .verbosity import FlopCountsWithLogging, Verbosity
 
 # What the ``flop_counts`` alias may point at: the thread's plain counts (active or the paused
 # sink), or the logging stand-in a verbose thread writes through.  Counting sites treat the
 # target as an opaque counts-shaped object, so which one is installed never reaches them.
-CountsTarget = FlopCounts | LoggingFlopCounts
+CountsTarget = FlopCounts | FlopCountsWithLogging
 
 # A bare threading.local() rather than a subclass: CPython resolves attribute access on
 # exact threading.local instances through a fast C-level code path, while instances of
@@ -100,7 +100,7 @@ def _create_thread_state() -> CountsTarget:
 def _counting_target() -> CountsTarget:
     """Return the object this thread's increments should go to while it is counting.
 
-    At verbosity OFF that is the thread's own FlopCounts.  At INFO it is a LoggingFlopCounts
+    At verbosity OFF that is the thread's own FlopCounts.  At INFO it is a FlopCountsWithLogging
     wrapping those same counts, which logs each increment before applying it.
 
     A fresh wrapper is built per call, which is cheap: this runs when the target changes — a
@@ -108,7 +108,7 @@ def _counting_target() -> CountsTarget:
     """
     if _TLS.verbosity is not Verbosity.INFO:
         return _TLS.flop_counts_active
-    return LoggingFlopCounts(_TLS.flop_counts_active)
+    return FlopCountsWithLogging(_TLS.flop_counts_active)
 
 
 class ThreadLocalFlopCounter:

--- a/src/counted_float/_core/counting/_thread_counter.py
+++ b/src/counted_float/_core/counting/_thread_counter.py
@@ -8,9 +8,18 @@ access:
   - ``flop_counts_inactive`` : a sink that absorbs increments while counting is paused
 
 ``flop_counts`` is an alias pointing at one of the two, and increments always go through
-the alias.  Because the alias always points at a valid FlopCounts object, an increment is
+the alias.  Because the alias always points at a valid counts object, an increment is
 one unconditional statement — ``_TLS.flop_counts.<FIELD> += 1`` — whether counting is
 paused or not; pause() and resume() just repoint the alias.
+
+A verbose thread gets a third target, ``flop_counts_logging``: a stand-in that logs each
+increment on its way into ``flop_counts_active`` (see the verbosity subpackage).  It is
+selected by the same repointing, so verbose counting costs the counting sites nothing —
+at level OFF the alias points at the plain counts, exactly as it would without the
+feature.  Consequently the alias target is only ever a counts-shaped object to write
+through: reading counts back goes to ``flop_counts_active`` directly, and "is counting
+paused?" is a comparison against ``flop_counts_inactive`` rather than against the active
+counts.
 
 Two kinds of code interact with this state:
 
@@ -53,6 +62,13 @@ import threading
 
 from counted_float._core.models import FlopCounts
 
+from .verbosity import LoggingFlopCounts, Verbosity
+
+# What the ``flop_counts`` alias may point at: the thread's plain counts (active or the paused
+# sink), or the logging stand-in a verbose thread writes through.  Counting sites treat the
+# target as an opaque counts-shaped object, so which one is installed never reaches them.
+CountsTarget = FlopCounts | LoggingFlopCounts
+
 # A bare threading.local() rather than a subclass: CPython resolves attribute access on
 # exact threading.local instances through a fast C-level code path, while instances of
 # subclasses fall back to a slower generic lookup.  The difference is a few ns per
@@ -60,18 +76,36 @@ from counted_float._core.models import FlopCounts
 _TLS = threading.local()
 
 
-def _create_thread_state() -> FlopCounts:
+def _create_thread_state() -> CountsTarget:
     """Create the calling thread's counting state; returns the fresh ``flop_counts`` alias target.
 
     Only called when the calling thread has no state yet: from the facade's ``_ensure()``
-    and from hot-path ``except AttributeError`` handlers.  Returning the active counts
-    object lets such a handler initialize the state and still count the triggering
-    operation in a single statement.  Threads start with counting unpaused.
+    and from hot-path ``except AttributeError`` handlers.  Returning the alias target lets
+    such a handler initialize the state and still count the triggering operation in a
+    single statement.  Threads start with counting unpaused and verbosity off.
     """
     _TLS.flop_counts_active = FlopCounts()
     _TLS.flop_counts_inactive = FlopCounts()
-    _TLS.flop_counts = _TLS.flop_counts_active
+    _TLS.verbosity = Verbosity.OFF
+    _TLS.flop_counts = _counting_target()
     return _TLS.flop_counts
+
+
+def _counting_target() -> CountsTarget:
+    """Return what increments go to while the calling thread's counting is not paused.
+
+    That is the thread's plain counts, unless its verbosity level asks for the flops to be
+    logged as they are registered, in which case increments are routed through a logging
+    stand-in wrapping those same counts.  The stand-in is created on the thread's first
+    verbose context and reused afterwards.
+    """
+    if _TLS.verbosity is not Verbosity.INFO:
+        return _TLS.flop_counts_active
+    try:
+        return _TLS.flop_counts_logging
+    except AttributeError:  # first verbose context on this thread
+        _TLS.flop_counts_logging = LoggingFlopCounts(_TLS.flop_counts_active)
+        return _TLS.flop_counts_logging
 
 
 class ThreadLocalFlopCounter:
@@ -103,16 +137,16 @@ class ThreadLocalFlopCounter:
 
     def resume(self) -> None:
         self._ensure()
-        _TLS.flop_counts = _TLS.flop_counts_active
+        _TLS.flop_counts = _counting_target()
 
     def reset(self) -> None:
         self._ensure()
         _TLS.flop_counts_active.reset()
-        _TLS.flop_counts = _TLS.flop_counts_active  # reset also resumes
+        _TLS.flop_counts = _counting_target()  # reset also resumes
 
     def is_active(self) -> bool:
         self._ensure()
-        return _TLS.flop_counts is _TLS.flop_counts_active
+        return _TLS.flop_counts is not _TLS.flop_counts_inactive
 
     def flop_counts(self) -> FlopCounts:
         self._ensure()
@@ -129,6 +163,31 @@ class ThreadLocalFlopCounter:
             self._ensure()
             return getattr(_TLS.flop_counts_active, item)
         raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{item}'")
+
+    # -------------------------------------------------------------------------
+    #  Verbosity API
+    # -------------------------------------------------------------------------
+    def verbosity(self) -> Verbosity:
+        """Return the calling thread's current verbosity level."""
+        self._ensure()
+        return _TLS.verbosity
+
+    def set_verbosity(self, level: Verbosity) -> Verbosity:
+        """Set the calling thread's verbosity level.
+
+        Args:
+            level: Level to switch this thread to.
+
+        Returns:
+            The level that was replaced, so the caller can restore it — which is how nested
+            counting contexts give the innermost one's level precedence.
+        """
+        self._ensure()
+        previous: Verbosity = _TLS.verbosity
+        _TLS.verbosity = level
+        if _TLS.flop_counts is not _TLS.flop_counts_inactive:
+            _TLS.flop_counts = _counting_target()  # paused threads pick the new target up on resume()
+        return previous
 
     # -------------------------------------------------------------------------
     #  Incrementing counts  (unit tests only -- production counting sites inline

--- a/src/counted_float/_core/counting/_thread_counter.py
+++ b/src/counted_float/_core/counting/_thread_counter.py
@@ -93,22 +93,8 @@ def _create_thread_state() -> CountsTarget:
     _TLS.flop_counts_active = FlopCounts()
     _TLS.flop_counts_inactive = FlopCounts()
     _TLS.verbosity = Verbosity.OFF
-    _TLS.flop_counts = _counting_target()
+    _TLS.flop_counts = ThreadLocalFlopCounter.counts_target_for_verbosity()
     return _TLS.flop_counts
-
-
-def _counting_target() -> CountsTarget:
-    """Return the object this thread's increments should go to while it is counting.
-
-    At verbosity OFF that is the thread's own FlopCounts.  At INFO it is a FlopCountsWithLogging
-    wrapping those same counts, which logs each increment before applying it.
-
-    A fresh wrapper is built per call, which is cheap: this runs when the target changes — a
-    context entry or exit, a pause, a resume, a reset — never per counted flop.
-    """
-    if _TLS.verbosity is not Verbosity.INFO:
-        return _TLS.flop_counts_active
-    return FlopCountsWithLogging(_TLS.flop_counts_active)
 
 
 class ThreadLocalFlopCounter:
@@ -134,18 +120,33 @@ class ThreadLocalFlopCounter:
         except AttributeError:
             _create_thread_state()
 
+    @staticmethod
+    def counts_target_for_verbosity() -> CountsTarget:
+        """Return the object this thread's increments should go to while it is counting.
+
+        At verbosity OFF that is the thread's own FlopCounts.  At INFO it is a
+        FlopCountsWithLogging wrapping those same counts, which logs each increment before
+        applying it.
+
+        A fresh wrapper is built per call, which is cheap: this runs when the target changes — a
+        context entry or exit, a pause, a resume, a reset — never per counted flop.
+        """
+        if _TLS.verbosity is not Verbosity.INFO:
+            return _TLS.flop_counts_active
+        return FlopCountsWithLogging(_TLS.flop_counts_active)
+
     def pause(self) -> None:
         self._ensure()
         _TLS.flop_counts = _TLS.flop_counts_inactive
 
     def resume(self) -> None:
         self._ensure()
-        _TLS.flop_counts = _counting_target()
+        _TLS.flop_counts = self.counts_target_for_verbosity()
 
     def reset(self) -> None:
         self._ensure()
         _TLS.flop_counts_active.reset()
-        _TLS.flop_counts = _counting_target()  # reset also resumes
+        _TLS.flop_counts = self.counts_target_for_verbosity()  # reset also resumes
 
     def is_active(self) -> bool:
         self._ensure()
@@ -189,7 +190,7 @@ class ThreadLocalFlopCounter:
         previous: Verbosity = _TLS.verbosity
         _TLS.verbosity = level
         if _TLS.flop_counts is not _TLS.flop_counts_inactive:
-            _TLS.flop_counts = _counting_target()  # paused threads pick the new target up on resume()
+            _TLS.flop_counts = self.counts_target_for_verbosity()  # paused threads pick the new target up on resume()
         return previous
 
     # -------------------------------------------------------------------------

--- a/src/counted_float/_core/counting/_thread_counter.py
+++ b/src/counted_float/_core/counting/_thread_counter.py
@@ -22,8 +22,10 @@ when a target is chosen, which happens only when one changes.
 Two invariants follow from the alias having three possible targets, and both are pinned by
 tests:
 
-  - "is counting paused?" is ``flop_counts is flop_counts_inactive`` — never a comparison
-    against ``flop_counts_active``, which a logging thread does not point at;
+  - "is this thread counting?" is derived from the alias in exactly one place, ``is_active()``,
+    and everything needing the answer calls it.  The comparison is against
+    ``flop_counts_inactive``; re-deriving it against ``flop_counts_active`` answers wrongly for
+    a thread whose increments are routed through a logging target;
   - reading counts back goes to ``flop_counts_active`` directly, never through the alias,
     whose target is only ever a counts-shaped object to write through.
 
@@ -149,6 +151,13 @@ class ThreadLocalFlopCounter:
         _TLS.flop_counts = self.counts_target_for_verbosity()  # reset also resumes
 
     def is_active(self) -> bool:
+        """Return whether the calling thread is counting, i.e. not paused.
+
+        The single place that derives this from the alias.  Anything else needing the answer
+        calls this rather than comparing targets again: the comparison is against the *inactive*
+        counts, and re-deriving it against the active ones would answer wrongly for a thread
+        whose increments are routed through a logging target.
+        """
         self._ensure()
         return _TLS.flop_counts is not _TLS.flop_counts_inactive
 
@@ -189,8 +198,8 @@ class ThreadLocalFlopCounter:
         self._ensure()
         previous: Verbosity = _TLS.verbosity
         _TLS.verbosity = level
-        if _TLS.flop_counts is not _TLS.flop_counts_inactive:
-            _TLS.flop_counts = self.counts_target_for_verbosity()  # paused threads pick the new target up on resume()
+        if self.is_active():
+            _TLS.flop_counts = self.counts_target_for_verbosity()  # paused threads pick it up on resume()
         return previous
 
     # -------------------------------------------------------------------------

--- a/src/counted_float/_core/counting/verbosity/__init__.py
+++ b/src/counted_float/_core/counting/verbosity/__init__.py
@@ -1,0 +1,2 @@
+from ._logging_flop_counts import LoggingFlopCounts
+from ._verbosity import Verbosity

--- a/src/counted_float/_core/counting/verbosity/__init__.py
+++ b/src/counted_float/_core/counting/verbosity/__init__.py
@@ -1,2 +1,2 @@
-from ._logging_flop_counts import LoggingFlopCounts
+from ._flop_counts_with_logging import FlopCountsWithLogging
 from ._verbosity import Verbosity

--- a/src/counted_float/_core/counting/verbosity/_callsite.py
+++ b/src/counted_float/_core/counting/verbosity/_callsite.py
@@ -19,9 +19,11 @@ def resolve_callsite() -> str:
     microscope for small snippets, where a full path is noise.
 
     Returns:
-        ``file.py:lineno``, or ``<unknown>`` when every frame on the stack belongs to this
-        package — which happens when counted code is driven from a C-level caller that has no
-        Python frame of its own.
+        ``file.py:lineno``, or ``<unknown>`` when no frame outside this package is on the stack.
+        The fallback is there to make the walk fail-safe — there is always a string to report —
+        rather than to describe a situation callers will meet: the entry module (``__main__``,
+        pytest, a notebook) is always a frame outside the package, so the only realistic way in
+        is the package driving counted code itself, e.g. in its own tests.
     """
     frame = sys._getframe(1)  # noqa: SLF001 -- the documented way to walk the Python stack
     while frame is not None:

--- a/src/counted_float/_core/counting/verbosity/_callsite.py
+++ b/src/counted_float/_core/counting/verbosity/_callsite.py
@@ -1,0 +1,32 @@
+"""Resolution of the user-code location that triggered a counted flop."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PACKAGE = "counted_float"
+_PACKAGE_PREFIX = "counted_float."
+_UNKNOWN = "<unknown>"
+
+
+def resolve_callsite() -> str:
+    """Return ``file.py:lineno`` for the innermost stack frame outside this package.
+
+    Walks outward past the counting machinery's own frames (operators, ``math`` replacements, the
+    logging target) so the reported location is the expression the user wrote rather than the
+    internals that counted it.  Only the file's base name is reported: verbose counting is a
+    microscope for small snippets, where a full path is noise.
+
+    Returns:
+        ``file.py:lineno``, or ``<unknown>`` when every frame on the stack belongs to this
+        package — which happens when counted code is driven from a C-level caller that has no
+        Python frame of its own.
+    """
+    frame = sys._getframe(1)  # noqa: SLF001 -- the documented way to walk the Python stack
+    while frame is not None:
+        module_name = frame.f_globals.get("__name__", "")
+        if module_name != _PACKAGE and not module_name.startswith(_PACKAGE_PREFIX):
+            return f"{Path(frame.f_code.co_filename).name}:{frame.f_lineno}"
+        frame = frame.f_back
+    return _UNKNOWN

--- a/src/counted_float/_core/counting/verbosity/_flop_counts_with_logging.py
+++ b/src/counted_float/_core/counting/verbosity/_flop_counts_with_logging.py
@@ -12,9 +12,9 @@ if TYPE_CHECKING:
 
 
 # =================================================================================================
-#  LoggingFlopCounts
+#  FlopCountsWithLogging
 # =================================================================================================
-class LoggingFlopCounts:
+class FlopCountsWithLogging:
     """Counts object that logs each flop registered on it, then forwards it to the real counts.
 
     While a thread counts verbosely, its increments are sent here instead of straight into its own

--- a/src/counted_float/_core/counting/verbosity/_logging_flop_counts.py
+++ b/src/counted_float/_core/counting/verbosity/_logging_flop_counts.py
@@ -15,16 +15,17 @@ if TYPE_CHECKING:
 #  LoggingFlopCounts
 # =================================================================================================
 class LoggingFlopCounts:
-    """Increment target that logs each registered flop before forwarding it to the real counts.
+    """Counts object that logs each flop registered on it, then forwards it to the real counts.
 
-    While a thread's counting is verbose, this stands in for that thread's plain FlopCounts in the
-    alias slot pause() and resume() already swap.  Writing a count field logs the increment it
-    carries and then applies it to the wrapped counts, so counting sites keep executing exactly the
-    same ``<target>.<FIELD> += 1`` statement they execute when verbosity is off -- which is what
-    makes verbosity free at level OFF: no counting site tests a verbosity flag of its own.
+    While a thread counts verbosely, its increments are sent here instead of straight into its own
+    FlopCounts -- the same redirection ``pause()`` uses to send them into a discard sink instead.
+    Writing a count field logs the increment and then applies it to the wrapped counts, so counting
+    sites keep executing the same ``<target>.<FIELD> += 1`` statement they execute when verbosity
+    is off.  That is what makes verbosity free at level OFF: no counting site tests a flag of its
+    own.
 
-    Only the increment path is proxied.  Reading counts back goes to the wrapped FlopCounts
-    directly, as the thread counter's read path does.
+    Only writes are handled here.  Reading counts back goes to the wrapped FlopCounts directly, as
+    the thread counter's read path does.
     """
 
     __slots__ = ("_counts", "_pending_rationale", "_writer")

--- a/src/counted_float/_core/counting/verbosity/_logging_flop_counts.py
+++ b/src/counted_float/_core/counting/verbosity/_logging_flop_counts.py
@@ -1,0 +1,90 @@
+"""Counts target that logs the flops registered on it."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ._callsite import resolve_callsite
+from ._output import VerbosityWriter
+
+if TYPE_CHECKING:
+    from counted_float._core.models import FlopCounts
+
+
+# =================================================================================================
+#  LoggingFlopCounts
+# =================================================================================================
+class LoggingFlopCounts:
+    """Increment target that logs each registered flop before forwarding it to the real counts.
+
+    While a thread's counting is verbose, this stands in for that thread's plain FlopCounts in the
+    alias slot pause() and resume() already swap.  Writing a count field logs the increment it
+    carries and then applies it to the wrapped counts, so counting sites keep executing exactly the
+    same ``<target>.<FIELD> += 1`` statement they execute when verbosity is off -- which is what
+    makes verbosity free at level OFF: no counting site tests a verbosity flag of its own.
+
+    Only the increment path is proxied.  Reading counts back goes to the wrapped FlopCounts
+    directly, as the thread counter's read path does.
+    """
+
+    __slots__ = ("_counts", "_pending_rationale", "_writer")
+
+    # -------------------------------------------------------------------------
+    #  Constructor
+    # -------------------------------------------------------------------------
+    def __init__(self, counts: FlopCounts) -> None:
+        """Wrap the counts that increments are forwarded to.
+
+        Args:
+            counts: The thread's real counts; this target logs on the way there and holds no
+                counts of its own.
+        """
+        self._counts = counts
+        self._writer = VerbosityWriter.shared()
+        self._pending_rationale = ""
+
+    # -------------------------------------------------------------------------
+    #  Increment-target contract
+    # -------------------------------------------------------------------------
+    def note(self, rationale: str) -> None:
+        """Render `rationale` on the line logged for the next flop registered here.
+
+        Args:
+            rationale: Short explanation of the counting rule being applied.
+        """
+        self._pending_rationale = rationale
+
+    def __getattr__(self, name: str) -> int:
+        """Read a count field from the wrapped counts.
+
+        Only reached for attributes this object does not have itself, which is exactly the count
+        fields -- its own live in ``__slots__``.  An unknown name raises, as it would on the
+        wrapped counts, so a mistyped field is still caught at the counting site.
+
+        Args:
+            name: Name of the count field to read.
+
+        Returns:
+            The wrapped counts' current value for that field.
+        """
+        return getattr(self._counts, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:  # noqa: ANN401 -- the name decides the type
+        """Log a count field's increment, then apply it to the wrapped counts.
+
+        ``target.FIELD += n`` reads through ``__getattr__`` and writes back through here, so a
+        counting site's single increment statement becomes one log line plus the real increment.
+
+        Args:
+            name: Name of the count field being written, or of one of this object's own
+                (underscore-prefixed) attributes, which are set as-is.
+            value: The field's new value.
+        """
+        if name.startswith("_"):
+            object.__setattr__(self, name, value)
+            return
+        counts = self._counts
+        increment = value - getattr(counts, name)
+        setattr(counts, name, value)
+        rationale, self._pending_rationale = self._pending_rationale, ""
+        self._writer.write_flop(name, increment, rationale, resolve_callsite())

--- a/src/counted_float/_core/counting/verbosity/_output.py
+++ b/src/counted_float/_core/counting/verbosity/_output.py
@@ -1,0 +1,108 @@
+"""Rendering of verbose counting output to stderr."""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+# --- column widths -----------------------------------
+# Alignment does the structural work of the output, so the columns are fixed-width: the level tag
+# and the flop type are sized to their longest member, the count column to a four-digit bulk
+# increment, and the rationale column to the longest rationale the counting rules produce.  The
+# location closes each line, at whatever width it needs.  A longer-than-expected field pushes the
+# rest of its line right rather than being truncated -- a misaligned line beats a lost message.
+_LEVEL_WIDTH = 4
+_FLOP_TYPE_WIDTH = 10
+_COUNT_WIDTH = 5
+_RATIONALE_WIDTH = 40
+
+
+# =================================================================================================
+#  VerbosityWriter
+# =================================================================================================
+class VerbosityWriter:
+    """Writes one line per counting event to stderr.
+
+    Output goes through a rich Console, which handles ``NO_COLOR`` and non-terminal streams by
+    itself, so the color scheme stays decorative: every line reads the same uncolored.
+    """
+
+    # one writer per process, so that rich's own output lock serializes the lines logged by
+    # concurrently counting threads instead of letting them interleave mid-line
+    _shared: VerbosityWriter | None = None
+    _shared_lock = threading.Lock()
+
+    # -------------------------------------------------------------------------
+    #  Constructor
+    # -------------------------------------------------------------------------
+    def __init__(self) -> None:
+        # imported here rather than at module level, so that importing this module -- which the
+        # counting core does, whatever the verbosity level -- costs nothing until a context
+        # actually asks for output
+        from rich.console import Console
+
+        # soft_wrap: these lines are tabular, so they must not be wrapped or cropped to the
+        # terminal width
+        self._console: Console = Console(stderr=True, highlight=False, soft_wrap=True)
+
+    @classmethod
+    def shared(cls) -> VerbosityWriter:
+        """Return the process-wide writer, creating it on first use."""
+        with cls._shared_lock:
+            if cls._shared is None:
+                cls._shared = cls()
+            return cls._shared
+
+    # -------------------------------------------------------------------------
+    #  Writing events
+    # -------------------------------------------------------------------------
+    def write_flop(self, flop_type: str, count: int, rationale: str, location: str) -> None:
+        """Log a registered flop count.
+
+        Args:
+            flop_type: Name of the flop type that was counted.
+            count: How many of them the single counting statement registered.
+            rationale: Short explanation of a counting rule that is not self-evident from the
+                source expression; empty when there is nothing to explain.
+            location: ``file.py:lineno`` of the user code that triggered the count.
+        """
+        from rich.text import Text
+
+        self._console.print(
+            Text.assemble(
+                (f"{'INFO':<{_LEVEL_WIDTH}}", "dim cyan"),
+                "  ",
+                # the column the eye scans, so it gets weight rather than a hue of its own
+                (f"{flop_type:<{_FLOP_TYPE_WIDTH}}", "bold"),
+                "  ",
+                f"{f'+{count}':<{_COUNT_WIDTH}}",
+                "  ",
+                (f"{rationale:<{_RATIONALE_WIDTH}}", "dim"),
+                "  ",
+                *_location_spans(location),
+            )
+        )
+
+
+# =================================================================================================
+#  Helpers
+# =================================================================================================
+def _location_spans(location: str) -> tuple[tuple[str, str], ...]:
+    """Split ``file.py:42`` into a dim path span and a normal-intensity line-number span.
+
+    The line number is what a reader jumps to, so it keeps full intensity while the file name
+    around it recedes.
+
+    Args:
+        location: A ``file.py:lineno`` location, or any string without a line number.
+
+    Returns:
+        Styled spans ready to pass to rich's ``Text.assemble``.
+    """
+    file_name, separator, line_number = location.rpartition(":")
+    if not separator:
+        return ((location, "dim"),)
+    return ((f"{file_name}:", "dim"), (line_number, "default"))

--- a/src/counted_float/_core/counting/verbosity/_verbosity.py
+++ b/src/counted_float/_core/counting/verbosity/_verbosity.py
@@ -1,0 +1,15 @@
+"""Verbosity levels for flop-counting contexts."""
+
+from enum import StrEnum
+
+
+class Verbosity(StrEnum):
+    """How much a counting context reports about the flops it registers, as it registers them.
+
+    ``OFF`` is the default and reports nothing; it is also the only level counting sites pay
+    nothing for.  ``INFO`` logs one line per registered flop, with the source location that
+    triggered it and, where the counting rule applied is not self-evident, a short rationale.
+    """
+
+    OFF = "off"
+    INFO = "info"

--- a/src/counted_float/_core/models/_flop_counts.py
+++ b/src/counted_float/_core/models/_flop_counts.py
@@ -103,7 +103,7 @@ class FlopCounts:
 
     # --- increment-target contract -----------------------
     def note(self, rationale: str) -> None:
-        """No-op counterpart of `LoggingFlopCounts.note()`: the rationale is dropped.
+        """No-op counterpart of `FlopCountsWithLogging.note()`: the rationale is dropped.
 
         Counting sites explain their less obvious decisions unconditionally, so plain counts have
         to accept a rationale too — they simply have nowhere to render it.

--- a/src/counted_float/_core/models/_flop_counts.py
+++ b/src/counted_float/_core/models/_flop_counts.py
@@ -101,6 +101,20 @@ class FlopCounts:
             count * weights.weights[flop_type] for flop_type in FlopType if (count := getattr(self, flop_type.name))
         )
 
+    # --- increment-target contract -----------------------
+    def note(self, rationale: str) -> None:
+        """Discard a rationale for the next flop counted here.
+
+        Counting sites explain their less obvious counting decisions unconditionally, and only a
+        target that renders those explanations (the logging target a verbose counting context
+        installs in place of these counts) does anything with them.
+
+        Args:
+            rationale: Short explanation of the counting rule being applied; ignored here.  Keep
+                it a constant string — counting sites build it on every call, including the runs
+                (like this one) that end up discarding it.
+        """
+
     # --- other -------------------------------------------
     def reset(self) -> None:
         """Reset all counts to 0."""

--- a/src/counted_float/_core/models/_flop_counts.py
+++ b/src/counted_float/_core/models/_flop_counts.py
@@ -103,16 +103,14 @@ class FlopCounts:
 
     # --- increment-target contract -----------------------
     def note(self, rationale: str) -> None:
-        """Discard a rationale for the next flop counted here.
+        """No-op counterpart of `LoggingFlopCounts.note()`: the rationale is dropped.
 
-        Counting sites explain their less obvious counting decisions unconditionally, and only a
-        target that renders those explanations (the logging target a verbose counting context
-        installs in place of these counts) does anything with them.
+        Counting sites explain their less obvious decisions unconditionally, so plain counts have
+        to accept a rationale too — they simply have nowhere to render it.
 
         Args:
-            rationale: Short explanation of the counting rule being applied; ignored here.  Keep
-                it a constant string — counting sites build it on every call, including the runs
-                (like this one) that end up discarding it.
+            rationale: Why the next flop is counted the way it is; unused here.  Keep it a
+                constant string: every call builds one, including the calls that discard it.
         """
 
     # --- other -------------------------------------------

--- a/tests/counting/conftest.py
+++ b/tests/counting/conftest.py
@@ -4,6 +4,20 @@ from counted_float import FlopCountingContext
 from counted_float._core.counting._thread_counter import THREAD_COUNTER, ThreadLocalFlopCounter
 
 
+@pytest.fixture(autouse=True)
+def restore_verbosity():
+    """Restore the worker thread's verbosity level after each test.
+
+    Verbosity is thread state that outlives a test: one that sets it directly (or fails inside a
+    context before it is restored) would otherwise leave every later test in the same worker
+    logging its counts.
+    """
+
+    previous = THREAD_COUNTER.verbosity()
+    yield
+    THREAD_COUNTER.set_verbosity(previous)
+
+
 @pytest.fixture
 def thread_counter() -> ThreadLocalFlopCounter:
     """

--- a/tests/counting/test_thread_counter.py
+++ b/tests/counting/test_thread_counter.py
@@ -2,6 +2,7 @@ import threading
 
 import pytest
 
+from counted_float import Verbosity
 from counted_float._core.counting._thread_counter import THREAD_COUNTER, ThreadLocalFlopCounter
 from counted_float._core.models import FlopCounts
 
@@ -163,6 +164,67 @@ def test_pause_swap_keeps_live_untouched(thread_counter):
     thread_counter.resume()
     assert thread_counter.flop_counts() == snapshot
     assert thread_counter.is_active()
+
+
+# ==================================================================================================
+#  Verbosity
+# ==================================================================================================
+def test_verbosity_defaults_to_off(thread_counter):
+    # --- act & assert ------------------------------------
+    assert thread_counter.verbosity() == Verbosity.OFF
+
+
+def test_set_verbosity_returns_the_replaced_level(thread_counter):
+    # --- act ---------------------------------------------
+    replaced_by_info = thread_counter.set_verbosity(Verbosity.INFO)
+    replaced_by_off = thread_counter.set_verbosity(Verbosity.OFF)
+
+    # --- assert ------------------------------------------
+    assert replaced_by_info == Verbosity.OFF
+    assert replaced_by_off == Verbosity.INFO
+
+
+def test_counting_through_the_logging_target_still_counts(thread_counter, capsys):
+    # --- act ---------------------------------------------
+    thread_counter.set_verbosity(Verbosity.INFO)
+    thread_counter.incr_add()
+
+    # --- assert ------------------------------------------
+    assert thread_counter.is_active(), "A logging target is not a paused one."
+    assert thread_counter.flop_counts() == FlopCounts(ADD=1)
+    assert "ADD" in capsys.readouterr().err
+
+
+def test_pause_and_resume_keep_the_logging_target(thread_counter, capsys):
+    # --- arrange -----------------------------------------
+    thread_counter.set_verbosity(Verbosity.INFO)
+
+    # --- act ---------------------------------------------
+    thread_counter.pause()
+    thread_counter.incr_mul()  # lands in the discard sink, so there is nothing to log
+    paused_output = capsys.readouterr().err
+    thread_counter.resume()
+    thread_counter.incr_mul()
+    resumed_output = capsys.readouterr().err
+
+    # --- assert ------------------------------------------
+    assert paused_output == ""
+    assert "MUL" in resumed_output
+    assert thread_counter.flop_counts() == FlopCounts(MUL=1)
+
+
+def test_reset_resumes_into_the_logging_target(thread_counter, capsys):
+    # --- arrange -----------------------------------------
+    thread_counter.set_verbosity(Verbosity.INFO)
+    thread_counter.pause()
+
+    # --- act ---------------------------------------------
+    thread_counter.reset()  # reset also resumes
+    thread_counter.incr_add()
+
+    # --- assert ------------------------------------------
+    assert thread_counter.is_active()
+    assert "ADD" in capsys.readouterr().err
 
 
 # ==================================================================================================

--- a/tests/counting/verbosity/conftest.py
+++ b/tests/counting/verbosity/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture
+def logged_lines(capsys):
+    """Return a reader for the non-empty lines logged to stderr so far."""
+
+    def read() -> list[str]:
+        return [line for line in capsys.readouterr().err.splitlines() if line.strip()]
+
+    return read

--- a/tests/counting/verbosity/test_callsite.py
+++ b/tests/counting/verbosity/test_callsite.py
@@ -1,0 +1,46 @@
+import sys
+
+from counted_float._core.counting.verbosity._callsite import resolve_callsite
+
+
+# ==================================================================================================
+#  Locating the caller
+# ==================================================================================================
+def test_resolve_callsite_reports_the_calling_line():
+    # --- act ---------------------------------------------
+    callsite, this_line = resolve_callsite(), sys._getframe().f_lineno  # one line, so both report it
+
+    # --- assert ------------------------------------------
+    assert callsite == f"test_callsite.py:{this_line}"
+
+
+def test_resolve_callsite_skips_frames_inside_the_package():
+    # --- arrange -----------------------------------------
+    # a frame that claims to live in the package, as every counting-machinery frame does
+    package_frame = compile(
+        "from counted_float._core.counting.verbosity._callsite import resolve_callsite\n"
+        "callsite = resolve_callsite()\n",
+        "_counted_float.py",
+        "exec",
+    )
+    namespace = {"__name__": "counted_float._core.counting._counted_float"}
+
+    # --- act ---------------------------------------------
+    exec(package_frame, namespace)  # noqa: S102 -- fabricating a package frame is the point
+
+    # --- assert ------------------------------------------
+    assert namespace["callsite"].startswith("test_callsite.py:"), (
+        "The package's own frame should have been walked past, down to this test's frame."
+    )
+
+
+def test_resolve_callsite_without_any_user_frame(monkeypatch):
+    # --- arrange -----------------------------------------
+    # counted code driven from a C-level caller leaves no Python frame to attribute it to
+    monkeypatch.setattr(sys, "_getframe", lambda _depth: None)
+
+    # --- act ---------------------------------------------
+    callsite = resolve_callsite()
+
+    # --- assert ------------------------------------------
+    assert callsite == "<unknown>"

--- a/tests/counting/verbosity/test_callsite.py
+++ b/tests/counting/verbosity/test_callsite.py
@@ -38,7 +38,8 @@ def test_resolve_callsite_skips_frames_inside_the_package():
 
 def test_resolve_callsite_without_any_user_frame(monkeypatch):
     # --- arrange -----------------------------------------
-    # counted code driven from a C-level caller leaves no Python frame to attribute it to
+    # the walk only gives up when no frame outside the package is left, which a caller of the
+    # library never produces -- simulated here by taking the stack away entirely
     monkeypatch.setattr(sys, "_getframe", lambda _depth: None)
 
     # --- act ---------------------------------------------

--- a/tests/counting/verbosity/test_callsite.py
+++ b/tests/counting/verbosity/test_callsite.py
@@ -16,11 +16,13 @@ def test_resolve_callsite_reports_the_calling_line():
 
 def test_resolve_callsite_skips_frames_inside_the_package():
     # --- arrange -----------------------------------------
-    # a frame that claims to live in the package, as every counting-machinery frame does
+    # a frame that claims to live in the package, as every counting-machinery frame does.  The
+    # angle-bracketed file name keeps coverage from tracing this fabricated code as if it were a
+    # source file of its own (it has none on disk).
     package_frame = compile(
         "from counted_float._core.counting.verbosity._callsite import resolve_callsite\n"
         "callsite = resolve_callsite()\n",
-        "_counted_float.py",
+        "<fabricated counted_float frame>",
         "exec",
     )
     namespace = {"__name__": "counted_float._core.counting._counted_float"}

--- a/tests/counting/verbosity/test_flop_counts_with_logging.py
+++ b/tests/counting/verbosity/test_flop_counts_with_logging.py
@@ -1,7 +1,7 @@
 import pytest
 
 from counted_float import FlopCounts
-from counted_float._core.counting.verbosity import LoggingFlopCounts
+from counted_float._core.counting.verbosity import FlopCountsWithLogging
 
 
 @pytest.fixture
@@ -10,8 +10,8 @@ def counts() -> FlopCounts:
 
 
 @pytest.fixture
-def target(counts) -> LoggingFlopCounts:
-    return LoggingFlopCounts(counts)
+def target(counts) -> FlopCountsWithLogging:
+    return FlopCountsWithLogging(counts)
 
 
 # ==================================================================================================
@@ -75,7 +75,7 @@ def test_the_logged_line_reports_the_incrementing_location(target, logged_lines)
 
     # --- assert ------------------------------------------
     (line,) = logged_lines()
-    assert "test_logging_flop_counts.py:" in line
+    assert "test_flop_counts_with_logging.py:" in line
 
 
 # ==================================================================================================
@@ -111,4 +111,4 @@ def test_lines_without_a_note_carry_no_rationale(target, logged_lines):
     (line,) = logged_lines()
     level, flop_type, count, location = line.split()
     assert (level, flop_type, count) == ("INFO", "ADD", "+1")
-    assert location.startswith("test_logging_flop_counts.py:")
+    assert location.startswith("test_flop_counts_with_logging.py:")

--- a/tests/counting/verbosity/test_info_counting.py
+++ b/tests/counting/verbosity/test_info_counting.py
@@ -113,15 +113,6 @@ def test_counts_are_the_same_whether_or_not_they_are_logged():
     assert verbose.flop_counts() == silent.flop_counts()
 
 
-def test_counting_stays_active_while_logging():
-    # --- act ---------------------------------------------
-    with FlopCountingContext(verbosity=Verbosity.INFO):
-        is_active = THREAD_COUNTER.is_active()
-
-    # --- assert ------------------------------------------
-    assert is_active, "Routing increments through the logging target should not read as 'paused'."
-
-
 # ==================================================================================================
 #  Interaction with pausing
 # ==================================================================================================

--- a/tests/counting/verbosity/test_info_counting.py
+++ b/tests/counting/verbosity/test_info_counting.py
@@ -182,7 +182,9 @@ def test_re_entering_one_context_keeps_its_level():
         with ctx:
             level_nested = THREAD_COUNTER.verbosity()
         level_outer = THREAD_COUNTER.verbosity()
+    level_after = THREAD_COUNTER.verbosity()
 
     # --- assert ------------------------------------------
     assert level_nested == Verbosity.INFO
     assert level_outer == Verbosity.INFO
+    assert level_after == Verbosity.OFF, "Re-entry must not leak the level past the outermost exit."

--- a/tests/counting/verbosity/test_info_counting.py
+++ b/tests/counting/verbosity/test_info_counting.py
@@ -1,0 +1,197 @@
+import math
+
+import pytest
+
+from counted_float import CountedFloat, FlopCountingContext, PauseFlopCounting, Verbosity
+from counted_float._core.counting._thread_counter import THREAD_COUNTER
+
+
+# ==================================================================================================
+#  What gets logged
+# ==================================================================================================
+def test_info_logs_every_counted_flop(logged_lines):
+    # --- arrange -----------------------------------------
+    x = CountedFloat(3.0)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext(verbosity=Verbosity.INFO):
+        _ = (x * x) + x
+
+    # --- assert ------------------------------------------
+    lines = logged_lines()
+    assert len(lines) == 2
+    assert "MUL" in lines[0]
+    assert "ADD" in lines[1]
+
+
+def test_off_logs_nothing(logged_lines):
+    # --- arrange -----------------------------------------
+    x = CountedFloat(3.0)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext():
+        _ = (x * x) + x
+
+    # --- assert ------------------------------------------
+    assert logged_lines() == []
+
+
+def test_logged_lines_locate_the_user_expression_not_the_library(logged_lines):
+    # --- arrange -----------------------------------------
+    x = CountedFloat(3.0)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext(verbosity=Verbosity.INFO):
+        _ = math.sqrt(x)
+
+    # --- assert ------------------------------------------
+    (line,) = logged_lines()
+    assert "test_info_counting.py:" in line, "The counting machinery's own frames should be skipped."
+
+
+@pytest.mark.parametrize(
+    ("expression", "flop_type", "rationale"),
+    [
+        (lambda x: x**2, "MUL", "const exponent -> square-and-multiply"),
+        (lambda x: x**0.5, "SQRT", "const exponent 0.5 -> sqrt"),
+        (lambda x: x**-1, "DIV", "const exponent -1 -> reciprocal"),
+        (lambda x: 2**x, "EXP2", "const base 2 -> exp2"),
+        (lambda x: 10**x, "EXP10", "const base 10 -> exp10"),
+        (lambda x: math.log(x, 2), "LOG2", "const base 2 -> log2"),
+        (lambda x: math.log(x, 10), "LOG10", "const base 10 -> log10"),
+        (lambda x: math.log(x, 7.0), "LOG", "const base -> log(x) * 1/log(base)"),
+        (lambda x: math.log(x, CountedFloat(7.0)), "LOG", "runtime base -> log(x)/log(base)"),
+    ],
+)
+def test_strength_reductions_are_explained(logged_lines, expression, flop_type, rationale):
+    # --- arrange -----------------------------------------
+    x = CountedFloat(3.0)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext(verbosity=Verbosity.INFO):
+        _ = expression(x)
+
+    # --- assert ------------------------------------------
+    first_line = logged_lines()[0]
+    assert flop_type in first_line
+    assert rationale in first_line
+
+
+def test_plainly_counted_flops_carry_no_rationale(logged_lines):
+    # --- arrange -----------------------------------------
+    x = CountedFloat(3.0)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext(verbosity=Verbosity.INFO):
+        _ = x * x
+
+    # --- assert ------------------------------------------
+    (line,) = logged_lines()
+    fields = line.split()
+    assert fields[:3] == ["INFO", "MUL", "+1"]
+    assert len(fields) == 4, "Without a rationale, a line holds only level, flop type, count and location."
+
+
+# ==================================================================================================
+#  Logging does not disturb counting
+# ==================================================================================================
+def test_counts_are_the_same_whether_or_not_they_are_logged():
+    # --- arrange -----------------------------------------
+    def counted_work() -> None:
+        x = CountedFloat(3.0)
+        _ = ((x * x) + x) / x
+        _ = math.dist([x, x], [x, x])
+        _ = x**2
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext() as silent:
+        counted_work()
+    with FlopCountingContext(verbosity=Verbosity.INFO) as verbose:
+        counted_work()
+
+    # --- assert ------------------------------------------
+    assert verbose.flop_counts() == silent.flop_counts()
+
+
+def test_counting_stays_active_while_logging():
+    # --- act ---------------------------------------------
+    with FlopCountingContext(verbosity=Verbosity.INFO):
+        is_active = THREAD_COUNTER.is_active()
+
+    # --- assert ------------------------------------------
+    assert is_active, "Routing increments through the logging target should not read as 'paused'."
+
+
+# ==================================================================================================
+#  Interaction with pausing
+# ==================================================================================================
+def test_paused_flops_are_neither_counted_nor_logged(logged_lines):
+    # --- arrange -----------------------------------------
+    x = CountedFloat(3.0)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext(verbosity=Verbosity.INFO) as ctx:
+        with PauseFlopCounting():
+            _ = x * x
+        _ = x + x
+
+    # --- assert ------------------------------------------
+    (line,) = logged_lines()
+    assert "ADD" in line
+    assert ctx.flop_counts().MUL == 0
+
+
+# ==================================================================================================
+#  Nesting and restoration
+# ==================================================================================================
+def test_the_innermost_context_decides_the_level(logged_lines):
+    # --- arrange -----------------------------------------
+    x = CountedFloat(3.0)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext(verbosity=Verbosity.INFO):
+        _ = x * x
+        with FlopCountingContext():
+            _ = x / x
+        _ = x + x
+
+    # --- assert ------------------------------------------
+    lines = logged_lines()
+    assert [line.split()[1] for line in lines] == ["MUL", "ADD"], (
+        "The nested silent context should have silenced only the flops inside it."
+    )
+
+
+def test_the_level_is_restored_when_the_context_exits():
+    # --- act ---------------------------------------------
+    with FlopCountingContext(verbosity=Verbosity.INFO):
+        level_inside = THREAD_COUNTER.verbosity()
+    level_after = THREAD_COUNTER.verbosity()
+
+    # --- assert ------------------------------------------
+    assert level_inside == Verbosity.INFO
+    assert level_after == Verbosity.OFF
+
+
+def test_the_level_is_restored_when_the_block_raises():
+    # --- act ---------------------------------------------
+    with pytest.raises(ValueError, match="counted"), FlopCountingContext(verbosity=Verbosity.INFO):
+        raise ValueError("counted work went wrong")
+
+    # --- assert ------------------------------------------
+    assert THREAD_COUNTER.verbosity() == Verbosity.OFF
+
+
+def test_re_entering_one_context_keeps_its_level():
+    # --- arrange -----------------------------------------
+    ctx = FlopCountingContext(verbosity=Verbosity.INFO)
+
+    # --- act ---------------------------------------------
+    with ctx:
+        with ctx:
+            level_nested = THREAD_COUNTER.verbosity()
+        level_outer = THREAD_COUNTER.verbosity()
+
+    # --- assert ------------------------------------------
+    assert level_nested == Verbosity.INFO
+    assert level_outer == Verbosity.INFO

--- a/tests/counting/verbosity/test_logging_flop_counts.py
+++ b/tests/counting/verbosity/test_logging_flop_counts.py
@@ -1,0 +1,114 @@
+import pytest
+
+from counted_float import FlopCounts
+from counted_float._core.counting.verbosity import LoggingFlopCounts
+
+
+@pytest.fixture
+def counts() -> FlopCounts:
+    return FlopCounts()
+
+
+@pytest.fixture
+def target(counts) -> LoggingFlopCounts:
+    return LoggingFlopCounts(counts)
+
+
+# ==================================================================================================
+#  Forwarding to the real counts
+# ==================================================================================================
+def test_increments_reach_the_wrapped_counts(target, counts):
+    # --- act ---------------------------------------------
+    target.ADD += 1
+    target.ADD += 1
+    target.MUL += 3
+
+    # --- assert ------------------------------------------
+    assert counts == FlopCounts(ADD=2, MUL=3)
+
+
+def test_reads_pass_through_to_the_wrapped_counts(target, counts):
+    # --- arrange -----------------------------------------
+    counts.DIV = 7
+
+    # --- act & assert ------------------------------------
+    assert target.DIV == 7
+
+
+def test_every_count_field_is_proxied(target, counts):
+    # --- act ---------------------------------------------
+    for field_name in FlopCounts.field_names():
+        setattr(target, field_name, 1)
+
+    # --- assert ------------------------------------------
+    assert counts == FlopCounts(**dict.fromkeys(FlopCounts.field_names(), 1))
+
+
+# ==================================================================================================
+#  Logging
+# ==================================================================================================
+def test_one_line_per_increment_statement(target, logged_lines):
+    # --- act ---------------------------------------------
+    target.ADD += 1
+    target.MUL += 1
+
+    # --- assert ------------------------------------------
+    lines = logged_lines()
+    assert len(lines) == 2
+    assert "ADD" in lines[0]
+    assert "MUL" in lines[1]
+
+
+def test_a_bulk_increment_logs_one_line_carrying_its_size(target, logged_lines):
+    # --- act ---------------------------------------------
+    target.SUB += 4
+
+    # --- assert ------------------------------------------
+    (line,) = logged_lines()
+    assert "SUB" in line
+    assert "+4" in line
+
+
+def test_the_logged_line_reports_the_incrementing_location(target, logged_lines):
+    # --- act ---------------------------------------------
+    target.ADD += 1
+
+    # --- assert ------------------------------------------
+    (line,) = logged_lines()
+    assert "test_logging_flop_counts.py:" in line
+
+
+# ==================================================================================================
+#  Rationales
+# ==================================================================================================
+def test_a_note_is_rendered_on_the_next_line(target, logged_lines):
+    # --- act ---------------------------------------------
+    target.note("const exponent -> sqrt")
+    target.SQRT += 1
+
+    # --- assert ------------------------------------------
+    (line,) = logged_lines()
+    assert "const exponent -> sqrt" in line
+
+
+def test_a_note_is_consumed_by_a_single_line(target, logged_lines):
+    # --- act ---------------------------------------------
+    target.note("const exponent -> sqrt")
+    target.SQRT += 1
+    target.DIV += 1
+
+    # --- assert ------------------------------------------
+    explained, unexplained = logged_lines()
+    assert "const exponent -> sqrt" in explained
+    assert "const exponent -> sqrt" not in unexplained
+
+
+def test_lines_without_a_note_carry_no_rationale(target, logged_lines):
+    # --- act ---------------------------------------------
+    target.ADD += 1
+
+    # --- assert ------------------------------------------
+    (line,) = logged_lines()
+    level, flop_type, count, location = line.split()
+    assert (level, flop_type, count) == ("INFO", "ADD", "+1")
+    assert location.startswith("test_logging_flop_counts.py:")

--- a/tests/counting/verbosity/test_target_invariants.py
+++ b/tests/counting/verbosity/test_target_invariants.py
@@ -1,0 +1,41 @@
+"""The alias invariants that hold across every (verbosity level, paused) combination.
+
+Increments go through one alias with more than one possible target, so the properties below are
+easy to break from a distance -- notably by testing "is counting paused?" against the active
+counts, which is wrong for a thread whose increments are routed through a logging target. They
+are stated once here, as a matrix, rather than left to the module docstring.
+"""
+
+import pytest
+
+from counted_float import FlopCounts, Verbosity
+from counted_float._core.counting._thread_counter import _TLS
+
+
+@pytest.mark.parametrize(
+    ("level", "paused", "counted", "logged"),
+    [
+        (Verbosity.OFF, False, True, False),
+        (Verbosity.OFF, True, False, False),
+        (Verbosity.INFO, False, True, True),
+        (Verbosity.INFO, True, False, False),
+    ],
+)
+def test_increment_target(thread_counter, logged_lines, level, paused, counted, logged):
+    # --- arrange -----------------------------------------
+    thread_counter.set_verbosity(level)
+    if paused:
+        thread_counter.pause()
+
+    # --- act ---------------------------------------------
+    thread_counter.incr_add()
+
+    # --- assert ------------------------------------------
+    # the alias points at the sink exactly while paused
+    assert (_TLS.flop_counts is _TLS.flop_counts_inactive) is paused
+    assert thread_counter.is_active() is (not paused)
+
+    # counts are read back from the real counts, never through the alias
+    assert thread_counter.flop_counts() == (FlopCounts(ADD=1) if counted else FlopCounts())
+
+    assert len(logged_lines()) == (1 if logged else 0)

--- a/tests/counting/verbosity/test_target_invariants.py
+++ b/tests/counting/verbosity/test_target_invariants.py
@@ -12,6 +12,9 @@ from counted_float import FlopCounts, Verbosity
 from counted_float._core.counting._thread_counter import _TLS
 
 
+# ==================================================================================================
+#  Which target increments go to, per (level, paused)
+# ==================================================================================================
 @pytest.mark.parametrize(
     ("level", "paused", "counted", "logged"),
     [
@@ -39,3 +42,37 @@ def test_increment_target(thread_counter, logged_lines, level, paused, counted, 
     assert thread_counter.flop_counts() == (FlopCounts(ADD=1) if counted else FlopCounts())
 
     assert len(logged_lines()) == (1 if logged else 0)
+
+
+# ==================================================================================================
+#  Changing the level while paused
+# ==================================================================================================
+def test_setting_verbosity_while_paused_does_not_resume(thread_counter, logged_lines):
+    # --- arrange -----------------------------------------
+    thread_counter.pause()
+
+    # --- act ---------------------------------------------
+    thread_counter.set_verbosity(Verbosity.INFO)
+    thread_counter.incr_add()
+
+    # --- assert ------------------------------------------
+    # the level lands, but the alias stays on the sink: switching it here would resume a thread
+    # that asked to be paused
+    assert _TLS.flop_counts is _TLS.flop_counts_inactive
+    assert not thread_counter.is_active()
+    assert thread_counter.flop_counts() == FlopCounts()
+    assert logged_lines() == []
+
+
+def test_resuming_picks_up_a_level_set_while_paused(thread_counter, logged_lines):
+    # --- arrange -----------------------------------------
+    thread_counter.pause()
+    thread_counter.set_verbosity(Verbosity.INFO)
+
+    # --- act ---------------------------------------------
+    thread_counter.resume()
+    thread_counter.incr_add()
+
+    # --- assert ------------------------------------------
+    assert thread_counter.flop_counts() == FlopCounts(ADD=1)
+    assert len(logged_lines()) == 1


### PR DESCRIPTION
`FlopCountingContext(verbosity=Verbosity.INFO)` reports each flop as it is registered — flop type, how many that statement counted, why (where the library applied a rule the source expression does not give away, like a constant pow exponent or log base), and the line of user code that triggered it. Output goes to stderr through rich.

Logging is installed by swapping the thread's increment target, the same alias slot pausing already swaps, so no counting site gained a verbosity check and the default level costs nothing. The three strength-reduction sites that now hand over a rationale measure 2-8% slower per op; the plain operator and `math.*` paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)