### PR TITLE
feat: show the machine code behind every benchmarked flop cost in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - free-threaded Python builds (3.14t) are now officially supported and CI-tested; the `numba` extra needs numba 0.65 or newer there
 - `FlopCountingContext(verbosity=...)` can log every flop as it is counted, with the source line that triggered it and why it was counted that way
 - verbosity level `WARNING` reports the operations that could not be counted at all, once per call site, so a quietly incomplete count says so
+- the docs now show, per benchmarked flop cost, the machine code the measurement isolates, with a verdict on whether it measures exactly the intended operation
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ help:
 	@echo ''
 	@echo '  precompute-weights            Regenerate the shipped consensus flop weights from the built-in source data.'
 	@echo '  regen-docs                    Regenerate the dataset-derived docs content (marked text blocks + screenshots).'
+	@echo '  regen-kernel-asm              Regenerate the benchmark-kernel machine-code listings (ARM64 machine only).'
 	@echo ''
 	@echo '  release       		            Release a version: make release VERSION=X.Y.Z (validates, bumps, tags, pushes).'
 	@echo ''
@@ -44,6 +45,9 @@ precompute-weights:
 
 regen-docs:
 	uv run python scripts/generate_docs_content.py
+
+regen-kernel-asm:
+	uv run --all-extras python scripts/generate_kernel_asm_docs.py
 
 release:
 	@test -n "$(VERSION)" || (echo "Usage: make release VERSION=X.Y.Z" && exit 1)

--- a/docs/kernel_asm/exp.md
+++ b/docs/kernel_asm/exp.md
@@ -1,0 +1,167 @@
+# EXP
+
+The `EXP` cost is the latency difference between a kernel chaining `exp(log(tmp + x[i]))` and one
+chaining `log(tmp + x[i])` — kernels `f_add_log_exp` and `f_add_log`. Exemplar of a **chained-base
+pair**: `exp` grows without bound, so a plain `exp` chain would overflow; instead `log` bounds the
+argument, and the `log`-only kernel is subtracted so its cost cancels.
+
+## Inner-loop diff
+
+<!-- BEGIN generated: kernel-asm-exp-diff -->
+```diff
+--- f_add_log
++++ f_add_log_exp
+  .L0:
+  ldr  %d0, [%x0], #8
+  fadd  %d1, %d1, %d0
+  blr  %x1
+- str  %d1, [%x2], #8
+- subs  %x3, %x3, #1
++ blr  %x2
++ str  %d1, [%x3], #8
++ subs  %x4, %x4, #1
+  b.ne  .L0
+```
+<!-- END generated: kernel-asm-exp-diff -->
+
+## Loop structure
+
+<!-- BEGIN generated: kernel-asm-exp-structure -->
+- `f_add_log` -- 1 innermost loop(s): 7 instructions
+- `f_add_log_exp` -- 1 innermost loop(s): 8 instructions
+
+The listings below are the complete compiled functions the benchmark times, raw as numba
+emits them (the cpython call wrappers around them are omitted -- they never run inside the
+timed loop). Listing lengths reflect the compiler's unrolling choices, not the kernels'
+amount of work -- see the discussion below.
+
+??? note "Full ASM listing: `f_add_log`"
+    ```asm
+      stp  d9, d8, [sp, #-112]!
+      stp  x28, x27, [sp, #16]
+      stp  x26, x25, [sp, #32]
+      stp  x24, x23, [sp, #48]
+      stp  x22, x21, [sp, #64]
+      stp  x20, x19, [sp, #80]
+      stp  x29, x30, [sp, #96]
+      mov  x19, x0
+      cmp  x2, #1
+      b.lt  LBB0_6
+      mov  x20, x3
+      cmp  x3, #1
+      b.lt  LBB0_6
+      mov  x21, x2
+      ldr  x22, [sp, #168]
+      ldr  x23, [sp, #112]
+      mov  x8, #22377
+      movk  x8, #35604, lsl #16
+      movk  x8, #48906, lsl #32
+      movk  x8, #16389, lsl #48
+      fmov  d8, x8
+    Lloh0:
+      adrp  x24, _log@GOTPAGE
+    Lloh1:
+      ldr  x24, [x24, _log@GOTPAGEOFF]
+    LBB0_3:
+      mov  x25, x20
+      mov  x26, x23
+      mov  x27, x22
+      mov.16b  v0, v8
+    LBB0_4:
+      ldr  d1, [x26], #8
+      fadd  d0, d0, d1
+      blr  x24
+      str  d0, [x27], #8
+      subs  x25, x25, #1
+      b.ne  LBB0_4
+      subs  x21, x21, #1
+      b.gt  LBB0_3
+    LBB0_6:
+      str  xzr, [x19]
+      mov  w0, #0
+      ldp  x29, x30, [sp, #96]
+      ldp  x20, x19, [sp, #80]
+      ldp  x22, x21, [sp, #64]
+      ldp  x24, x23, [sp, #48]
+      ldp  x26, x25, [sp, #32]
+      ldp  x28, x27, [sp, #16]
+      ldp  d9, d8, [sp], #112
+      ret
+      .loh AdrpLdrGot  Lloh0, Lloh1
+    ```
+
+??? note "Full ASM listing: `f_add_log_exp`"
+    ```asm
+      stp  d9, d8, [sp, #-112]!
+      stp  x28, x27, [sp, #16]
+      stp  x26, x25, [sp, #32]
+      stp  x24, x23, [sp, #48]
+      stp  x22, x21, [sp, #64]
+      stp  x20, x19, [sp, #80]
+      stp  x29, x30, [sp, #96]
+      mov  x19, x0
+      cmp  x2, #1
+      b.lt  LBB0_6
+      mov  x20, x3
+      cmp  x3, #1
+      b.lt  LBB0_6
+      mov  x21, x2
+      ldr  x22, [sp, #168]
+      ldr  x23, [sp, #112]
+      mov  x8, #22377
+      movk  x8, #35604, lsl #16
+      movk  x8, #48906, lsl #32
+      movk  x8, #16389, lsl #48
+      fmov  d8, x8
+    Lloh0:
+      adrp  x24, _log@GOTPAGE
+    Lloh1:
+      ldr  x24, [x24, _log@GOTPAGEOFF]
+    Lloh2:
+      adrp  x25, _exp@GOTPAGE
+    Lloh3:
+      ldr  x25, [x25, _exp@GOTPAGEOFF]
+    LBB0_3:
+      mov  x26, x20
+      mov  x27, x23
+      mov  x28, x22
+      mov.16b  v0, v8
+    LBB0_4:
+      ldr  d1, [x27], #8
+      fadd  d0, d0, d1
+      blr  x24
+      blr  x25
+      str  d0, [x28], #8
+      subs  x26, x26, #1
+      b.ne  LBB0_4
+      subs  x21, x21, #1
+      b.gt  LBB0_3
+    LBB0_6:
+      str  xzr, [x19]
+      mov  w0, #0
+      ldp  x29, x30, [sp, #96]
+      ldp  x20, x19, [sp, #80]
+      ldp  x22, x21, [sp, #64]
+      ldp  x24, x23, [sp, #48]
+      ldp  x26, x25, [sp, #32]
+      ldp  x28, x27, [sp, #16]
+      ldp  d9, d8, [sp], #112
+      ret
+      .loh AdrpLdrGot  Lloh2, Lloh3
+      .loh AdrpLdrGot  Lloh0, Lloh1
+    ```
+<!-- END generated: kernel-asm-exp-structure -->
+
+## Discussion
+
+**The subtraction isolates exactly one call to libm's `exp`.**
+
+1. *Intended call, and nothing else*: the one structural addition is the second `blr` —
+   `f_add_log`'s loop contains one indirect libm call (`log`), `f_add_log_exp`'s contains two
+   (`log`, then `exp`), each through its own preloaded call-target register. The remaining
+   `-`/`+` pairs are the canonical-index shift described on the [index page](index.md).
+2. *In the dependency chain*: the calls are back-to-back on the accumulator — `log`'s return
+   value is `exp`'s argument, whose return value feeds the next iteration's `fadd` — so each
+   iteration pays the full add→log→exp latency and the subtraction leaves exactly the `exp` leg.
+3. *Loop-structure symmetry*: **symmetric.** Both kernels compile to a single scalar loop (7 vs 8
+   instructions) — this is the cleanest of the exemplar shapes, since neither side unrolls.

