### PR TITLE
docs: state the cost-model principles and map every flop type onto them

### DIFF
--- a/docs/analysis_methodology.md
+++ b/docs/analysis_methodology.md
@@ -62,32 +62,9 @@ to work with a maximum of 4K double precision values.
 
 ## 1.6. Benchmark design rationale
 
-What each benchmark actually executes is governed by a few principles:
-
-1. **Measure the real call when possible.** Where numba can compile the operation Python
-   actually executes — libm's `sin`, `log`, the 2-argument `hypot`, ... — the benchmark measures
-   that call directly: no re-implementation, no modeling. The
-   [machine-code listings](kernel_asm/index.md) show, per weight, that this is what happens.
-2. **Hand-roll only when there is no alternative.** numba cannot compile n-ary `math.hypot` or
-   `math.dist` at all, so their kernels port the algorithm instead — that is the only reason a
-   port exists.
-3. **`dist` and n-ary `hypot` are priced as the overflow-safe scaled algorithm — a deliberate
-   departure from the compiled-port lens.** Elsewhere the model asks what an optimizing compiler
-   would emit for your code (hence e.g. strength-reduced `POW` for constant exponents), and that
-   compiler would emit naive sum-of-squares here. Pricing that instead was rejected for two
-   reasons. *Semantics*: `math.dist` and `math.hypot` are named calls whose contract includes
-   overflow safety — scaling every coordinate by the largest magnitude before squaring — and a
-   user reaching for them rather than writing `sqrt(dx*dx + dy*dy)` plausibly wants exactly
-   that, so the naive price would model a different function than the one invoked. *Coherence*:
-   the 2-argument base is libm's `hypot`, which **is** scaled — grafting a naive per-coordinate
-   slope onto a scaled base would produce a cost curve where a 3-argument call can price below
-   the 2-argument one, collapsing the "one algorithm, base plus linear slope" model. Pricing the
-   scaled flavor at every arity keeps one algorithm and one monotone linear model, matching the
-   call's semantics. (A user who writes the naive formula out by hand gets the naive decomposed
-   price — the compiled-port lens still applies to their code.)
-4. **Validate the port where it overlaps something measurable.** The scaled arity-2 hypot kernel
-   reproduces libm's 2-argument `hypot` cost to within ~10%, which is what justifies deriving a
-   base from libm and a slope from the port on one line.
+What each benchmark executes — which call or port is measured, and over which input ranges —
+follows the package-wide pricing rules; see [Cost-model principles](cost_model.md) for the
+rules and the per-type table applying them.
 
 
 # 2. Sources