--- a/docs/kernel_asm/hypot_xarg.md
+++ b/docs/kernel_asm/hypot_xarg.md
@@ -1,0 +1,769 @@
+# HYPOT_XARG
+
+The `HYPOT_XARG` cost is the per-extra-coordinate slope of the overflow-safe scaled `hypot`
+algorithm: the latency difference between its 8-coordinate and 2-coordinate forms — kernels
+`f_add_hypot_scaled8` and `f_add_hypot_scaled2` — divided by the 6 extra coordinates. Exemplar of
+an **arity-scaled pair**: the two sides are not "same loop ± one instruction" but the same
+algorithm at two sizes, so the diff is expected to be large — what must hold is that every added
+line belongs to the six extra coordinates and their scaling, and nothing shared changed shape.
+
+## Inner-loop diff
+
+<!-- BEGIN generated: kernel-asm-hypot-xarg-diff -->
+```diff
+--- f_add_hypot_scaled2
++++ f_add_hypot_scaled8
+  .L0:
+- ldp  %d0, %d1, [%x0, #-8]
+- fadd  %d1, %d2, %d1
+- fabs  %d2, %d1
++ ldp  %d0, %d1, [%x0, #48]
++ fadd  %d2, %d2, %d1
++ fabs  %d1, %d2
+  fabs  %d3, %d0
+- fcmp  %d3, %d2
+- fcsel  %d2, %d3, %d2, gt
+- fcmp  %d2, #0.0
++ fcmp  %d3, %d1
++ fcsel  %d4, %d3, %d1, gt
++ ldp  %d3, %d1, [%x0, #32]
++ fabs  %d5, %d1
++ fcmp  %d5, %d4
++ fcsel  %d4, %d5, %d4, gt
++ fabs  %d5, %d3
++ fcmp  %d5, %d4
++ fcsel  %d6, %d5, %d4, gt
++ ldp  %d5, %d4, [%x0, #16]
++ fabs  %d7, %d4
++ fcmp  %d7, %d6
++ fcsel  %d7, %d7, %d6, gt
++ fabs  %d8, %d5
++ fcmp  %d8, %d7
++ ldr  %d6, [%x1, #8]!
++ fcsel  %d7, %d8, %d7, gt
++ fabs  %d8, %d6
++ fcmp  %d8, %d7
++ fcsel  %d7, %d8, %d7, gt
++ cmp  %x2, #7
++ csel  %x3, %x4, xzr, lo
++ ldr  %d8, [%x0, %x3, lsl #3]
++ fabs  %d9, %d8
++ fcmp  %d9, %d7
++ fcsel  %d7, %d9, %d7, gt
++ fcmp  %d7, #0.0
+  b.eq  .L1
+- fdiv  %d3, %d4, %d2
+- fmul  %d1, %d1, %d3
+- fmul  %d0, %d0, %d3
+- fmul  %d1, %d1, %d1
++ fdiv  %d9, %d10, %d7
++ fmul  %d2, %d2, %d9
++ fmul  %d2, %d2, %d2
++ fmul  %d0, %d0, %d9
+  fmul  %d0, %d0, %d0
+- fadd  %d0, %d1, %d0
++ fadd  %d0, %d2, %d0
++ fmul  %d2, %d1, %d9
++ fmul  %d2, %d2, %d2
++ fadd  %d0, %d2, %d0
++ fmul  %d2, %d3, %d9
++ fmul  %d2, %d2, %d2
++ fadd  %d0, %d2, %d0
++ fmul  %d2, %d4, %d9
++ fmul  %d2, %d2, %d2
++ fadd  %d0, %d2, %d0
++ fmul  %d2, %d5, %d9
++ fmul  %d2, %d2, %d2
++ fadd  %d0, %d2, %d0
++ fmul  %d2, %d6, %d9
++ fmul  %d2, %d2, %d2
++ fadd  %d0, %d2, %d0
++ fmul  %d2, %d8, %d9
++ fmul  %d2, %d2, %d2
++ fadd  %d0, %d2, %d0
+  fsqrt  %d0, %d0
+- fmul  %d2, %d2, %d0
+- str  %d2, [%x1], #8
+- add  %x0, %x0, #8
+- subs  %x2, %x2, #1
++ fmul  %d2, %d7, %d0
++ str  %d2, [%x5, %x2, lsl #3]
++ add  %x2, %x2, #1
++ mov  %x0, %x1
++ cmp  %x6, %x2
+  b.ne  .L0
+```
+<!-- END generated: kernel-asm-hypot-xarg-diff -->
+
+## Loop structure
+
+<!-- BEGIN generated: kernel-asm-hypot-xarg-structure -->
+- `f_add_hypot_scaled2` -- 2 innermost loop(s): 22 instructions, 21 instructions
+- `f_add_hypot_scaled8` -- 1 innermost loop(s): 64 instructions
+
+The listings below are the complete compiled functions the benchmark times, raw as numba
+emits them (the cpython call wrappers around them are omitted -- they never run inside the
+timed loop). Listing lengths reflect the compiler's unrolling choices, not the kernels'
+amount of work -- see the discussion below.
+
+??? note "Full ASM listing: `f_add_hypot_scaled2`"
+    ```asm
+      .cfi_startproc
+      cmp  x2, #1
+      b.lt  LBB0_6
+      cmp  x3, #1
+      b.lt  LBB0_6
+      ldr  x8, [sp, #56]
+      ldp  x10, x9, [sp]
+      sub  x11, x10, #8
+      subs  x12, x3, #1
+      b.ne  LBB0_7
+      add  x12, x2, #1
+      mov  x13, #22377
+      movk  x13, #35604, lsl #16
+      movk  x13, #48906, lsl #32
+      movk  x13, #16389, lsl #48
+      fmov  d0, x13
+      fmov  d1, #1.00000000
+    LBB0_4:
+      ldr  d3, [x10]
+      ldr  d2, [x11, x9, lsl #3]
+      fadd  d4, d3, d0
+      fabs  d3, d4
+      fabs  d5, d2
+      fcmp  d5, d3
+      fcsel  d3, d5, d3, gt
+      fcmp  d3, #0.0
+      b.eq  LBB0_13
+      fdiv  d5, d1, d3
+      fmul  d4, d4, d5
+      fmul  d2, d2, d5
+      fmul  d4, d4, d4
+      fmul  d2, d2, d2
+      fadd  d2, d4, d2
+      fsqrt  d2, d2
+      fmul  d2, d3, d2
+      str  d2, [x8]
+      sub  x12, x12, #1
+      cmp  x12, #1
+      b.gt  LBB0_4
+    LBB0_6:
+      str  xzr, [x0]
+      mov  w0, #0
+      ret
+    LBB0_7:
+      mov  x13, #22377
+      movk  x13, #35604, lsl #16
+      movk  x13, #48906, lsl #32
+      movk  x13, #16389, lsl #48
+      fmov  d0, x13
+      fmov  d1, #1.00000000
+    LBB0_8:
+      ldr  d3, [x10]
+      ldr  d2, [x11, x9, lsl #3]
+      fadd  d4, d3, d0
+      fabs  d3, d4
+      fabs  d5, d2
+      fcmp  d5, d3
+      fcsel  d3, d5, d3, gt
+      fcmp  d3, #0.0
+      b.eq  LBB0_13
+      sub  x13, x2, #1
+      fdiv  d5, d1, d3
+      fmul  d4, d4, d5
+      fmul  d2, d2, d5
+      fmul  d4, d4, d4
+      fmul  d2, d2, d2
+      fadd  d2, d4, d2
+      fsqrt  d2, d2
+      fmul  d2, d3, d2
+      str  d2, [x8]
+      mov  x14, x12
+      add  x15, x10, #8
+      add  x16, x8, #8
+    LBB0_10:
+      ldp  d3, d4, [x15, #-8]
+      fadd  d4, d2, d4
+      fabs  d2, d4
+      fabs  d5, d3
+      fcmp  d5, d2
+      fcsel  d2, d5, d2, gt
+      fcmp  d2, #0.0
+      b.eq  LBB0_13
+      fdiv  d5, d1, d2
+      fmul  d4, d4, d5
+      fmul  d3, d3, d5
+      fmul  d4, d4, d4
+      fmul  d3, d3, d3
+      fadd  d3, d4, d3
+      fsqrt  d3, d3
+      fmul  d2, d2, d3
+      str  d2, [x16], #8
+      add  x15, x15, #8
+      subs  x14, x14, #1
+      b.ne  LBB0_10
+      cmp  x2, #1
+      mov  x2, x13
+      b.gt  LBB0_8
+      b  LBB0_6
+    LBB0_13:
+    Lloh0:
+      adrp  x8, _.const.picklebuf.<addr>@GOTPAGE
+    Lloh1:
+      ldr  x8, [x8, _.const.picklebuf.<addr>@GOTPAGEOFF]
+      str  x8, [x1]
+      mov  w0, #1
+      ret
+      .loh AdrpLdrGot  Lloh0, Lloh1
+      .cfi_endproc
+    ```
+
+??? note "Full ASM listing: `f_add_hypot_scaled8`"
+    ```asm
+      .cfi_startproc
+      stp  x26, x25, [sp, #-80]!
+      stp  x24, x23, [sp, #16]
+      stp  x22, x21, [sp, #32]
+      stp  x20, x19, [sp, #48]
+      stp  x29, x30, [sp, #64]
+      .cfi_def_cfa_offset 80
+      .cfi_offset w30, -8
+      .cfi_offset w29, -16
+      .cfi_offset w19, -24
+      .cfi_offset w20, -32
+      .cfi_offset w21, -40
+      .cfi_offset w22, -48
+      .cfi_offset w23, -56
+      .cfi_offset w24, -64
+      .cfi_offset w25, -72
+      .cfi_offset w26, -80
+      mov  x20, x4
+      mov  x23, x3
+      mov  x24, x2
+      mov  x21, x1
+      mov  x19, x0
+      ldr  x22, [sp, #104]
+    Lloh0:
+      adrp  x25, _NRT_incref@GOTPAGE
+    Lloh1:
+      ldr  x25, [x25, _NRT_incref@GOTPAGEOFF]
+      mov  x0, x4
+      blr  x25
+      mov  x0, x22
+      blr  x25
+      cmp  x24, #1
+      b.lt  LBB0_19
+      cmp  x23, #1
+      b.lt  LBB0_19
+      ldp  x9, x8, [sp, #80]
+      sub  x10, x9, #8
+      ldr  x11, [sp, #136]
+      sub  x12, x9, #16
+      sub  x13, x9, #24
+      sub  x14, x9, #32
+      sub  x15, x9, #40
+      sub  x16, x9, #48
+      sub  x17, x9, #56
+      mov  x0, #22377
+      movk  x0, #35604, lsl #16
+      movk  x0, #48906, lsl #32
+      movk  x0, #16389, lsl #48
+      fmov  d0, x0
+      fmov  d1, #1.00000000
+      b  LBB0_4
+    LBB0_3:
+      cmp  x24, #1
+      sub  x24, x24, #1
+      b.le  LBB0_19
+    LBB0_4:
+      ldr  d2, [x9]
+      fadd  d2, d2, d0
+      fabs  d5, d2
+      ldr  d3, [x10, x8, lsl #3]
+      fabs  d6, d3
+      fcmp  d6, d5
+      ldr  d4, [x12, x8, lsl #3]
+      fcsel  d5, d6, d5, gt
+      fabs  d6, d4
+      fcmp  d6, d5
+      fcsel  d6, d6, d5, gt
+      ldr  d5, [x13, x8, lsl #3]
+      fabs  d7, d5
+      fcmp  d7, d6
+      fcsel  d7, d7, d6, gt
+      ldr  d6, [x14, x8, lsl #3]
+      fabs  d16, d6
+      fcmp  d16, d7
+      fcsel  d16, d16, d7, gt
+      ldr  d7, [x15, x8, lsl #3]
+      fabs  d17, d7
+      fcmp  d17, d16
+      fcsel  d17, d17, d16, gt
+      ldr  d16, [x16, x8, lsl #3]
+      fabs  d18, d16
+      fcmp  d18, d17
+      fcsel  d17, d18, d17, gt
+      ldr  d18, [x17, x8, lsl #3]
+      fabs  d19, d18
+      fcmp  d19, d17
+      fcsel  d17, d19, d17, gt
+      fcmp  d17, #0.0
+      b.eq  LBB0_20
+      fdiv  d19, d1, d17
+      fmul  d2, d2, d19
+      fmul  d2, d2, d2
+      fmul  d3, d3, d19
+      fmul  d3, d3, d3
+      fadd  d2, d2, d3
+      fmul  d3, d4, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d5, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d6, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d7, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d16, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d18, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fsqrt  d2, d2
+      fmul  d3, d17, d2
+      str  d3, [x11]
+      cmp  x23, #1
+      b.eq  LBB0_3
+      ldp  d2, d4, [x9]
+      fadd  d3, d3, d4
+      fabs  d5, d3
+      fabs  d6, d2
+      fcmp  d6, d5
+      ldr  d4, [x10, x8, lsl #3]
+      fcsel  d5, d6, d5, gt
+      fabs  d6, d4
+      fcmp  d6, d5
+      fcsel  d6, d6, d5, gt
+      ldr  d5, [x12, x8, lsl #3]
+      fabs  d7, d5
+      fcmp  d7, d6
+      fcsel  d7, d7, d6, gt
+      ldr  d6, [x13, x8, lsl #3]
+      fabs  d16, d6
+      fcmp  d16, d7
+      fcsel  d16, d16, d7, gt
+      ldr  d7, [x14, x8, lsl #3]
+      fabs  d17, d7
+      fcmp  d17, d16
+      fcsel  d17, d17, d16, gt
+      ldr  d16, [x15, x8, lsl #3]
+      fabs  d18, d16
+      fcmp  d18, d17
+      fcsel  d17, d18, d17, gt
+      ldr  d18, [x16, x8, lsl #3]
+      fabs  d19, d18
+      fcmp  d19, d17
+      fcsel  d17, d19, d17, gt
+      fcmp  d17, #0.0
+      b.eq  LBB0_20
+      fdiv  d19, d1, d17
+      fmul  d3, d3, d19
+      fmul  d3, d3, d3
+      fmul  d2, d2, d19
+      fmul  d2, d2, d2
+      fadd  d2, d3, d2
+      fmul  d3, d4, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d5, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d6, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d7, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d16, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d18, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fsqrt  d2, d2
+      fmul  d2, d17, d2
+      str  d2, [x11, #8]
+      cmp  x23, #2
+      b.eq  LBB0_3
+      ldp  d3, d4, [x9, #8]
+      fadd  d2, d2, d4
+      fabs  d5, d2
+      ldr  d4, [x9]
+      fabs  d6, d3
+      fcmp  d6, d5
+      fcsel  d5, d6, d5, gt
+      fabs  d6, d4
+      fcmp  d6, d5
+      fcsel  d6, d6, d5, gt
+      ldr  d5, [x10, x8, lsl #3]
+      fabs  d7, d5
+      fcmp  d7, d6
+      fcsel  d7, d7, d6, gt
+      ldr  d6, [x12, x8, lsl #3]
+      fabs  d16, d6
+      fcmp  d16, d7
+      fcsel  d16, d16, d7, gt
+      ldr  d7, [x13, x8, lsl #3]
+      fabs  d17, d7
+      fcmp  d17, d16
+      fcsel  d17, d17, d16, gt
+      ldr  d16, [x14, x8, lsl #3]
+      fabs  d18, d16
+      fcmp  d18, d17
+      fcsel  d17, d18, d17, gt
+      ldr  d18, [x15, x8, lsl #3]
+      fabs  d19, d18
+      fcmp  d19, d17
+      fcsel  d17, d19, d17, gt
+      fcmp  d17, #0.0
+      b.eq  LBB0_20
+      fdiv  d19, d1, d17
+      fmul  d2, d2, d19
+      fmul  d2, d2, d2
+      fmul  d3, d3, d19
+      fmul  d3, d3, d3
+      fadd  d2, d2, d3
+      fmul  d3, d4, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d5, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d6, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d7, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d16, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d18, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fsqrt  d2, d2
+      fmul  d3, d17, d2
+      str  d3, [x11, #16]
+      cmp  x23, #3
+      b.eq  LBB0_3
+      ldp  d2, d4, [x9, #16]
+      fadd  d3, d3, d4
+      fabs  d4, d3
+      fabs  d5, d2
+      fcmp  d5, d4
+      fcsel  d6, d5, d4, gt
+      ldp  d5, d4, [x9]
+      fabs  d7, d4
+      fcmp  d7, d6
+      fcsel  d6, d7, d6, gt
+      fabs  d7, d5
+      fcmp  d7, d6
+      fcsel  d7, d7, d6, gt
+      ldr  d6, [x10, x8, lsl #3]
+      fabs  d16, d6
+      fcmp  d16, d7
+      fcsel  d16, d16, d7, gt
+      ldr  d7, [x12, x8, lsl #3]
+      fabs  d17, d7
+      fcmp  d17, d16
+      fcsel  d17, d17, d16, gt
+      ldr  d16, [x13, x8, lsl #3]
+      fabs  d18, d16
+      fcmp  d18, d17
+      fcsel  d17, d18, d17, gt
+      ldr  d18, [x14, x8, lsl #3]
+      fabs  d19, d18
+      fcmp  d19, d17
+      fcsel  d17, d19, d17, gt
+      fcmp  d17, #0.0
+      b.eq  LBB0_20
+      fdiv  d19, d1, d17
+      fmul  d3, d3, d19
+      fmul  d3, d3, d3
+      fmul  d2, d2, d19
+      fmul  d2, d2, d2
+      fadd  d2, d3, d2
+      fmul  d3, d4, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d5, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d6, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d7, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d16, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d18, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fsqrt  d2, d2
+      fmul  d2, d17, d2
+      str  d2, [x11, #24]
+      cmp  x23, #4
+      b.eq  LBB0_3
+      ldp  d3, d4, [x9, #24]
+      fadd  d2, d2, d4
+      fabs  d5, d2
+      ldr  d4, [x9, #16]
+      fabs  d6, d3
+      fcmp  d6, d5
+      fcsel  d5, d6, d5, gt
+      fabs  d6, d4
+      fcmp  d6, d5
+      fcsel  d7, d6, d5, gt
+      ldp  d6, d5, [x9]
+      fabs  d16, d5
+      fcmp  d16, d7
+      fcsel  d7, d16, d7, gt
+      fabs  d16, d6
+      fcmp  d16, d7
+      fcsel  d16, d16, d7, gt
+      ldr  d7, [x10, x8, lsl #3]
+      fabs  d17, d7
+      fcmp  d17, d16
+      fcsel  d17, d17, d16, gt
+      ldr  d16, [x12, x8, lsl #3]
+      fabs  d18, d16
+      fcmp  d18, d17
+      fcsel  d17, d18, d17, gt
+      ldr  d18, [x13, x8, lsl #3]
+      fabs  d19, d18
+      fcmp  d19, d17
+      fcsel  d17, d19, d17, gt
+      fcmp  d17, #0.0
+      b.eq  LBB0_20
+      fdiv  d19, d1, d17
+      fmul  d2, d2, d19
+      fmul  d2, d2, d2
+      fmul  d3, d3, d19
+      fmul  d3, d3, d3
+      fadd  d2, d2, d3
+      fmul  d3, d4, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d5, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d6, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d7, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d16, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d18, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fsqrt  d2, d2
+      fmul  d3, d17, d2
+      str  d3, [x11, #32]
+      cmp  x23, #5
+      b.eq  LBB0_3
+      ldp  d2, d4, [x9, #32]
+      fadd  d3, d3, d4
+      fabs  d4, d3
+      fabs  d5, d2
+      fcmp  d5, d4
+      fcsel  d6, d5, d4, gt
+      ldp  d5, d4, [x9, #16]
+      fabs  d7, d4
+      fcmp  d7, d6
+      fcsel  d6, d7, d6, gt
+      fabs  d7, d5
+      fcmp  d7, d6
+      fcsel  d16, d7, d6, gt
+      ldp  d7, d6, [x9]
+      fabs  d17, d6
+      fcmp  d17, d16
+      fcsel  d16, d17, d16, gt
+      fabs  d17, d7
+      fcmp  d17, d16
+      fcsel  d17, d17, d16, gt
+      ldr  d16, [x10, x8, lsl #3]
+      fabs  d18, d16
+      fcmp  d18, d17
+      fcsel  d17, d18, d17, gt
+      ldr  d18, [x12, x8, lsl #3]
+      fabs  d19, d18
+      fcmp  d19, d17
+      fcsel  d17, d19, d17, gt
+      fcmp  d17, #0.0
+      b.eq  LBB0_20
+      fdiv  d19, d1, d17
+      fmul  d3, d3, d19
+      fmul  d3, d3, d3
+      fmul  d2, d2, d19
+      fmul  d2, d2, d2
+      fadd  d2, d3, d2
+      fmul  d3, d4, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d5, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d6, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d7, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d16, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d18, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fsqrt  d2, d2
+      fmul  d3, d17, d2
+      str  d3, [x11, #40]
+      cmp  x23, #6
+      b.eq  LBB0_3
+      sub  x2, x9, #8
+      mov  w1, #6
+      mov  x0, x2
+    LBB0_17:
+      ldp  d2, d4, [x2, #48]
+      fadd  d3, d3, d4
+      fabs  d4, d3
+      fabs  d5, d2
+      fcmp  d5, d4
+      fcsel  d6, d5, d4, gt
+      ldp  d5, d4, [x2, #32]
+      fabs  d7, d4
+      fcmp  d7, d6
+      fcsel  d6, d7, d6, gt
+      fabs  d7, d5
+      fcmp  d7, d6
+      fcsel  d16, d7, d6, gt
+      ldp  d7, d6, [x2, #16]
+      fabs  d17, d6
+      fcmp  d17, d16
+      fcsel  d17, d17, d16, gt
+      fabs  d18, d7
+      fcmp  d18, d17
+      ldr  d16, [x0, #8]!
+      fcsel  d17, d18, d17, gt
+      fabs  d18, d16
+      fcmp  d18, d17
+      fcsel  d17, d18, d17, gt
+      cmp  x1, #7
+      csel  x3, x8, xzr, lo
+      ldr  d18, [x2, x3, lsl #3]
+      fabs  d19, d18
+      fcmp  d19, d17
+      fcsel  d17, d19, d17, gt
+      fcmp  d17, #0.0
+      b.eq  LBB0_20
+      fdiv  d19, d1, d17
+      fmul  d3, d3, d19
+      fmul  d3, d3, d3
+      fmul  d2, d2, d19
+      fmul  d2, d2, d2
+      fadd  d2, d3, d2
+      fmul  d3, d4, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d5, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d6, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d7, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d16, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fmul  d3, d18, d19
+      fmul  d3, d3, d3
+      fadd  d2, d3, d2
+      fsqrt  d2, d2
+      fmul  d3, d17, d2
+      str  d3, [x11, x1, lsl #3]
+      add  x1, x1, #1
+      mov  x2, x0
+      cmp  x23, x1
+      b.ne  LBB0_17
+      b  LBB0_3
+    LBB0_19:
+    Lloh2:
+      adrp  x21, _NRT_decref@GOTPAGE
+    Lloh3:
+      ldr  x21, [x21, _NRT_decref@GOTPAGEOFF]
+      mov  x0, x22
+      blr  x21
+      mov  x0, x20
+      blr  x21
+      mov  w0, #0
+      str  xzr, [x19]
+      ldp  x29, x30, [sp, #64]
+      ldp  x20, x19, [sp, #48]
+      ldp  x22, x21, [sp, #32]
+      ldp  x24, x23, [sp, #16]
+      ldp  x26, x25, [sp], #80
+      ret
+    LBB0_20:
+    Lloh4:
+      adrp  x8, _.const.picklebuf.<addr>@GOTPAGE
+    Lloh5:
+      ldr  x8, [x8, _.const.picklebuf.<addr>@GOTPAGEOFF]
+      str  x8, [x21]
+      mov  w0, #1
+      ldp  x29, x30, [sp, #64]
+      ldp  x20, x19, [sp, #48]
+      ldp  x22, x21, [sp, #32]
+      ldp  x24, x23, [sp, #16]
+      ldp  x26, x25, [sp], #80
+      ret
+      .loh AdrpLdrGot  Lloh0, Lloh1
+      .loh AdrpLdrGot  Lloh2, Lloh3
+      .loh AdrpLdrGot  Lloh4, Lloh5
+      .cfi_endproc
+    ```
+<!-- END generated: kernel-asm-hypot-xarg-structure -->
+
+## Discussion
+
+**The subtraction isolates six extra coordinates' worth of the scaled-hypot algorithm, and the
+÷6 therefore prices one coordinate.**
+
+1. *Intended work, and nothing else*: the added lines decompose per extra coordinate into the
+   max-scan step (`fabs` + `fcmp` + `fcsel`, with an `ldp`/`ldr` load per coordinate pair) and
+   the accumulation step (`fmul` scale, `fmul` square, `fadd` accumulate) — six of each, matching
+   the six extra coordinates exactly. The shared skeleton (reciprocal `fdiv`, final `fsqrt`,
+   rescale `fmul`, store, loop control) appears once on both sides, unchanged. The one addition
+   that is *not* floating-point work is an integer `cmp`/`csel` pair feeding one load — index
+   wraparound handling for the deepest negative array offset. It runs on the integer side,
+   overlapping the floating-point chain rather than extending it, so it does not contaminate the
+   measured latency.
+2. *In the dependency chain*: both the max-scan (`fcsel` chain into the reciprocal) and the
+   accumulation (`fadd` chain into the `fsqrt`) serialize per coordinate, and the result feeds
+   the next iteration's first coordinate — more coordinates means a proportionally longer chain,
+   which is precisely what a per-coordinate latency slope should measure.
+3. *Loop-structure symmetry*: neither kernel unrolls (the bodies are large enough that LLVM
+   leaves them alone). `f_add_hypot_scaled2` compiles to two variants of its loop with an
+   identical floating-point sequence, differing only in address computation (the same wraparound
+   handling the `csel` performs in the 8-coordinate kernel); the diff shows the variant that
+   best matches the 8-coordinate loop.

--- a/docs/kernel_asm/index.md
+++ b/docs/kernel_asm/index.md
@@ -1,0 +1,55 @@
+# Benchmark kernel machine code
+
+Every benchmarked flop weight is a measured latency *difference* between two compiled kernels: a
+kernel containing the operation of interest, minus a kernel identical except for that operation.
+The pages in this section show the machine code behind each of those differences, so you can see
+for yourself exactly what a weight does — and does not — include: the compiled inner loops of the
+two kernels as a unified diff, each kernel's loop structure, and the complete compiled functions.
+Nothing about a weight is reduced to trust.
+
+Each page closes with a short discussion walking through what the listings show:
+
+1. **What the diff isolates** — the intended instruction (or call), and whatever else changed
+   with it.
+2. **Where it sits in the dependency chain** the kernel serializes through — the measurement is
+   designed to capture latency, not throughput.
+3. **How the loop structures compare** — unrolling or vectorization differences that would move
+   loop overhead between the two sides.
+
+## Pages
+
+<!-- BEGIN generated: kernel-asm-page-list -->
+**Hardware instructions**
+
+- [SQRT](sqrt.md)
+
+**Library calls (libm)**
+
+- [EXP](exp.md)
+- [LOG](log.md)
+
+**Arity-scaled algorithms**
+
+- [HYPOT_XARG](hypot_xarg.md)
+<!-- END generated: kernel-asm-page-list -->
+
+## How to read the listings
+
+- **Architecture: ARM64 (Apple M-series).** Machine code is architecture-specific, so the
+  committed listings are generated on one architecture only. What a weight measures is decided by
+  the kernel pair, and that shows on any single target.
+- **The diff shows inner loops.** Full-function dumps are dominated by prologue and setup code
+  that runs once rather than inside the timed loop, so the diff compares *innermost* loops of the
+  two kernels' compiled native functions. The compiler may turn one source loop into several
+  innermost loops (e.g. an 8×-unrolled main loop plus a scalar remainder loop) — each page
+  inventories all of them, and the diff shows the best-matching pair across the two kernels. The
+  complete compiled functions are included in collapsed listings on each page.
+- **Registers and labels are canonicalized** (renamed in order of first appearance, e.g. `%x0`,
+  `%d1`, `.L0`) before diffing, so a diff line always means a structural difference — never the
+  register allocator picking different names for the same code. One side effect: when one kernel
+  holds an extra live register, every later register gets a shifted canonical index, so an
+  otherwise-identical line can show as a `-`/`+` pair differing only in those indices. The
+  discussions call this out where it happens.
+
+The listings are regenerated from the compiled kernels and committed; the prose discussions are
+written against them.