--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -1,0 +1,151 @@
+# Cost-model principles
+
+Every flop weight and every counting decision in `counted-float` answers the same question:
+**what does this operation cost?** — and that question has more than one defensible answer
+(the code as written, what a compiler would make of it, what the interpreter actually
+executes). This page states the rules used to pick one, so that every pricing choice in the
+package can name the rule it follows — and the few that deviate can say so explicitly.
+
+One convention underlies everything below: in counted code, a **plain `float` operand is a
+compile-time [constant](glossary.md#constant)** — something the hypothetical compiled
+program would know while being compiled — while a **`CountedFloat` operand is dynamic
+algorithm input**. Rules that depend on an operand being constant (strength reduction,
+reciprocal multiplication) key on exactly this distinction.
+
+## The rules
+
+**Rule 1 — operations that compile to CPU instructions only (no library call) are priced
+as a value-preserving [compiled port](glossary.md#compiled-port).**
+
+- **1.1** *(scope)* — covers arithmetic written in operators (`+`, `*`, `%`,
+  `round(x, n)`, ...) *and* the named calls that reduce to single instructions
+  (`math.sqrt` → `FSQRT`, `abs`/`math.fabs` → `FABS`, `math.copysign`).
+- **1.2** *(definition)* — "value-preserving" means the port must produce bit-identical
+  results; transformations a compiler only applies under fast-math flags are out.
+- **1.3** *(consequence)* — no FP [contraction](glossary.md#fp-contraction): `x*y + z`
+  counts MUL + ADD, not FMA — fusing changes rounding.
+- **1.4** *(consequence)* — [strength reduction](glossary.md#strength-reduction) applies
+  only where the reduced form is value-identical *and* is what a standard-C port genuinely
+  emits.
+- **1.5** *(example)* — constant exponents: `x ** 2` → MUL, `2 ** x` → C99 `exp2`; but
+  `10 ** x` → `pow(10, x)`, since `exp10` is not standard C.
+- **1.6** *(example)* — reciprocal multiplication for division only where it is exact: a
+  power-of-two constant divisor with a finite reciprocal — there, and only there,
+  `x * (1/c)` is bit-identical to `x / c`, and compilers apply the fold at plain `-O2`.
+  *Known deviation: counted-float currently prices every division as DIV, this fold
+  included.*
+
+**Rule 2 — operations that compile to a library call are priced as the call's real
+algorithm, contract included.**
+
+- **2.1** *(scope)* — applies whenever the call's cost is *deterministic per call*: a
+  fixed number of operations per invocation (or per element or coordinate), independent
+  of the data values. Anything else falls to rule 3.
+- **2.2** *(consequence)* — the weight is measured on the very call wherever the
+  toolchain can compile it ([libm](glossary.md#libm)'s `sin`, `log`, ...).
+- **2.3** *(nuance)* — where the toolchain cannot compile the real call, a faithful port
+  of the algorithm it executes is benchmarked instead — never a naive substitute
+  (`math.dist`'s overflow-safe scaling, not a plain sum of squares).
+- **2.4** *(nuance)* — regime-dependent [fast paths](glossary.md#fast-path) inside such
+  functions are handled by rule 4's input ranges, not by pricing the shortcut.
+
+**Rule 3 — operations whose real algorithm has input-dependent cost are priced as their
+deterministic mathematical core, with the gap stated.**
+
+- **3.1** *(example)* — `math.fsum` maintains as many non-overlapping partial sums as the
+  *values* force (mixing widely different magnitudes grows the list, cancellation shrinks
+  it), so even for a fixed-length input there is no constant to benchmark; it is priced as
+  the mathematical reduction, (n−1) ADD.
+- **3.2** *(consequence)* — the un-priced machinery is stated explicitly wherever the
+  price is documented: a deviation under this rule is a documented gap, never a silent
+  one.
+
+**Rule 4 — benchmark inputs represent the operation's general case.**
+
+- **4.1** *(consequence)* — input ranges stay inside the operation's domain.
+- **4.2** *(consequence)* — input ranges avoid cheap fast paths (saturation shortcuts,
+  early returns — e.g. `tanh` beyond ±20, `erf` beyond ±6), so a weight prices the real
+  computation rather than a shortcut.
+- **4.3** *(consequence)* — input ranges represent the general-case cost, not a degenerate
+  regime.
+- **4.4** *(practice)* — where a range needs a non-obvious choice, the benchmark source
+  carries a comment saying why.
+
+## Per-type pricing
+
+One row per `FlopType`: the benchmark pair whose latency difference prices it (see
+[Benchmark machine code](kernel_asm/index.md) for the compiled loops behind each pair), the
+rule that governs it, and — for grey-zone cases — why the choice is what it is.
+
+<!-- BEGIN generated: cost-model-flop-type-table -->
+| Flop type | Weight measured as | Rule | Notes |
+|---|---|---|---|
+| [`ABS`](kernel_asm/abs.md) | `f_add_abs` − `f_add` | 1 |  |
+| [`ACOS`](kernel_asm/acos.md) | `f_add_sin_acos` − `f_add_sin` | 2 |  |
+| [`ACOSH`](kernel_asm/acosh.md) | `f_add_acosh` − `f_add` | 2, 4 |  |
+| [`ADD`](kernel_asm/add.md) | `f_add_add` − `f_add` | 1 |  |
+| [`ASIN`](kernel_asm/asin.md) | `f_add_sin_asin` − `f_add_sin` | 2 |  |
+| [`ASINH`](kernel_asm/asinh.md) | `f_add_asinh` − `f_add` | 2 |  |
+| [`ATAN`](kernel_asm/atan.md) | `f_add_atan` − `f_add` | 2 |  |
+| [`ATAN2`](kernel_asm/atan2.md) | `f_add_atan2` − `f_add` | 2 |  |
+| [`ATANH`](kernel_asm/atanh.md) | `f_add_halfsin_atanh` − `f_add_halfsin` | 2 |  |
+| [`CBRT`](kernel_asm/cbrt.md) | `f_add_cbrt` − `f_add` | 2 | a known deviation from rule 2.2: measured through numba's `np.cbrt`, whose NaN/sign handling around the libm call is included in the weight (CPython's `math.cbrt` calls libm directly) |
+| [`COMP`](kernel_asm/comp.md) | `f_lte_addsub` − `f_add` | 1 | the subtrahend is the ADD/SUB average, and the branchy source compiles branchless -- the weight prices compare-and-select machinery, matching what float comparisons cost in optimized code |
+| [`COPYSIGN`](kernel_asm/copysign.md) | `f_add_copysign` − `f_add` | 1 |  |
+| [`COS`](kernel_asm/cos.md) | `f_add_cos` − `f_add` | 2 |  |
+| [`COSH`](kernel_asm/cosh.md) | `f_add_acosh_cosh` − `f_add_acosh` | 2 |  |
+| [`DIST`](kernel_asm/dist.md) | `f_add_dist2` − `f_add` | 2 | hand-rolled overflow-safe port (no libm `dist` exists); prices the scaled algorithm `math.dist` executes, not a naive sum of squares |
+| [`DIST_XARG`](kernel_asm/dist_xarg.md) | `f_add_dist8` − `f_add_dist2` | 2 | per-extra-coordinate slope of the same overflow-safe port as `DIST` |
+| [`DIV`](kernel_asm/div.md) | `f_div_div` − `f_div` | 1 |  |
+| [`ERF`](kernel_asm/erf.md) | `f_add_erf` − `f_add` | 2, 4 |  |
+| [`ERFC`](kernel_asm/erfc.md) | `f_add_erfc` − `f_add` | 2, 4 |  |
+| [`EXP`](kernel_asm/exp.md) | `f_add_log_exp` − `f_add_log` | 2 |  |
+| [`EXP10`](kernel_asm/exp10.md) | `f_add_log10_exp10` − `f_add_log10` | 2 | `10 ** x` cannot strength-reduce to an `exp10` call -- `exp10` is not standard C -- so a port emits `pow(10, x)`, and that is exactly what the weight measures |
+| [`EXP2`](kernel_asm/exp2.md) | `f_add_log2_exp2` − `f_add_log2` | 2 | `2 ** x` strength-reduces here because a standard-C port emits C99 `exp2`; the weight is measured on the real `exp2` call |
+| [`EXPM1`](kernel_asm/expm1.md) | `f_add_log1p_expm1` − `f_add_log1p` | 2 |  |
+| [`FMA`](kernel_asm/fma.md) | `f_fma_fma` − `f_fma` | 1 |  |
+| [`FMOD`](kernel_asm/fmod.md) | `f_add_fmod` − `f_add` | 2, 4 |  |
+| [`GAMMA`](kernel_asm/gamma.md) | `f_add_gammabase_gamma` − `f_add_gammabase` | 2 |  |
+| [`HYPOT`](kernel_asm/hypot.md) | `f_add_hypot` − `f_add` | 2 | the 2-argument base weight is the real libm call; the hand-rolled scaled kernels only supply the per- extra-coordinate slope, validated against this base (within ~10%) |
+| [`HYPOT_XARG`](kernel_asm/hypot_xarg.md) | `f_add_hypot_scaled8` − `f_add_hypot_scaled2` | 2 | hand-rolled overflow-safe port (numba cannot compile n-ary `hypot`); deterministic per-coordinate cost, so rule 2 applies to the port |
+| [`LGAMMA`](kernel_asm/lgamma.md) | `f_add_gammabase_lgamma` − `f_add_gammabase` | 2 |  |
+| [`LOG`](kernel_asm/log.md) | `f_add_log` − `f_add` | 2 |  |
+| [`LOG10`](kernel_asm/log10.md) | `f_add_log10` − `f_add` | 2 |  |
+| [`LOG1P`](kernel_asm/log1p.md) | `f_add_log1p` − `f_add` | 2 |  |
+| [`LOG2`](kernel_asm/log2.md) | `f_add_log2` − `f_add` | 2 |  |
+| [`MINUS`](kernel_asm/minus.md) | `f_add_minus` − `f_add` | 1 |  |
+| [`MUL`](kernel_asm/mul.md) | `f_mul_mul` − `f_mul` | 1 |  |
+| [`POW`](kernel_asm/pow.md) | `f_pow_pow` − `f_pow` | 2 |  |
+| [`REMAINDER`](kernel_asm/remainder.md) | `f_add_remainder` − `f_add` | 2, 4 | numba has no `math.remainder`, so the kernel calls libm through a ctypes binding -- still the bare call CPython executes |
+| [`RND`](kernel_asm/rnd.md) | `f_add_round` − `f_add` | 1 |  |
+| [`SIN`](kernel_asm/sin.md) | `f_add_sin` − `f_add` | 2 |  |
+| [`SINH`](kernel_asm/sinh.md) | `f_add_asinh_sinh` − `f_add_asinh` | 2 |  |
+| [`SQRT`](kernel_asm/sqrt.md) | `f_add_sqrt` − `f_add` | 1 |  |
+| [`SUB`](kernel_asm/sub.md) | `f_add_sub` − `f_add` | 1 |  |
+| [`TAN`](kernel_asm/tan.md) | `f_add_tan` − `f_add` | 2 |  |
+| [`TANH`](kernel_asm/tanh.md) | `f_add_tanh` − `f_add` | 2, 4 |  |
+| `F2I` | *(no benchmark kernel — priced from spec sheets and third-party tables)* | 1 | float→int conversion instruction of the port |
+| `I2F` | *(no benchmark kernel — priced from spec sheets and third-party tables)* | 1 | int→float conversion instruction of the port |
+<!-- END generated: cost-model-flop-type-table -->
+
+## Decomposed operations
+
+Some Python operations have no `FlopType` of their own and count as a composition of the
+types above (see [FLOP types](flop_types.md#coverage-at-a-glance) for the full operation
+table). Most follow rule 1 at the operation level; the last three entries are **known
+deviations** from the rule that governs them, stated here explicitly:
+
+- `x // y` → DIV + RND, `x % y` / `divmod` → DIV + RND + MUL + SUB — the floored-division
+  sequences a port emits.
+- `math.degrees` / `math.radians` → MUL, `math.prod` → one MUL per chained multiply.
+- `math.fsum` → (n−1) ADD under rule 3: the compensation machinery is input-dependent and
+  knowingly not modeled.
+- `round(x, n)` with nonzero `n` → RND. *Known deviation from rule 1: the port price is
+  the scale/round/unscale sequence MUL + RND + DIV; the scaling is currently not counted.*
+- `math.dist` → n SUB + n MUL + (n−1) ADD + SQRT. *Known deviation from rule 2: the
+  counting uses this naive decomposition even though the `DIST`/`DIST_XARG` weights
+  measuring the real overflow-safe algorithm are already benchmarked — the two layers
+  currently disagree.*
+- `math.hypot` with 3+ arguments → n MUL + (n−1) ADD + SQRT. *Known deviation from rule 2,
+  same situation as `math.dist`: the `HYPOT`/`HYPOT_XARG` weights exist, the counting does
+  not use them yet.* (The 2-argument form counts `HYPOT` and follows rule 2.)

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -11,6 +11,9 @@ find:
 - Python operations that are counted for this flop type
 - Python operations that are *not* counted for this flop type
 
+The rules deciding *how* each type is priced (compiled-port lens, real-call lens, and the
+documented fallback) are stated in [Cost-model principles](cost_model.md).
+
 ## Coverage at a glance
 
 | Python operation | Counts as | Mechanism | Weight source | Stays `CountedFloat`? |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,70 @@
+# Glossary
+
+Terms used across the reference pages, defined once. Each entry carries a stable anchor for
+linking.
+
+## Compiled port { #compiled-port }
+
+The hypothetical result of rewriting the Python code in C and compiling it at ordinary
+optimization levels, without accuracy-trading flags (no fast-math): a program that produces
+bit-identical results, as fast as a compiler can make it without changing any of them. The
+cost model prices operator arithmetic as what this port would execute, rather than what the
+much slower Python interpreter happens to do — see
+[Cost-model principles](cost_model.md).
+
+## Constant { #constant }
+
+A value the compiled port would know at compile time — a literal, a configuration number —
+as opposed to the data the algorithm processes. In counted code the type carries the
+distinction: plain `float` operands are treated as constants, `CountedFloat` operands as
+dynamic algorithm input. Compilers treat constants specially (see
+[strength reduction](#strength-reduction)), and the pricing follows.
+
+## Dependent chain { #dependent-chain }
+
+A sequence of operations where each needs the previous one's result before it can start,
+forcing strictly sequential execution — no overlap between consecutive operations. The
+benchmarks deliberately feed every measured operation's result into the next iteration,
+so they measure [latency](#latency-vs-throughput) rather than the CPU's ability to run
+independent operations in parallel.
+
+## Fast path { #fast-path }
+
+A shortcut inside a math function for input regimes where the full computation is
+unnecessary. For any argument beyond ±20, `tanh` equals ±1 to machine precision, so the
+library returns that constant immediately. Fast paths cost far less than the general case,
+so the benchmarks pick input ranges that avoid them: a weight should price the work the
+function normally performs, not its shortcut ([cost-model rule 4](cost_model.md#the-rules)).
+
+## FP contraction { #fp-contraction }
+
+A compiler transformation fusing a multiply followed by an add (`x*y + z`) into a single
+fused multiply-add instruction. The fused form rounds once instead of twice — faster and
+marginally more accurate, but *different*: results no longer match the two separate
+operations bit for bit. Since the [compiled port](#compiled-port) must reproduce results
+exactly, it does not contract: operator arithmetic counts MUL + ADD, and only the explicit
+`math.fma(x, y, z)` counts FMA.
+
+## Latency vs. throughput { #latency-vs-throughput }
+
+Two different answers to "how fast is this operation?". *Latency* is the time from start
+until the result is ready; *throughput* is how many such operations complete per unit of
+time when the CPU can overlap independent ones — often several times more than latency
+suggests. The flop weights are **latency** weights, measured through
+[dependent chains](#dependent-chain): they describe the cost seen by an algorithm whose
+every step needs the previous step's result.
+
+## libm { #libm }
+
+The C standard math library — the routines (`sin`, `log`, `pow`, ...) shipped with every C
+toolchain, and what Python's `math` module calls under the hood. CPUs have no `sin`
+instruction; these functions are software routines built from ordinary arithmetic.
+Operations in that category are priced by benchmarking the actual libm call.
+
+## Strength reduction { #strength-reduction }
+
+A compiler transformation replacing an expensive operation with a cheaper one that yields
+the same result, enabled when part of the expression is [constant](#constant): `x ** 2`
+becomes a single multiply, `x / 2.0` becomes `x * 0.5` (exact, since `0.5` is exactly
+representable). The cost model applies it only where the replacement is bit-identical *and*
+a standard C compiler genuinely performs it ([cost-model rule 1](cost_model.md#the-rules)).

--- a/docs/kernel_asm/exp10.md
+++ b/docs/kernel_asm/exp10.md
@@ -160,8 +160,9 @@ amount of work -- see the discussion below.
 
 ## Discussion
 
-**The subtraction isolates one call to libm's `pow` with the base fixed at 10 — there is no
-`exp10` in libm, and `10 ** x` lowers to `pow(10.0, x)`.**
+**The subtraction isolates one call to libm's `pow` with the base fixed at 10 — `exp10` is
+not standard C (some libms carry it as an extension; macOS's does not), so `10 ** x` lowers
+to `pow(10.0, x)`.**
 
 1. *What the diff shows*: the additions are the `pow` call plus its argument setup — a register
    move and `fmov %d1, #10.0` materializing the constant base each iteration. Both setup

--- a/docs/kernel_asm/index.md
+++ b/docs/kernel_asm/index.md
@@ -1,4 +1,4 @@
-# Benchmark kernel machine code
+# Benchmark machine code
 
 Every benchmarked flop weight is a measured latency *difference* between two compiled kernels: a
 kernel containing the operation of interest, minus a kernel identical except for that operation.
@@ -92,4 +92,5 @@ Each page closes with a short discussion walking through what the listings show:
   discussions call this out where it happens.
 
 The listings are regenerated from the compiled kernels and committed; the prose discussions are
-written against them.
+written against them. The rules governing *what* each kernel pair measures — real call, port,
+or fallback — are stated in [Cost-model principles](../cost_model.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,7 +41,8 @@ nav:
       - Built-in data: builtin_data.md
       - Methodology: analysis_methodology.md
       - CPU architecture scope: cpu_architectures_scope.md
-      - Benchmark kernel machine code:
+      - Cost-model principles: cost_model.md
+      - Benchmark machine code:
           - Overview: kernel_asm/index.md
           - ABS: kernel_asm/abs.md
           - ACOS: kernel_asm/acos.md
@@ -87,6 +88,7 @@ nav:
           - SUB: kernel_asm/sub.md
           - TAN: kernel_asm/tan.md
           - TANH: kernel_asm/tanh.md
+      - Glossary: glossary.md
   - Changelog: changelog.md
 
 plugins:

--- a/scripts/generate_kernel_asm_docs.py
+++ b/scripts/generate_kernel_asm_docs.py
@@ -191,19 +191,28 @@ class KernelAsmPage:
         kind: The overview page's grouping bucket the flop cost belongs to.
         base_kernel: The subtracted kernel (diff "before" side).
         extended_kernel: The kernel carrying the extra operation (diff "after" side).
+        rationale: Cost-model table note for grey-zone cases -- filled only where the pricing
+            choice needs defending beyond the kind's default rule.
+        range_sensitive: True where the benchmark's input range is load-bearing for the
+            weight's validity (a why-comment in the benchmark source marks these); the
+            cost-model table then lists rule 4 alongside the kind's default rule.
     """
 
     doc_name: str
     kind: str
     base_kernel: str
     extended_kernel: str
+    rationale: str = ""
+    range_sensitive: bool = False
 
 
-# The overview page's grouping buckets, in display order.
+# The overview page's grouping buckets, in display order, and the cost-model rule each one
+# defaults to (see docs/cost_model.md for the rules' statements).
 KIND_HARDWARE = "Hardware instructions"
 KIND_LIBM = "Library calls (libm)"
 KIND_ARITY = "Arity-scaled algorithms"
 KINDS: list[str] = [KIND_HARDWARE, KIND_LIBM, KIND_ARITY]
+RULE_BY_KIND: dict[str, str] = {KIND_HARDWARE: "1", KIND_LIBM: "2", KIND_ARITY: "2"}
 
 # One page per benchmarked flop cost; the kernel pairs mirror the subtractions in
 # FlopsBenchmarkSuite.run()'s estimated_flop_latencies. COMP's true subtrahend is the average of
@@ -212,7 +221,16 @@ PAGES: list[KernelAsmPage] = [
     # --- hardware instructions -------------------
     KernelAsmPage("abs", kind=KIND_HARDWARE, base_kernel="f_add", extended_kernel="f_add_abs"),
     KernelAsmPage("add", kind=KIND_HARDWARE, base_kernel="f_add", extended_kernel="f_add_add"),
-    KernelAsmPage("comp", kind=KIND_HARDWARE, base_kernel="f_add", extended_kernel="f_lte_addsub"),
+    KernelAsmPage(
+        "comp",
+        kind=KIND_HARDWARE,
+        base_kernel="f_add",
+        extended_kernel="f_lte_addsub",
+        rationale=(
+            "the subtrahend is the ADD/SUB average, and the branchy source compiles branchless -- the weight prices "
+            "compare-and-select machinery, matching what float comparisons cost in optimized code"
+        ),
+    ),
     KernelAsmPage("copysign", kind=KIND_HARDWARE, base_kernel="f_add", extended_kernel="f_add_copysign"),
     KernelAsmPage("div", kind=KIND_HARDWARE, base_kernel="f_div", extended_kernel="f_div_div"),
     KernelAsmPage("fma", kind=KIND_HARDWARE, base_kernel="f_fma", extended_kernel="f_fma_fma"),
@@ -223,40 +241,108 @@ PAGES: list[KernelAsmPage] = [
     KernelAsmPage("sub", kind=KIND_HARDWARE, base_kernel="f_add", extended_kernel="f_add_sub"),
     # --- library calls ---------------------------
     KernelAsmPage("acos", kind=KIND_LIBM, base_kernel="f_add_sin", extended_kernel="f_add_sin_acos"),
-    KernelAsmPage("acosh", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_acosh"),
+    KernelAsmPage("acosh", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_acosh", range_sensitive=True),
     KernelAsmPage("asin", kind=KIND_LIBM, base_kernel="f_add_sin", extended_kernel="f_add_sin_asin"),
     KernelAsmPage("asinh", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_asinh"),
     KernelAsmPage("atan", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_atan"),
     KernelAsmPage("atan2", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_atan2"),
     KernelAsmPage("atanh", kind=KIND_LIBM, base_kernel="f_add_halfsin", extended_kernel="f_add_halfsin_atanh"),
-    KernelAsmPage("cbrt", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_cbrt"),
+    KernelAsmPage(
+        "cbrt",
+        kind=KIND_LIBM,
+        base_kernel="f_add",
+        extended_kernel="f_add_cbrt",
+        rationale=(
+            "a known deviation from rule 2.2: measured through numba's `np.cbrt`, whose NaN/sign handling "
+            "around the libm call is included in the weight (CPython's `math.cbrt` calls libm directly)"
+        ),
+    ),
     KernelAsmPage("cos", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_cos"),
     KernelAsmPage("cosh", kind=KIND_LIBM, base_kernel="f_add_acosh", extended_kernel="f_add_acosh_cosh"),
-    KernelAsmPage("erf", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_erf"),
-    KernelAsmPage("erfc", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_erfc"),
+    KernelAsmPage("erf", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_erf", range_sensitive=True),
+    KernelAsmPage("erfc", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_erfc", range_sensitive=True),
     KernelAsmPage("exp", kind=KIND_LIBM, base_kernel="f_add_log", extended_kernel="f_add_log_exp"),
-    KernelAsmPage("exp2", kind=KIND_LIBM, base_kernel="f_add_log2", extended_kernel="f_add_log2_exp2"),
-    KernelAsmPage("exp10", kind=KIND_LIBM, base_kernel="f_add_log10", extended_kernel="f_add_log10_exp10"),
+    KernelAsmPage(
+        "exp2",
+        kind=KIND_LIBM,
+        base_kernel="f_add_log2",
+        extended_kernel="f_add_log2_exp2",
+        rationale=(
+            "`2 ** x` strength-reduces here because a standard-C port emits C99 `exp2`; the weight is measured on the "
+            "real `exp2` call"
+        ),
+    ),
+    KernelAsmPage(
+        "exp10",
+        kind=KIND_LIBM,
+        base_kernel="f_add_log10",
+        extended_kernel="f_add_log10_exp10",
+        rationale=(
+            "`10 ** x` cannot strength-reduce to an `exp10` call -- `exp10` is not standard C -- so a port emits "
+            "`pow(10, x)`, and that is exactly what the weight measures"
+        ),
+    ),
     KernelAsmPage("expm1", kind=KIND_LIBM, base_kernel="f_add_log1p", extended_kernel="f_add_log1p_expm1"),
-    KernelAsmPage("fmod", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_fmod"),
+    KernelAsmPage("fmod", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_fmod", range_sensitive=True),
     KernelAsmPage("gamma", kind=KIND_LIBM, base_kernel="f_add_gammabase", extended_kernel="f_add_gammabase_gamma"),
-    KernelAsmPage("hypot", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_hypot"),
+    KernelAsmPage(
+        "hypot",
+        kind=KIND_LIBM,
+        base_kernel="f_add",
+        extended_kernel="f_add_hypot",
+        rationale=(
+            "the 2-argument base weight is the real libm call; the hand-rolled scaled kernels only supply the per- "
+            "extra-coordinate slope, validated against this base (within ~10%)"
+        ),
+    ),
     KernelAsmPage("lgamma", kind=KIND_LIBM, base_kernel="f_add_gammabase", extended_kernel="f_add_gammabase_lgamma"),
     KernelAsmPage("log", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_log"),
     KernelAsmPage("log1p", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_log1p"),
     KernelAsmPage("log2", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_log2"),
     KernelAsmPage("log10", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_log10"),
     KernelAsmPage("pow", kind=KIND_LIBM, base_kernel="f_pow", extended_kernel="f_pow_pow"),
-    KernelAsmPage("remainder", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_remainder"),
+    KernelAsmPage(
+        "remainder",
+        kind=KIND_LIBM,
+        base_kernel="f_add",
+        extended_kernel="f_add_remainder",
+        rationale=(
+            "numba has no `math.remainder`, so the kernel calls libm through a ctypes binding -- still the bare call "
+            "CPython executes"
+        ),
+        range_sensitive=True,
+    ),
     KernelAsmPage("sin", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_sin"),
     KernelAsmPage("sinh", kind=KIND_LIBM, base_kernel="f_add_asinh", extended_kernel="f_add_asinh_sinh"),
     KernelAsmPage("tan", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_tan"),
-    KernelAsmPage("tanh", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_tanh"),
+    KernelAsmPage("tanh", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_tanh", range_sensitive=True),
     # --- arity-scaled algorithms -----------------
-    KernelAsmPage("dist", kind=KIND_ARITY, base_kernel="f_add", extended_kernel="f_add_dist2"),
-    KernelAsmPage("dist_xarg", kind=KIND_ARITY, base_kernel="f_add_dist2", extended_kernel="f_add_dist8"),
     KernelAsmPage(
-        "hypot_xarg", kind=KIND_ARITY, base_kernel="f_add_hypot_scaled2", extended_kernel="f_add_hypot_scaled8"
+        "dist",
+        kind=KIND_ARITY,
+        base_kernel="f_add",
+        extended_kernel="f_add_dist2",
+        rationale=(
+            "hand-rolled overflow-safe port (no libm `dist` exists); prices the scaled algorithm `math.dist` executes, "
+            "not a naive sum of squares"
+        ),
+    ),
+    KernelAsmPage(
+        "dist_xarg",
+        kind=KIND_ARITY,
+        base_kernel="f_add_dist2",
+        extended_kernel="f_add_dist8",
+        rationale="per-extra-coordinate slope of the same overflow-safe port as `DIST`",
+    ),
+    KernelAsmPage(
+        "hypot_xarg",
+        kind=KIND_ARITY,
+        base_kernel="f_add_hypot_scaled2",
+        extended_kernel="f_add_hypot_scaled8",
+        rationale=(
+            "hand-rolled overflow-safe port (numba cannot compile n-ary `hypot`); deterministic per-coordinate cost, "
+            "so rule 2 applies to the port"
+        ),
     ),
 ]
 
@@ -330,6 +416,32 @@ def render_page_list_block() -> str:
     return "\n".join(lines).rstrip()
 
 
+def render_cost_model_table() -> str:
+    """The per-FlopType pricing table on the cost-model page, derived from the page registry.
+
+    F2I and I2F close the table as static rows: they are the only FlopTypes without a benchmark
+    kernel (spec-sheet and third-party sources price them), so the registry cannot supply them.
+    """
+    rows = [
+        "| Flop type | Weight measured as | Rule | Notes |",
+        "|---|---|---|---|",
+    ]
+    for page in sorted(PAGES, key=lambda entry: entry.doc_name):
+        name_cell = f"[`{page.doc_name.upper()}`](kernel_asm/{page.doc_name}.md)"
+        measured_cell = f"`{page.extended_kernel}` − `{page.base_kernel}`"
+        rule_cell = RULE_BY_KIND[page.kind] + (", 4" if page.range_sensitive else "")
+        rows.append(f"| {name_cell} | {measured_cell} | {rule_cell} | {page.rationale} |")
+    rows.append(
+        "| `F2I` | *(no benchmark kernel — priced from spec sheets and third-party tables)* | 1 | "
+        "float→int conversion instruction of the port |"
+    )
+    rows.append(
+        "| `I2F` | *(no benchmark kernel — priced from spec sheets and third-party tables)* | 1 | "
+        "int→float conversion instruction of the port |"
+    )
+    return "\n".join(rows)
+
+
 def regenerate_pages() -> dict[Path, str]:
     """Regenerate every page's marked blocks; returns the intended full content per page file."""
     kernel_cache: dict[str, CompiledKernel] = {}
@@ -355,6 +467,10 @@ def regenerate_pages() -> dict[Path, str]:
     index_path = KERNEL_ASM_DOCS_DIR / "index.md"
     regenerated[index_path] = rewrite_marked_blocks(
         _read_lf(index_path), index_path, {"kernel-asm-page-list": render_page_list_block()}
+    )
+    cost_model_path = REPO_ROOT / "docs" / "cost_model.md"
+    regenerated[cost_model_path] = rewrite_marked_blocks(
+        _read_lf(cost_model_path), cost_model_path, {"cost-model-flop-type-table": render_cost_model_table()}
     )
     return regenerated
 

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -567,11 +567,12 @@ def math_prod(iterable: Iterable[float], /, *, start: float = 1) -> float | Coun
 def math_fsum(seq: Iterable[float]) -> float | CountedFloat:
     """Patch math.fsum: stdlib contract (Shewchuk exact summation), counted as (n-1) ADD.
 
-    Counts the mathematical reduction, knowingly under-counting fsum's compensation machinery
-    (a semantics-preserving compiled port would emit compensated summation at ~3-4 flops per
-    element). The compensation multiplier would be a speculative constant; a prototype that
-    wants compensation costed can write Kahan out in operators and have it counted exactly.
-    The value is computed by the original, so fsum's exactness is untouched.
+    Counts the mathematical reduction, knowingly under-counting fsum's compensation machinery:
+    the exact-summation partials grow and shrink with the data, so the real cost has no per-call
+    constant to price -- the input-dependent-cost fallback in the cost-model docs
+    (docs/cost_model.md). A prototype that wants compensation costed can write Kahan out in
+    operators and have it counted exactly. The value is computed by the original, so fsum's
+    exactness is untouched.
     """
     values = list(seq)
     result = original_math_fsum(values)


### PR DESCRIPTION
New `Reference → Cost-model principles` page making the pricing philosophy explicit and auditable:

- **Four spec-style rules**, each a concise statement plus numbered qualified bullets (scope / definition / consequence / example / nuance): instruction-only operations priced as a value-preserving compiled port; library calls priced as their real algorithm, contract included; input-dependent-cost operations priced as their deterministic core with the gap stated; benchmark inputs drawn from general-case ranges.
- **A per-FlopType table** (generated from the machine-code page registry, drift-tested like everything else): kernel pair, governing rule, rule-4 marker where the input range is load-bearing, and rationale on grey-zone rows.
- **Every known deviation between model and current behavior named in place**, present tense: division's exact reciprocal fold, `round(x, n)`'s uncounted scaling, `math.dist` / n-ary `math.hypot` still counting naive decompositions despite benchmarked arity weights, CBRT measured through numba's np.cbrt wrapper.

Supporting changes: a glossary (8 entries, stable anchors), Reference nav reordered with the machine-code group renamed to "Benchmark machine code", the methodology's rationale section shrunk to a pointer, cross-links from flop_types / the machine-code overview / the fsum docstring, and a corrected EXP10 claim (`exp10` is not standard C, rather than absent from every libm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)