--- a/docs/kernel_asm/log.md
+++ b/docs/kernel_asm/log.md
@@ -1,0 +1,187 @@
+# LOG
+
+The `LOG` cost is the latency difference between a kernel chaining `log(tmp + x[i])` and one
+chaining only `tmp + x[i]` — kernels `f_add_log` and `f_add`. Exemplar of a **libm call**: unlike
+`sqrt`, the natural logarithm has no hardware instruction on ARM64, so the loop contains an actual
+call into the math library.
+
+## Inner-loop diff
+
+<!-- BEGIN generated: kernel-asm-log-diff -->
+```diff
+--- f_add
++++ f_add_log
+  .L0:
+  ldr  %d0, [%x0], #8
+  fadd  %d1, %d1, %d0
+- str  %d1, [%x1], #8
+- subs  %x2, %x2, #1
++ blr  %x1
++ str  %d1, [%x2], #8
++ subs  %x3, %x3, #1
+  b.ne  .L0
+```
+<!-- END generated: kernel-asm-log-diff -->
+
+## Loop structure
+
+<!-- BEGIN generated: kernel-asm-log-structure -->
+- `f_add` -- 2 innermost loop(s): 30 instructions, 6 instructions
+- `f_add_log` -- 1 innermost loop(s): 7 instructions
+
+The listings below are the complete compiled functions the benchmark times, raw as numba
+emits them (the cpython call wrappers around them are omitted -- they never run inside the
+timed loop). Listing lengths reflect the compiler's unrolling choices, not the kernels'
+amount of work -- see the discussion below.
+
+??? note "Full ASM listing: `f_add`"
+    ```asm
+      cmp  x2, #1
+      b.lt  LBB0_11
+      subs  x8, x3, #1
+      b.lt  LBB0_11
+      ldr  x9, [sp, #56]
+      ldr  x10, [sp]
+      and  x11, x3, #0x7
+      and  x12, x3, #0x7ffffffffffffff8
+      mov  x13, #22377
+      movk  x13, #35604, lsl #16
+      movk  x13, #48906, lsl #32
+      movk  x13, #16389, lsl #48
+      fmov  d0, x13
+      b  LBB0_4
+    LBB0_3:
+      subs  x2, x2, #1
+      b.le  LBB0_11
+    LBB0_4:
+      cmp  x8, #7
+      b.hs  LBB0_6
+      mov  x13, #0
+      mov.16b  v1, v0
+      b  LBB0_9
+    LBB0_6:
+      mov  x13, #0
+      add  x14, x10, #32
+      add  x15, x9, #32
+      mov.16b  v1, v0
+    LBB0_7:
+      ldur  d2, [x14, #-32]
+      fadd  d1, d1, d2
+      stur  d1, [x15, #-32]
+      ldur  d2, [x14, #-24]
+      fadd  d1, d1, d2
+      stur  d1, [x15, #-24]
+      ldur  d2, [x14, #-16]
+      fadd  d1, d1, d2
+      stur  d1, [x15, #-16]
+      ldur  d2, [x14, #-8]
+      fadd  d1, d1, d2
+      stur  d1, [x15, #-8]
+      ldr  d2, [x14]
+      fadd  d1, d1, d2
+      str  d1, [x15]
+      ldr  d2, [x14, #8]
+      fadd  d1, d1, d2
+      str  d1, [x15, #8]
+      ldr  d2, [x14, #16]
+      fadd  d1, d1, d2
+      str  d1, [x15, #16]
+      ldr  d2, [x14, #24]
+      fadd  d1, d1, d2
+      str  d1, [x15, #24]
+      add  x15, x15, #64
+      add  x14, x14, #64
+      add  x13, x13, #8
+      cmp  x12, x13
+      b.ne  LBB0_7
+      cbz  x11, LBB0_3
+    LBB0_9:
+      lsl  x14, x13, #3
+      add  x13, x9, x14
+      add  x14, x10, x14
+      mov  x15, x11
+    LBB0_10:
+      ldr  d2, [x14], #8
+      fadd  d1, d1, d2
+      str  d1, [x13], #8
+      subs  x15, x15, #1
+      b.ne  LBB0_10
+      b  LBB0_3
+    LBB0_11:
+      str  xzr, [x0]
+      mov  w0, #0
+      ret
+    ```
+
+??? note "Full ASM listing: `f_add_log`"
+    ```asm
+      stp  d9, d8, [sp, #-112]!
+      stp  x28, x27, [sp, #16]
+      stp  x26, x25, [sp, #32]
+      stp  x24, x23, [sp, #48]
+      stp  x22, x21, [sp, #64]
+      stp  x20, x19, [sp, #80]
+      stp  x29, x30, [sp, #96]
+      mov  x19, x0
+      cmp  x2, #1
+      b.lt  LBB0_6
+      mov  x20, x3
+      cmp  x3, #1
+      b.lt  LBB0_6
+      mov  x21, x2
+      ldr  x22, [sp, #168]
+      ldr  x23, [sp, #112]
+      mov  x8, #22377
+      movk  x8, #35604, lsl #16
+      movk  x8, #48906, lsl #32
+      movk  x8, #16389, lsl #48
+      fmov  d8, x8
+    Lloh0:
+      adrp  x24, _log@GOTPAGE
+    Lloh1:
+      ldr  x24, [x24, _log@GOTPAGEOFF]
+    LBB0_3:
+      mov  x25, x20
+      mov  x26, x23
+      mov  x27, x22
+      mov.16b  v0, v8
+    LBB0_4:
+      ldr  d1, [x26], #8
+      fadd  d0, d0, d1
+      blr  x24
+      str  d0, [x27], #8
+      subs  x25, x25, #1
+      b.ne  LBB0_4
+      subs  x21, x21, #1
+      b.gt  LBB0_3
+    LBB0_6:
+      str  xzr, [x19]
+      mov  w0, #0
+      ldp  x29, x30, [sp, #96]
+      ldp  x20, x19, [sp, #80]
+      ldp  x22, x21, [sp, #64]
+      ldp  x24, x23, [sp, #48]
+      ldp  x26, x25, [sp, #32]
+      ldp  x28, x27, [sp, #16]
+      ldp  d9, d8, [sp], #112
+      ret
+      .loh AdrpLdrGot  Lloh0, Lloh1
+    ```
+<!-- END generated: kernel-asm-log-structure -->
+
+## Discussion
+
+**The subtraction isolates exactly one call to libm's `log`.**
+
+1. *Intended call, and nothing else*: the one structural addition is `+ blr %x1` — an indirect
+   call through a register that holds the `log` address (loaded once, outside the loop). The
+   `-`/`+` pairs on the `str`/`subs` lines are the canonical-index shift described on the
+   [index page](index.md) — the call-target register occupies one canonical slot, renumbering
+   the registers after it; the instructions themselves are identical.
+2. *In the dependency chain*: the accumulator flows through the call — `fadd` produces the
+   argument, the call returns the result the next iteration's `fadd` consumes (both in the ARM64
+   float argument/return register), so each iteration pays the full add→log latency.
+3. *Loop-structure symmetry*: same asymmetry as the [SQRT page](sqrt.md) — `f_add` unrolls 8×,
+   `f_add_log` (whose loop body contains a call) does not; the diff shows `f_add`'s scalar
+   remainder. As there, both sides stay latency-bound through the accumulator chain, so the
+   subtraction holds.

--- a/docs/kernel_asm/sqrt.md
+++ b/docs/kernel_asm/sqrt.md
@@ -1,0 +1,163 @@
+# SQRT
+
+The `SQRT` cost is the latency difference between a kernel chaining `sqrt(tmp + x[i])` and one
+chaining only `tmp + x[i]` — kernels `f_add_sqrt` and `f_add`. Exemplar of a **bare arithmetic
+instruction**: on ARM64, `math.sqrt` compiles to a single `fsqrt` instruction, not a library call.
+
+## Inner-loop diff
+
+<!-- BEGIN generated: kernel-asm-sqrt-diff -->
+```diff
+--- f_add
++++ f_add_sqrt
+  .L0:
+  ldr  %d0, [%x0], #8
+  fadd  %d1, %d1, %d0
++ fsqrt  %d1, %d1
+  str  %d1, [%x1], #8
+  subs  %x2, %x2, #1
+  b.ne  .L0
+```
+<!-- END generated: kernel-asm-sqrt-diff -->
+
+## Loop structure
+
+<!-- BEGIN generated: kernel-asm-sqrt-structure -->
+- `f_add` -- 2 innermost loop(s): 30 instructions, 6 instructions
+- `f_add_sqrt` -- 1 innermost loop(s): 7 instructions
+
+The listings below are the complete compiled functions the benchmark times, raw as numba
+emits them (the cpython call wrappers around them are omitted -- they never run inside the
+timed loop). Listing lengths reflect the compiler's unrolling choices, not the kernels'
+amount of work -- see the discussion below.
+
+??? note "Full ASM listing: `f_add`"
+    ```asm
+      cmp  x2, #1
+      b.lt  LBB0_11
+      subs  x8, x3, #1
+      b.lt  LBB0_11
+      ldr  x9, [sp, #56]
+      ldr  x10, [sp]
+      and  x11, x3, #0x7
+      and  x12, x3, #0x7ffffffffffffff8
+      mov  x13, #22377
+      movk  x13, #35604, lsl #16
+      movk  x13, #48906, lsl #32
+      movk  x13, #16389, lsl #48
+      fmov  d0, x13
+      b  LBB0_4
+    LBB0_3:
+      subs  x2, x2, #1
+      b.le  LBB0_11
+    LBB0_4:
+      cmp  x8, #7
+      b.hs  LBB0_6
+      mov  x13, #0
+      mov.16b  v1, v0
+      b  LBB0_9
+    LBB0_6:
+      mov  x13, #0
+      add  x14, x10, #32
+      add  x15, x9, #32
+      mov.16b  v1, v0
+    LBB0_7:
+      ldur  d2, [x14, #-32]
+      fadd  d1, d1, d2
+      stur  d1, [x15, #-32]
+      ldur  d2, [x14, #-24]
+      fadd  d1, d1, d2
+      stur  d1, [x15, #-24]
+      ldur  d2, [x14, #-16]
+      fadd  d1, d1, d2
+      stur  d1, [x15, #-16]
+      ldur  d2, [x14, #-8]
+      fadd  d1, d1, d2
+      stur  d1, [x15, #-8]
+      ldr  d2, [x14]
+      fadd  d1, d1, d2
+      str  d1, [x15]
+      ldr  d2, [x14, #8]
+      fadd  d1, d1, d2
+      str  d1, [x15, #8]
+      ldr  d2, [x14, #16]
+      fadd  d1, d1, d2
+      str  d1, [x15, #16]
+      ldr  d2, [x14, #24]
+      fadd  d1, d1, d2
+      str  d1, [x15, #24]
+      add  x15, x15, #64
+      add  x14, x14, #64
+      add  x13, x13, #8
+      cmp  x12, x13
+      b.ne  LBB0_7
+      cbz  x11, LBB0_3
+    LBB0_9:
+      lsl  x14, x13, #3
+      add  x13, x9, x14
+      add  x14, x10, x14
+      mov  x15, x11
+    LBB0_10:
+      ldr  d2, [x14], #8
+      fadd  d1, d1, d2
+      str  d1, [x13], #8
+      subs  x15, x15, #1
+      b.ne  LBB0_10
+      b  LBB0_3
+    LBB0_11:
+      str  xzr, [x0]
+      mov  w0, #0
+      ret
+    ```
+
+??? note "Full ASM listing: `f_add_sqrt`"
+    ```asm
+      cmp  x2, #1
+      b.lt  LBB0_6
+      cmp  x3, #1
+      b.lt  LBB0_6
+      ldr  x8, [sp, #56]
+      ldr  x9, [sp]
+      mov  x10, #22377
+      movk  x10, #35604, lsl #16
+      movk  x10, #48906, lsl #32
+      movk  x10, #16389, lsl #48
+      fmov  d0, x10
+    LBB0_3:
+      mov  x10, x3
+      mov  x11, x9
+      mov  x12, x8
+      mov.16b  v1, v0
+    LBB0_4:
+      ldr  d2, [x11], #8
+      fadd  d1, d1, d2
+      fsqrt  d1, d1
+      str  d1, [x12], #8
+      subs  x10, x10, #1
+      b.ne  LBB0_4
+      subs  x2, x2, #1
+      b.gt  LBB0_3
+    LBB0_6:
+      str  xzr, [x0]
+      mov  w0, #0
+      ret
+    ```
+<!-- END generated: kernel-asm-sqrt-structure -->
+
+## Discussion
+
+**The subtraction isolates exactly one `fsqrt`.**
+
+1. *Intended instruction, and nothing else*: the diff is the single line `+ fsqrt %d1, %d1` —
+   loads, stores and loop control are identical on both sides.
+2. *In the dependency chain*: `fsqrt` reads and writes `%d1`, the accumulator that feeds the next
+   iteration's `fadd`, so each iteration waits for the full add→sqrt latency.
+3. *Loop-structure symmetry*: **not symmetric, deliberately surfaced.** `f_add` compiles to an
+   8×-unrolled main loop plus a scalar remainder (the diff shows the remainder), while
+   `f_add_sqrt` compiles to a single scalar loop. This does not invalidate the measurement: both
+   loops serialize through the `%d1` chain, so per-iteration latency is the chained operations'
+   latency regardless of unrolling — the unrolled body performs 8 chained iterations' work and
+   takes 8 chained iterations' time. But `f_add` is the subtrahend of most derived costs, so a
+   toolchain change that alters this unrolling decision *without* preserving the latency-bound
+   property would shift the whole weight table — this asymmetry is the primary thing to re-check
+   on regeneration.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,12 @@ nav:
       - Built-in data: builtin_data.md
       - Methodology: analysis_methodology.md
       - CPU architecture scope: cpu_architectures_scope.md
+      - Benchmark kernel machine code:
+          - Overview: kernel_asm/index.md
+          - EXP: kernel_asm/exp.md
+          - HYPOT_XARG: kernel_asm/hypot_xarg.md
+          - LOG: kernel_asm/log.md
+          - SQRT: kernel_asm/sqrt.md
   - Changelog: changelog.md
 
 plugins:
@@ -57,6 +63,7 @@ markdown_extensions:
       permalink: true
   - pymdownx.highlight:
       anchor_linenums: true
+  - pymdownx.details
   - pymdownx.superfences
   - tables
 

--- a/scripts/generate_kernel_asm_docs.py
+++ b/scripts/generate_kernel_asm_docs.py
@@ -1,0 +1,335 @@
+"""Regenerate the benchmark-kernel machine-code listings committed under docs/kernel_asm/.
+
+Every benchmarked flop cost is a *difference* of two kernel latencies, which silently assumes the
+compiler emitted exactly the intended extra work. The pages under `docs/kernel_asm/` make that
+assumption inspectable: per flop cost, the compiled inner loops of the two kernels are shown as a
+unified diff, together with each kernel's loop structure, so a reader can verify the measurement
+isolates what its name claims. The prose discussion on each page is hand-written; this script only
+rewrites the marked listing blocks (same marker mechanism as `generate_docs_content.py`).
+
+Run via `make regen-kernel-asm` whenever a kernel, numba, or LLVM changes the generated code.
+
+Unlike the dataset-derived docs content, these listings are machine-code and therefore
+architecture-specific: the committed pages are generated on ARM64 (Apple M-series), and the script
+refuses to run anywhere else so a regen on another machine cannot silently swap the architecture
+out from under the committed pages. The drift test skips on other platforms for the same reason.
+
+What "inner loop" means here: each kernel is a doubly-nested loop; the listings show every
+*innermost* loop of the kernel's compiled native function -- a backward branch to a label with no
+other label in between. LLVM may compile one source loop into several such loops (e.g. an
+8x-unrolled main loop plus a scalar remainder loop), which is exactly the kind of structural
+asymmetry these pages exist to surface, so all of them are listed. The diff shows the
+best-matching pair of loops across the two kernels.
+
+Registers and labels are canonicalized (in order of first appearance) before diffing, so a diff
+line means a structural difference, never LLVM's register allocator picking different names.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import difflib
+import platform
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# sibling script, not a package: make its marked-block engine importable
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from generate_docs_content import _read_lf, rewrite_marked_blocks
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+KERNEL_ASM_DOCS_DIR = REPO_ROOT / "docs" / "kernel_asm"
+
+# The architecture the committed listings are generated on; pages state it in prose.
+REQUIRED_MACHINE = "arm64"
+
+_LABEL_RE = re.compile(r"^(LBB\d+_\d+):")
+_BRANCH_TO_LABEL_RE = re.compile(r"^\t(?:b(?:\.\w+)?|cbz|cbnz|tbz|tbnz)\t.*?(LBB\d+_\d+)$")
+_LABEL_REF_RE = re.compile(r"LBB\d+_\d+")
+_REGISTER_RE = re.compile(r"\b([xwdsqv])(\d+)\b")
+
+
+# ==================================================================================================
+#  ASM parsing
+# ==================================================================================================
+def native_function_body(asm: str) -> list[str]:
+    """The instruction lines of the first function in a numba ASM dump.
+
+    numba emits the native nopython function first, followed by the cpython wrapper, the cfunc
+    wrapper and runtime helpers -- everything after the native function is call-glue that never
+    runs inside the timed loop, so only the first function body is of interest.
+    """
+    lines = asm.splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith("__ZN") and line.endswith(":"))
+    end = next(i for i in range(start + 1, len(lines)) if lines[i].lstrip().startswith(".globl"))
+    return lines[start + 1 : end]
+
+
+def innermost_loops(body: list[str]) -> list[list[str]]:
+    """Every innermost loop in `body`: label through backward branch, no label in between.
+
+    Returns:
+        The loop blocks in source order, each a list of raw ASM lines starting with the loop
+        label and ending with the branch back to it.
+    """
+    label_positions = {match.group(1): i for i, line in enumerate(body) if (match := _LABEL_RE.match(line))}
+    loops: list[list[str]] = []
+    for i, line in enumerate(body):
+        match = _BRANCH_TO_LABEL_RE.match(line.rstrip())
+        if not match:
+            continue
+        target = label_positions.get(match.group(1))
+        if target is None or target >= i:
+            continue  # forward branch, not a loop
+        block = body[target : i + 1]
+        if not any(_LABEL_RE.match(inner) for inner in block[1:]):
+            loops.append(block)
+    return loops
+
+
+def canonicalize_loop(block: list[str]) -> list[str]:
+    """Rename registers and labels to appearance-ordered canonical names, for diffability.
+
+    GPRs keep their width letter (`x`/`w`) but share one numbering per underlying register, and
+    FPRs (`d`/`s`/`q`/`v`) likewise, so e.g. the third distinct float register is always `%d2`
+    no matter which physical register the allocator picked. Special names (`sp`, `xzr`, ...)
+    carry no allocator choice and stay as-is.
+    """
+    gpr_indices: dict[str, str] = {}
+    fpr_indices: dict[str, str] = {}
+    label_names: dict[str, str] = {}
+
+    def rename_register(match: re.Match[str]) -> str:
+        kind, number = match.groups()
+        indices = gpr_indices if kind in "xw" else fpr_indices
+        indices.setdefault(number, str(len(indices)))
+        return f"%{kind}{indices[number]}"
+
+    out: list[str] = []
+    for line in block:
+        for label in _LABEL_REF_RE.findall(line):
+            label_names.setdefault(label, f".L{len(label_names)}")
+        renamed = _REGISTER_RE.sub(rename_register, line)
+        for label, canonical in label_names.items():
+            renamed = renamed.replace(label, canonical)
+        out.append(re.sub(r"\t", "  ", renamed.strip()))
+    return out
+
+
+# ==================================================================================================
+#  Kernel compilation
+# ==================================================================================================
+@dataclasses.dataclass(frozen=True)
+class CompiledKernel:
+    """One benchmark kernel's compiled native function, in the two forms the pages show.
+
+    Attributes:
+        loops: The canonicalized innermost loops, for diffing.
+        full_listing: The complete native-function ASM, raw as numba emits it, for the
+            collapsible full listing.
+    """
+
+    loops: list[list[str]]
+    full_listing: list[str]
+
+
+def compile_kernel(kernel_name: str) -> CompiledKernel:
+    """Compile one benchmark kernel with the suite's signature and dissect its ASM."""
+    from counted_float._core.benchmarking.flops import _flops_kernels as kernels
+
+    kernel = getattr(kernels, kernel_name)
+    size = 16
+    kernel(1, size, np.linspace(1.0, 2.0, size), np.zeros(size), np.zeros(size, dtype=np.int64))
+    asm = kernel.inspect_asm(next(iter(kernel.signatures)))
+    body = native_function_body(asm)
+    return CompiledKernel(
+        loops=[canonicalize_loop(loop) for loop in innermost_loops(body)],
+        full_listing=[_stabilize_symbols(line.replace("\t", "  ").rstrip()) for line in body],
+    )
+
+
+def _stabilize_symbols(line: str) -> str:
+    """Strip the per-process address suffix from numba's constant symbols.
+
+    Kernels with an error path (e.g. the scaled hypot/dist kernels' zero-maximum guard) reference
+    constants numba names `_.const.<name>.<address>`; the address changes every process, which
+    would make the committed listings flap on every regen.
+    """
+    return re.sub(r"(_\.const\.\w+)\.\d+", r"\1.<addr>", line)
+
+
+# ==================================================================================================
+#  Page-block rendering
+# ==================================================================================================
+@dataclasses.dataclass(frozen=True)
+class KernelAsmPage:
+    """One flop cost's page: the kernel pair whose latency difference prices it.
+
+    Attributes:
+        doc_name: Page file name under docs/kernel_asm/, without extension.
+        kind: The overview page's grouping bucket the flop cost belongs to.
+        base_kernel: The subtracted kernel (diff "before" side).
+        extended_kernel: The kernel carrying the extra operation (diff "after" side).
+    """
+
+    doc_name: str
+    kind: str
+    base_kernel: str
+    extended_kernel: str
+
+
+# The overview page's grouping buckets, in display order.
+KIND_HARDWARE = "Hardware instructions"
+KIND_LIBM = "Library calls (libm)"
+KIND_ARITY = "Arity-scaled algorithms"
+KINDS: list[str] = [KIND_HARDWARE, KIND_LIBM, KIND_ARITY]
+
+# The exemplar pages, spanning the distinct kernel shapes: a bare arithmetic instruction (SQRT),
+# a libm call (LOG), a chained-base pair (EXP), and an arity-scaled pair (HYPOT_XARG).
+PAGES: list[KernelAsmPage] = [
+    KernelAsmPage("sqrt", kind=KIND_HARDWARE, base_kernel="f_add", extended_kernel="f_add_sqrt"),
+    KernelAsmPage("log", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_log"),
+    KernelAsmPage("exp", kind=KIND_LIBM, base_kernel="f_add_log", extended_kernel="f_add_log_exp"),
+    KernelAsmPage(
+        "hypot_xarg", kind=KIND_ARITY, base_kernel="f_add_hypot_scaled2", extended_kernel="f_add_hypot_scaled8"
+    ),
+]
+
+
+def best_matching_loops(base_loops: list[list[str]], extended_loops: list[list[str]]) -> tuple[list[str], list[str]]:
+    """The pair of loops (one per kernel) with the highest line-level similarity.
+
+    When a kernel compiles to several innermost loops (unrolled main + remainder), the remainder
+    is the one structurally comparable to the other kernel's loop -- highest-similarity selection
+    finds it without hard-coding which kernel unrolled.
+    """
+    _, base, extended = max(
+        (difflib.SequenceMatcher(a=base, b=extended).ratio(), base, extended)
+        for base in base_loops
+        for extended in extended_loops
+    )
+    return base, extended
+
+
+def render_diff_block(page: KernelAsmPage, base: list[str], extended: list[str]) -> str:
+    """The unified diff of the best-matching loop pair, as a `diff`-fenced markdown block."""
+    body: list[str] = []
+    for tag, a_lo, a_hi, b_lo, b_hi in difflib.SequenceMatcher(a=base, b=extended).get_opcodes():
+        if tag in ("equal", "delete", "replace"):
+            body.extend(f"  {line}" if tag == "equal" else f"- {line}" for line in base[a_lo:a_hi])
+        if tag in ("insert", "replace"):
+            body.extend(f"+ {line}" for line in extended[b_lo:b_hi])
+    return "\n".join(["```diff", f"--- {page.base_kernel}", f"+++ {page.extended_kernel}", *body, "```"])
+
+
+def render_structure_block(page: KernelAsmPage, kernels_by_name: dict[str, CompiledKernel]) -> str:
+    """Each kernel's innermost-loop inventory, with the full function ASM behind a collapsible.
+
+    The inventory line is the at-a-glance unrolling check (one loop vs. main + remainder); the
+    collapsed complete listings let a reader verify the diffed loop was not cherry-picked and
+    that nothing relevant sits outside it.
+    """
+    inventory = [
+        f"- `{name}` -- {len(compiled.loops)} innermost loop(s): "
+        + ", ".join(f"{len(loop)} instructions" for loop in compiled.loops)
+        for name, compiled in kernels_by_name.items()
+    ]
+    intro = [
+        "The listings below are the complete compiled functions the benchmark times, raw as numba",
+        "emits them (the cpython call wrappers around them are omitted -- they never run inside the",
+        "timed loop). Listing lengths reflect the compiler's unrolling choices, not the kernels'",
+        "amount of work -- see the discussion below.",
+    ]
+    listings: list[str] = []
+    for name, compiled in kernels_by_name.items():
+        listing_lines = "\n".join(compiled.full_listing).rstrip("\n").split("\n")
+        listings.append(f'??? note "Full ASM listing: `{name}`"')
+        listings.append("    ```asm")
+        listings.extend(f"    {line}".rstrip() for line in listing_lines)
+        listings.append("    ```")
+        listings.append("")
+    return "\n".join([*inventory, "", *intro, "", *listings]).rstrip()
+
+
+def render_page_list_block() -> str:
+    """The overview page's grouped links to the per-cost pages, alphabetical within each group."""
+    lines: list[str] = []
+    for kind in KINDS:
+        pages = sorted((page for page in PAGES if page.kind == kind), key=lambda page: page.doc_name)
+        if not pages:
+            continue
+        lines.append(f"**{kind}**")
+        lines.append("")
+        lines.extend(f"- [{page.doc_name.upper()}]({page.doc_name}.md)" for page in pages)
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def regenerate_pages() -> dict[Path, str]:
+    """Regenerate every page's marked blocks; returns the intended full content per page file."""
+    kernel_cache: dict[str, CompiledKernel] = {}
+
+    def compiled(kernel_name: str) -> CompiledKernel:
+        if kernel_name not in kernel_cache:
+            kernel_cache[kernel_name] = compile_kernel(kernel_name)
+        return kernel_cache[kernel_name]
+
+    regenerated: dict[Path, str] = {}
+    for page in PAGES:
+        base_kernel, extended_kernel = compiled(page.base_kernel), compiled(page.extended_kernel)
+        base, extended = best_matching_loops(base_kernel.loops, extended_kernel.loops)
+        marker_stem = f"kernel-asm-{page.doc_name.replace('_', '-')}"
+        replacements = {
+            f"{marker_stem}-diff": render_diff_block(page, base, extended),
+            f"{marker_stem}-structure": render_structure_block(
+                page, {page.base_kernel: base_kernel, page.extended_kernel: extended_kernel}
+            ),
+        }
+        file_path = KERNEL_ASM_DOCS_DIR / f"{page.doc_name}.md"
+        regenerated[file_path] = rewrite_marked_blocks(_read_lf(file_path), file_path, replacements)
+    index_path = KERNEL_ASM_DOCS_DIR / "index.md"
+    regenerated[index_path] = rewrite_marked_blocks(
+        _read_lf(index_path), index_path, {"kernel-asm-page-list": render_page_list_block()}
+    )
+    return regenerated
+
+
+# ==================================================================================================
+#  Entry point
+# ==================================================================================================
+def main() -> int:
+    """Regenerate the kernel ASM listing blocks; `--check` verifies instead of writing."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail on stale listings, write nothing")
+    args = parser.parse_args()
+
+    if platform.machine() != REQUIRED_MACHINE:
+        sys.stderr.write(
+            f"kernel ASM listings are committed as {REQUIRED_MACHINE} machine code; "
+            f"refusing to regenerate on '{platform.machine()}' -- see module docstring\n"
+        )
+        return 1
+
+    regenerated = regenerate_pages()
+    if args.check:
+        stale = [path for path, intended in regenerated.items() if _read_lf(path) != intended]
+        for path in stale:
+            sys.stderr.write(f"stale kernel ASM listings in {path.relative_to(REPO_ROOT)}\n")
+        if stale:
+            sys.stderr.write("run `make regen-kernel-asm`\n")
+            return 1
+        return 0
+
+    for file_path, intended in regenerated.items():
+        if _read_lf(file_path) != intended:
+            file_path.write_text(intended, encoding="utf-8", newline="\n")
+            print(f"rewrote {file_path.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/docs/test_kernel_asm_drift.py
+++ b/tests/docs/test_kernel_asm_drift.py
@@ -1,0 +1,39 @@
+"""The committed kernel ASM listings must stay in step with what the kernels compile to.
+
+Counterpart of the docs-content drift test, for the machine-code listings under docs/kernel_asm/:
+the generator recompiles the kernels and this test fails on any difference with the committed
+listings. Unlike that test, this one can only run where the listings were generated — the pages
+are committed as ARM64 machine code and need numba to compile — so it skips everywhere else and
+guards the listings on the regen machine rather than in CI.
+"""
+
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from counted_float._core.compatibility import is_numba_installed
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+GENERATOR = REPO_ROOT / "scripts" / "generate_kernel_asm_docs.py"
+
+
+@pytest.mark.skipif(
+    platform.machine() != "arm64" or not is_numba_installed(),
+    reason="listings are ARM64 machine code and need numba to regenerate",
+)
+def test_kernel_asm_listings_match_committed_content():
+    """Fails when a kernel compiles differently and `make regen-kernel-asm` was not re-run."""
+    # --- act ---------------------------------------------
+    result = subprocess.run(  # noqa: S603 -- fixed, repo-local command
+        [sys.executable, str(GENERATOR), "--check"],
+        capture_output=True,
+        encoding="utf-8",
+        cwd=REPO_ROOT,
+        check=False,  # the return code is the assertion
+    )
+
+    # --- assert ------------------------------------------
+    assert result.returncode == 0, f"stale kernel ASM listings:\n{result.stderr}"

--- a/tests/docs/test_kernel_asm_drift.py
+++ b/tests/docs/test_kernel_asm_drift.py
@@ -7,6 +7,7 @@ are committed as ARM64 machine code and need numba to compile — so it skips ev
 guards the listings on the regen machine rather than in CI.
 """
 
+import os
 import platform
 import subprocess
 import sys
@@ -21,8 +22,10 @@ GENERATOR = REPO_ROOT / "scripts" / "generate_kernel_asm_docs.py"
 
 
 @pytest.mark.skipif(
-    platform.machine() != "arm64" or not is_numba_installed(),
-    reason="listings are ARM64 machine code and need numba to regenerate",
+    platform.machine() != "arm64" or not is_numba_installed() or os.environ.get("CI") is not None,
+    reason="listings are ARM64 machine code, need numba to regenerate, and are pinned to the "
+    "regen machine's toolchain -- CI's macos runners are arm64 too, but their LLVM/numba may "
+    "legitimately generate different code",
 )
 def test_kernel_asm_listings_match_committed_content():
     """Fails when a kernel compiles differently and `make regen-kernel-asm` was not re-run."""

--- a/tests/docs/test_kernel_asm_extraction.py
+++ b/tests/docs/test_kernel_asm_extraction.py
@@ -1,0 +1,103 @@
+"""The kernel ASM extraction must find the right loops and canonicalize them deterministically."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_GENERATOR = Path(__file__).resolve().parent.parent.parent / "scripts" / "generate_kernel_asm_docs.py"
+_spec = importlib.util.spec_from_file_location("generate_kernel_asm_docs", _GENERATOR)
+generate_kernel_asm_docs = importlib.util.module_from_spec(_spec)
+# registered before executing: dataclass field resolution looks the defining module up in
+# sys.modules, which a bare module_from_spec import would leave absent
+sys.modules[_spec.name] = generate_kernel_asm_docs
+_spec.loader.exec_module(generate_kernel_asm_docs)
+
+best_matching_loops = generate_kernel_asm_docs.best_matching_loops
+canonicalize_loop = generate_kernel_asm_docs.canonicalize_loop
+innermost_loops = generate_kernel_asm_docs.innermost_loops
+native_function_body = generate_kernel_asm_docs.native_function_body
+
+# A hand-written miniature of numba's ASM dump shape: the native function first, then the cpython
+# wrapper (which must be excluded), with an outer loop wrapping an inner one (only the inner is an
+# innermost loop) and a forward branch (not a loop at all).
+_ASM = """\t.section\t__TEXT,__text
+\t.globl\t__ZN8testfuncE
+__ZN8testfuncE:
+\tcmp\tx2, #1
+\tb.lt\tLBB0_5
+LBB0_1:
+\tmov\tx10, x3
+LBB0_2:
+\tldr\td2, [x11], #8
+\tfadd\td1, d1, d2
+\tsubs\tx10, x10, #1
+\tb.ne\tLBB0_2
+\tsubs\tx2, x2, #1
+\tb.gt\tLBB0_1
+LBB0_5:
+\tret
+\t.globl\t__ZN7cpython8testfuncE
+__ZN7cpython8testfuncE:
+\tbl\t_PyArg_UnpackTuple
+\tret
+"""
+
+
+def test_native_function_body_excludes_the_cpython_wrapper():
+    # --- act ---------------------------------------------
+    body = native_function_body(_ASM)
+
+    # --- assert ------------------------------------------
+    assert body[0] == "\tcmp\tx2, #1"
+    assert body[-1] == "\tret"
+    assert not any("PyArg" in line for line in body)
+
+
+def test_innermost_loops_finds_only_the_label_free_backward_branch_block():
+    # --- act ---------------------------------------------
+    loops = innermost_loops(native_function_body(_ASM))
+
+    # --- assert ------------------------------------------
+    # the outer loop (LBB0_1) contains the inner label, so only the inner block qualifies
+    assert [loop[0] for loop in loops] == ["LBB0_2:"]
+    assert loops[0][-1] == "\tb.ne\tLBB0_2"
+    assert len(loops[0]) == 5
+
+
+def test_canonicalize_loop_renames_registers_and_labels_by_first_appearance():
+    # --- arrange -----------------------------------------
+    loop = ["LBB0_7:", "\tldr\td2, [x11], #8", "\tfadd\td1, d1, d2", "\tb.ne\tLBB0_7"]
+
+    # --- act ---------------------------------------------
+    canonical = canonicalize_loop(loop)
+
+    # --- assert ------------------------------------------
+    # d2 is the first float register seen (index 0), d1 the second; x11 the first general-purpose
+    # register; the label becomes .L0
+    assert canonical == [".L0:", "ldr  %d0, [%x0], #8", "fadd  %d1, %d1, %d0", "b.ne  .L0"]
+
+
+def test_canonicalize_loop_keeps_width_letters_but_shares_numbering_per_register():
+    # --- arrange -----------------------------------------
+    # w8 and x8 are the same underlying register accessed at two widths: same index, own letter
+    loop = ["\tmov\tw8, #1", "\tadd\tx8, x8, x9"]
+
+    # --- act ---------------------------------------------
+    canonical = canonicalize_loop(loop)
+
+    # --- assert ------------------------------------------
+    assert canonical == ["mov  %w0, #1", "add  %x0, %x0, %x1"]
+
+
+def test_best_matching_loops_picks_the_structurally_closest_pair():
+    # --- arrange -----------------------------------------
+    remainder = ["ldr", "fadd", "str", "b.ne"]
+    unrolled_main = ["ldur", "fadd", "stur"] * 8
+    extended = ["ldr", "fadd", "fsqrt", "str", "b.ne"]
+
+    # --- act ---------------------------------------------
+    base, matched = best_matching_loops([unrolled_main, remainder], [extended])
+
+    # --- assert ------------------------------------------
+    assert base == remainder
+    assert matched == extended


### PR DESCRIPTION
Each flop weight is a latency *difference* between two compiled kernels, which silently assumes the compiler emitted exactly the intended extra work. This PR adds a docs section (`Reference → Benchmark kernel machine code`) that makes that inspectable: per flop cost, the two kernels' inner loops as a unified diff — registers and labels canonicalized so every diff line is a structural difference — plus a loop-structure inventory, collapsed full ASM listings, and a short discussion of what the measurement isolates.

The listings are generated by a new `make regen-kernel-asm` script (ARM64-only, since the committed pages are ARM64 machine code) reusing the docs marked-block mechanism; a drift test recompiles and compares on the regen machine and skips elsewhere. Four exemplar pages establish the format across the distinct kernel shapes: a bare hardware instruction (SQRT), libm calls (LOG, EXP), and an arity-scaled pair (HYPOT_XARG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)