### PR TITLE
feat: benchmark and counting consistency fixes from the cost-model audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - flop-weight JSON files now key on stable identifiers instead of display labels; an unrecognized key now raises instead of silently degrading to a missing weight. Pre-2.0.0 label-keyed files (including your own saved benchmark results) no longer load and must be regenerated
 - flop counting state is now per-thread: contexts measure only the thread that opened them, and pausing affects the calling thread only
+- the CBRT weight now measures the bare libm call, no longer including numba-specific argument handling
+- `round(x, n)` with a nonzero digit count now counts MUL + RND + DIV (scale, round, unscale) instead of a single RND
+- dividing by a power-of-two constant now counts MUL instead of DIV, matching the exact reciprocal multiplication a compiler emits; dividing by 1.0 now counts nothing, as the division folds away entirely
+- the sin/cos/tan and asinh/acosh benchmarks now draw their inputs from general-case argument ranges, instead of extreme magnitudes that priced a costlier (trig) or cheaper (inverse-hyperbolic) special regime
 
 ### Deprecated
 

--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -31,9 +31,9 @@ as a value-preserving [compiled port](glossary.md#compiled-port).**
   `10 ** x` → `pow(10, x)`, since `exp10` is not standard C.
 - **1.6** *(example)* — reciprocal multiplication for division only where it is exact: a
   power-of-two constant divisor with a finite reciprocal — there, and only there,
-  `x * (1/c)` is bit-identical to `x / c`, and compilers apply the fold at plain `-O2`.
-  *Known deviation: counted-float currently prices every division as DIV, this fold
-  included.*
+  `x * (1/c)` is bit-identical to `x / c`, and compilers apply the fold at plain `-O2` —
+  so `x / c` counts MUL for exactly those divisors, and DIV for every other. The one
+  stronger fold: `x / 1.0` disappears entirely and counts nothing, like `x ** 1`.
 
 **Rule 2 — operations that compile to a library call are priced as the call's real
 algorithm, contract included.**
@@ -85,15 +85,15 @@ rule that governs it, and — for grey-zone cases — why the choice is what it 
 | [`ACOSH`](kernel_asm/acosh.md) | `f_add_acosh` − `f_add` | 2, 4 |  |
 | [`ADD`](kernel_asm/add.md) | `f_add_add` − `f_add` | 1 |  |
 | [`ASIN`](kernel_asm/asin.md) | `f_add_sin_asin` − `f_add_sin` | 2 |  |
-| [`ASINH`](kernel_asm/asinh.md) | `f_add_asinh` − `f_add` | 2 |  |
-| [`ATAN`](kernel_asm/atan.md) | `f_add_atan` − `f_add` | 2 |  |
-| [`ATAN2`](kernel_asm/atan2.md) | `f_add_atan2` − `f_add` | 2 |  |
+| [`ASINH`](kernel_asm/asinh.md) | `f_add_asinh` − `f_add` | 2, 4 |  |
+| [`ATAN`](kernel_asm/atan.md) | `f_add_atan` − `f_add` | 2, 4 |  |
+| [`ATAN2`](kernel_asm/atan2.md) | `f_add_atan2` − `f_add` | 2, 4 |  |
 | [`ATANH`](kernel_asm/atanh.md) | `f_add_halfsin_atanh` − `f_add_halfsin` | 2 |  |
-| [`CBRT`](kernel_asm/cbrt.md) | `f_add_cbrt` − `f_add` | 2 | a known deviation from rule 2.2: measured through numba's `np.cbrt`, whose NaN/sign handling around the libm call is included in the weight (CPython's `math.cbrt` calls libm directly) |
+| [`CBRT`](kernel_asm/cbrt.md) | `f_add_cbrt` − `f_add` | 2 | numba's `np.cbrt` wraps the libm call in NaN/sign handling CPython's `math.cbrt` never executes, so the kernel calls libm through a ctypes binding -- the bare call CPython executes |
 | [`COMP`](kernel_asm/comp.md) | `f_lte_addsub` − `f_add` | 1 | the subtrahend is the ADD/SUB average, and the branchy source compiles branchless -- the weight prices compare-and-select machinery, matching what float comparisons cost in optimized code |
 | [`COPYSIGN`](kernel_asm/copysign.md) | `f_add_copysign` − `f_add` | 1 |  |
-| [`COS`](kernel_asm/cos.md) | `f_add_cos` − `f_add` | 2 |  |
-| [`COSH`](kernel_asm/cosh.md) | `f_add_acosh_cosh` − `f_add_acosh` | 2 |  |
+| [`COS`](kernel_asm/cos.md) | `f_add_cos` − `f_add` | 2, 4 |  |
+| [`COSH`](kernel_asm/cosh.md) | `f_add_acosh_cosh` − `f_add_acosh` | 2, 4 |  |
 | [`DIST`](kernel_asm/dist.md) | `f_add_dist2` − `f_add` | 2 | hand-rolled overflow-safe port (no libm `dist` exists); prices the scaled algorithm `math.dist` executes, not a naive sum of squares |
 | [`DIST_XARG`](kernel_asm/dist_xarg.md) | `f_add_dist8` − `f_add_dist2` | 2 | per-extra-coordinate slope of the same overflow-safe port as `DIST` |
 | [`DIV`](kernel_asm/div.md) | `f_div_div` − `f_div` | 1 |  |
@@ -118,11 +118,11 @@ rule that governs it, and — for grey-zone cases — why the choice is what it 
 | [`POW`](kernel_asm/pow.md) | `f_pow_pow` − `f_pow` | 2 |  |
 | [`REMAINDER`](kernel_asm/remainder.md) | `f_add_remainder` − `f_add` | 2, 4 | numba has no `math.remainder`, so the kernel calls libm through a ctypes binding -- still the bare call CPython executes |
 | [`RND`](kernel_asm/rnd.md) | `f_add_round` − `f_add` | 1 |  |
-| [`SIN`](kernel_asm/sin.md) | `f_add_sin` − `f_add` | 2 |  |
-| [`SINH`](kernel_asm/sinh.md) | `f_add_asinh_sinh` − `f_add_asinh` | 2 |  |
+| [`SIN`](kernel_asm/sin.md) | `f_add_sin` − `f_add` | 2, 4 |  |
+| [`SINH`](kernel_asm/sinh.md) | `f_add_asinh_sinh` − `f_add_asinh` | 2, 4 |  |
 | [`SQRT`](kernel_asm/sqrt.md) | `f_add_sqrt` − `f_add` | 1 |  |
 | [`SUB`](kernel_asm/sub.md) | `f_add_sub` − `f_add` | 1 |  |
-| [`TAN`](kernel_asm/tan.md) | `f_add_tan` − `f_add` | 2 |  |
+| [`TAN`](kernel_asm/tan.md) | `f_add_tan` − `f_add` | 2, 4 |  |
 | [`TANH`](kernel_asm/tanh.md) | `f_add_tanh` − `f_add` | 2, 4 |  |
 | `F2I` | *(no benchmark kernel — priced from spec sheets and third-party tables)* | 1 | float→int conversion instruction of the port |
 | `I2F` | *(no benchmark kernel — priced from spec sheets and third-party tables)* | 1 | int→float conversion instruction of the port |
@@ -132,16 +132,19 @@ rule that governs it, and — for grey-zone cases — why the choice is what it 
 
 Some Python operations have no `FlopType` of their own and count as a composition of the
 types above (see [FLOP types](flop_types.md#coverage-at-a-glance) for the full operation
-table). Most follow rule 1 at the operation level; the last three entries are **known
+table). Most follow rule 1 at the operation level; the last two entries are **known
 deviations** from the rule that governs them, stated here explicitly:
 
 - `x // y` → DIV + RND, `x % y` / `divmod` → DIV + RND + MUL + SUB — the floored-division
   sequences a port emits.
+- `round(x, n)` with nonzero `n` → MUL + RND + DIV — scale into the digit position, round,
+  scale back (the unscale is a true divide: the power-of-ten scale factor has no exact
+  reciprocal, so rule 1.6's fold does not apply). Stated gap under rule 3: CPython itself
+  computes this via correctly-rounded decimal conversion, whose input-dependent machinery
+  is knowingly not modeled.
 - `math.degrees` / `math.radians` → MUL, `math.prod` → one MUL per chained multiply.
 - `math.fsum` → (n−1) ADD under rule 3: the compensation machinery is input-dependent and
   knowingly not modeled.
-- `round(x, n)` with nonzero `n` → RND. *Known deviation from rule 1: the port price is
-  the scale/round/unscale sequence MUL + RND + DIV; the scaling is currently not counted.*
 - `math.dist` → n SUB + n MUL + (n−1) ADD + SQRT. *Known deviation from rule 2: the
   counting uses this naive decomposition even though the `DIST`/`DIST_XARG` weights
   measuring the real overflow-safe algorithm are already benchmarked — the two layers

--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -89,7 +89,7 @@ rule that governs it, and — for grey-zone cases — why the choice is what it 
 | [`ATAN`](kernel_asm/atan.md) | `f_add_atan` − `f_add` | 2, 4 |  |
 | [`ATAN2`](kernel_asm/atan2.md) | `f_add_atan2` − `f_add` | 2, 4 |  |
 | [`ATANH`](kernel_asm/atanh.md) | `f_add_halfsin_atanh` − `f_add_halfsin` | 2 |  |
-| [`CBRT`](kernel_asm/cbrt.md) | `f_add_cbrt` − `f_add` | 2 | numba's `np.cbrt` wraps the libm call in NaN/sign handling CPython's `math.cbrt` never executes, so the kernel calls libm through a ctypes binding -- the bare call CPython executes |
+| [`CBRT`](kernel_asm/cbrt.md) | `f_add_cbrt` − `f_add` | 2 | numba's `np.cbrt` wraps the libm call in NaN/sign handling CPython's `math.cbrt` never executes, so the probe calls libm through a ctypes binding -- the bare call CPython executes |
 | [`COMP`](kernel_asm/comp.md) | `f_lte_addsub` − `f_add` | 1 | the subtrahend is the ADD/SUB average, and the branchy source compiles branchless -- the weight prices compare-and-select machinery, matching what float comparisons cost in optimized code |
 | [`COPYSIGN`](kernel_asm/copysign.md) | `f_add_copysign` − `f_add` | 1 |  |
 | [`COS`](kernel_asm/cos.md) | `f_add_cos` − `f_add` | 2, 4 |  |

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -72,6 +72,8 @@ patched `math` functions:
    | `x ** 2` (or `2.0`) | MUL |
    | `x ** n`, integer 2 ≤ \|n\| ≤ 16 | square-and-multiply MULs (`x**3` → 2 MUL, `x**8` → 3 MUL); negative `n` adds one DIV |
    | `x ** -1` | DIV (reciprocal) |
+   | `x / 1.0` | nothing (folds away; result stays `CountedFloat`) |
+   | `x / c`, power-of-two `c` | MUL — `x * (1/c)` is bit-identical exactly there, so a compiler folds it; any other constant divisor stays DIV |
    | `x ** 0.5` / `x ** -0.5` | SQRT / SQRT + DIV |
    | `x ** 0`, `x ** 1` | nothing (folds away; result stays `CountedFloat`) |
    | `x ** c`, other values | POW |

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -18,7 +18,8 @@ documented fallback) are stated in [Cost-model principles](cost_model.md).
 
 | Python operation | Counts as | Mechanism | Weight source | Stays `CountedFloat`? |
 |---|---|---|---|---|
-| `x + y`, `x - y`, `x * y`, `x / y` | `ADD`, `SUB`, `MUL`, `DIV` | operator | ISA | yes |
+| `x + y`, `x - y`, `x * y` | `ADD`, `SUB`, `MUL` | operator | ISA | yes |
+| `x / y` | `DIV` (`MUL` for a power-of-two constant divisor — the exact reciprocal fold; nothing for `x / 1.0`) | operator | ISA | yes |
 | `x // y` | `DIV + RND` | operator (decomposed) | ISA | yes |
 | `x % y` | `DIV + RND + MUL + SUB` | operator (decomposed) | ISA | yes |
 | `divmod(x, y)` | `DIV + RND + MUL + SUB` | operator (decomposed) | ISA | yes (both) |
@@ -26,7 +27,8 @@ documented fallback) are stated in [Cost-model principles](cost_model.md).
 | `+x` | *(nothing)* | operator | — | yes |
 | `abs(x)`, `math.fabs(x)` | `ABS` | operator / patch | ISA | yes |
 | `x == y`, `x < y`, …, `min`, `max` | `COMP` | operator | ISA | returns `bool` |
-| `round(x, n)` | `RND` | operator | ISA | yes (float) |
+| `round(x, 0)` | `RND` | operator | ISA | yes (float) |
+| `round(x, n)`, `n != 0` | `MUL + RND + DIV` | operator (decomposed) | ISA | yes (float) |
 | `round(x)`, `int(x)`, `math.floor`/`ceil`/`trunc` | `F2I` | operator | ISA | returns `int` |
 | `CountedFloat(int)` | `I2F` | constructor | ISA | yes |
 | `x ** y`, `math.pow(x, y)` | `POW` (or cheaper via constant strength reduction — MULs, SQRT, DIV, EXP2, EXP10) | operator / patch | benchmarked | yes |
@@ -69,6 +71,15 @@ float→float round (`RND`), not an `F2I`:
 - `x % y` → `DIV + RND + MUL + SUB` — the floored remainder `r = x − y·⌊x/y⌋`.
 - `divmod(x, y)` → `DIV + RND + MUL + SUB` — quotient and remainder share the
   `DIV + RND`, so it costs the same as a lone `%`.
+
+`round(x, n)` with a nonzero digit count decomposes the same way:
+
+- `round(x, n)`, `n != 0` → `MUL + RND + DIV` — scale into the digit position,
+  round, scale back. The unscale is a true divide (the scale factor is a power
+  of ten, whose reciprocal is not exact). Stated gap: CPython itself computes
+  this via correctly-rounded decimal conversion, whose input-dependent cost the
+  port price knowingly omits. `round(x, 0)` needs no scaling and counts a lone
+  `RND`.
 
 Note the `%` operator (floored) is distinct from `math.fmod` (the truncated C
 remainder, which has its own `FlopType.FMOD`). `math.log(x, base)` also
@@ -122,9 +133,10 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
 - Relevant CPU instructions
     - **ARM:** `FRINT`
     - **x86:** `ROUNDSD`
-- **Counted Python operations:** `round(x, n)` with explicit `n` — including
-  rounding to decimals, e.g. `round(x, 2)` — for `CountedFloat` (returns
-  float)
+- **Counted Python operations:** `round(x, 0)` for `CountedFloat` (returns
+  float), plus the round step inside the decomposed operations — `round(x, n)`
+  with nonzero `n` (`MUL + RND + DIV`) and the floor of `x // y` / `x % y` /
+  `divmod`
 - **Not counted:** `numpy.round`, rounding on non-CountedFloat
 - **Weight measurement:** [the machine code behind the `RND` weight](kernel_asm/rnd.md)
 
@@ -182,7 +194,11 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
 - Relevant CPU instructions
     - **ARM:** `FDIV`
     - **x86:** `DIVSD`
-- **Counted Python operations:** `x / y` or `y / x` for `CountedFloat`
+- **Counted Python operations:** `x / y` or `y / x` for `CountedFloat` —
+  except division by a power-of-two constant divisor with a finite reciprocal,
+  which counts `MUL`: for exactly those divisors `x * (1/c)` is bit-identical
+  to `x / c`, so a compiled port applies the reciprocal fold. `x / 1.0` counts
+  nothing at all (it folds away entirely, mirroring `x ** 1`)
 - **Not counted:** Division on non-CountedFloat, numpy division
 - **Weight measurement:** [the machine code behind the `DIV` weight](kernel_asm/div.md)
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -3,6 +3,14 @@
 Terms used across the reference pages, defined once. Each entry carries a stable anchor for
 linking.
 
+## Benchmark probe { #benchmark-probe }
+
+One of the small numba-compiled functions the flops benchmark times: a doubly-nested loop
+feeding one combination of operations through a [dependent chain](#dependent-chain). Each
+flop weight is the latency difference between two probes that differ by exactly the
+operation being priced. (GPU and HPC literature would call these compute kernels; *probe*
+avoids the collision with the operating-system sense of the word.)
+
 ## Compiled port { #compiled-port }
 
 The hypothetical result of rewriting the Python code in C and compiling it at ordinary

--- a/docs/kernel_asm/acosh.md
+++ b/docs/kernel_asm/acosh.md
@@ -2,7 +2,7 @@
 
 The `ACOSH` cost is the latency difference between a kernel chaining `math.acosh(tmp + x[i])` and
 one chaining only `tmp + x[i]` — kernels `f_add_acosh` and `f_add`. Like most libm-backed functions,
-`math.acosh` compiles to a call into the math library. The kernel's positive input range keeps the argument at or above 1, inside `acosh`'s domain, and its moderate magnitude keeps the measurement out of the cheaper asymptotic large-argument regime.
+`math.acosh` compiles to a call into the math library. The probe's positive input range keeps the argument at or above 1, inside `acosh`'s domain, and its moderate magnitude keeps the measurement out of the cheaper asymptotic large-argument regime.
 
 What Python code counts into `ACOSH` is described in
 [FLOP types](../flop_types.md#flop-acosh).

--- a/docs/kernel_asm/acosh.md
+++ b/docs/kernel_asm/acosh.md
@@ -2,7 +2,7 @@
 
 The `ACOSH` cost is the latency difference between a kernel chaining `math.acosh(tmp + x[i])` and
 one chaining only `tmp + x[i]` — kernels `f_add_acosh` and `f_add`. Like most libm-backed functions,
-`math.acosh` compiles to a call into the math library. The kernel's large positive input range keeps the argument at or above 1, inside `acosh`'s domain.
+`math.acosh` compiles to a call into the math library. The kernel's positive input range keeps the argument at or above 1, inside `acosh`'s domain, and its moderate magnitude keeps the measurement out of the cheaper asymptotic large-argument regime.
 
 What Python code counts into `ACOSH` is described in
 [FLOP types](../flop_types.md#flop-acosh).

--- a/docs/kernel_asm/asinh.md
+++ b/docs/kernel_asm/asinh.md
@@ -2,7 +2,7 @@
 
 The `ASINH` cost is the latency difference between a kernel chaining `math.asinh(tmp + x[i])` and
 one chaining only `tmp + x[i]` — kernels `f_add_asinh` and `f_add`. Like most libm-backed functions,
-`math.asinh` compiles to a call into the math library.
+`math.asinh` compiles to a call into the math library. The kernel's moderate input range targets the general-case cost -- huge arguments would land in `asinh`'s cheaper asymptotic `log`-shortcut regime.
 
 What Python code counts into `ASINH` is described in
 [FLOP types](../flop_types.md#flop-asinh).

--- a/docs/kernel_asm/asinh.md
+++ b/docs/kernel_asm/asinh.md
@@ -2,7 +2,7 @@
 
 The `ASINH` cost is the latency difference between a kernel chaining `math.asinh(tmp + x[i])` and
 one chaining only `tmp + x[i]` — kernels `f_add_asinh` and `f_add`. Like most libm-backed functions,
-`math.asinh` compiles to a call into the math library. The kernel's moderate input range targets the general-case cost -- huge arguments would land in `asinh`'s cheaper asymptotic `log`-shortcut regime.
+`math.asinh` compiles to a call into the math library. The probe's moderate input range targets the general-case cost -- huge arguments would land in `asinh`'s cheaper asymptotic `log`-shortcut regime.
 
 What Python code counts into `ASINH` is described in
 [FLOP types](../flop_types.md#flop-asinh).

--- a/docs/kernel_asm/atan.md
+++ b/docs/kernel_asm/atan.md
@@ -2,7 +2,7 @@
 
 The `ATAN` cost is the latency difference between a kernel chaining `math.atan(tmp + x[i])` and
 one chaining only `tmp + x[i]` — kernels `f_add_atan` and `f_add`. Like most libm-backed functions,
-`math.atan` compiles to a call into the math library.
+`math.atan` compiles to a call into the math library. The kernel's input range keeps most magnitudes above 1, where `atan` takes its reciprocal branch -- the cost is flat from there through huge arguments, while sub-1 arguments would underprice the call.
 
 What Python code counts into `ATAN` is described in
 [FLOP types](../flop_types.md#flop-atan).

--- a/docs/kernel_asm/atan.md
+++ b/docs/kernel_asm/atan.md
@@ -2,7 +2,7 @@
 
 The `ATAN` cost is the latency difference between a kernel chaining `math.atan(tmp + x[i])` and
 one chaining only `tmp + x[i]` — kernels `f_add_atan` and `f_add`. Like most libm-backed functions,
-`math.atan` compiles to a call into the math library. The kernel's input range keeps most magnitudes above 1, where `atan` takes its reciprocal branch -- the cost is flat from there through huge arguments, while sub-1 arguments would underprice the call.
+`math.atan` compiles to a call into the math library. The probe's input range keeps most magnitudes above 1, where `atan` takes its reciprocal branch -- the cost is flat from there through huge arguments, while sub-1 arguments would underprice the call.
 
 What Python code counts into `ATAN` is described in
 [FLOP types](../flop_types.md#flop-atan).

--- a/docs/kernel_asm/atan2.md
+++ b/docs/kernel_asm/atan2.md
@@ -2,7 +2,7 @@
 
 The `ATAN2` cost is the latency difference between a kernel chaining
 `atan2(tmp + x[i], x[i])` and one chaining only `tmp + x[i]` — kernels `f_add_atan2` and
-`f_add`. A libm call with two arguments: the chained value and the freshly loaded element. The kernel's input range keeps most magnitudes above 1, matching `atan`'s general-case regime; the cost is flat from there through huge arguments.
+`f_add`. A libm call with two arguments: the chained value and the freshly loaded element. The probe's input range keeps most magnitudes above 1, matching `atan`'s general-case regime; the cost is flat from there through huge arguments.
 
 What Python code counts into `ATAN2` is described in
 [FLOP types](../flop_types.md#flop-atan2).

--- a/docs/kernel_asm/atan2.md
+++ b/docs/kernel_asm/atan2.md
@@ -2,7 +2,7 @@
 
 The `ATAN2` cost is the latency difference between a kernel chaining
 `atan2(tmp + x[i], x[i])` and one chaining only `tmp + x[i]` — kernels `f_add_atan2` and
-`f_add`. A libm call with two arguments: the chained value and the freshly loaded element.
+`f_add`. A libm call with two arguments: the chained value and the freshly loaded element. The kernel's input range keeps most magnitudes above 1, matching `atan`'s general-case regime; the cost is flat from there through huge arguments.
 
 What Python code counts into `ATAN2` is described in
 [FLOP types](../flop_types.md#flop-atan2).

--- a/docs/kernel_asm/cbrt.md
+++ b/docs/kernel_asm/cbrt.md
@@ -1,11 +1,11 @@
 # CBRT
 
-The `CBRT` cost is the latency difference between a kernel chaining `cbrt(tmp + x[i])` and
-one chaining only `tmp + x[i]` — kernels `f_add_cbrt` and `f_add`. A libm call with one
+The `CBRT` cost is the latency difference between a probe chaining `cbrt(tmp + x[i])` and
+one chaining only `tmp + x[i]` — probes `f_add_cbrt` and `f_add`. A libm call with one
 wrinkle: numba's own route (`np.cbrt`) wraps the libm call in a NaN check and
-negative-argument handling that CPython's `math.cbrt` never executes, so the kernel calls
+negative-argument handling that CPython's `math.cbrt` never executes, so the probe calls
 libm's `cbrt` through a ctypes binding instead — the bare call CPython executes, compiling to
-the same indirect-call loop shape as the [REMAINDER](remainder.md) kernel.
+the same indirect-call loop shape as the [REMAINDER](remainder.md) probe.
 
 What Python code counts into `CBRT` is described in
 [FLOP types](../flop_types.md#flop-cbrt).
@@ -200,11 +200,11 @@ amount of work -- see the discussion below.
 
 1. *Intended call, and nothing else*: the structural additions are the `blr` — the `cbrt`
    call — plus one integer load per iteration re-fetching the call-target pointer from the
-   ctypes closure (the libm kernels numba compiles directly keep their target in a register;
+   ctypes closure (the libm probes numba compiles directly keep their target in a register;
    the ctypes route reloads it). That load is a stride-0 L1 hit on the integer side. The
    remaining `-`/`+` pairs are the canonical-index shift described on the
    [index page](index.md). No NaN check and no sign branches: numba's `np.cbrt` would add
-   those around the call, which is exactly why the kernel binds libm directly — CPython's
+   those around the call, which is exactly why the probe binds libm directly — CPython's
    `math.cbrt` executes the bare call.
 2. *In the dependency chain*: the accumulator flows through the call — `fadd` produces the
    argument, the call returns the result the next iteration's `fadd` consumes. The pointer

--- a/docs/kernel_asm/cbrt.md
+++ b/docs/kernel_asm/cbrt.md
@@ -1,9 +1,11 @@
 # CBRT
 
-The `CBRT` cost is the latency difference between a kernel chaining `np.cbrt(tmp + x[i])` and
-one chaining only `tmp + x[i]` — kernels `f_add_cbrt` and `f_add`. A libm call — with extra
-handling: numba implements `np.cbrt` with its own NaN check and negative-argument handling
-around the `cbrt` call, and that wrapper code is part of what the weight measures.
+The `CBRT` cost is the latency difference between a kernel chaining `cbrt(tmp + x[i])` and
+one chaining only `tmp + x[i]` — kernels `f_add_cbrt` and `f_add`. A libm call with one
+wrinkle: numba's own route (`np.cbrt`) wraps the libm call in a NaN check and
+negative-argument handling that CPython's `math.cbrt` never executes, so the kernel calls
+libm's `cbrt` through a ctypes binding instead — the bare call CPython executes, compiling to
+the same indirect-call loop shape as the [REMAINDER](remainder.md) kernel.
 
 What Python code counts into `CBRT` is described in
 [FLOP types](../flop_types.md#flop-cbrt).
@@ -16,35 +18,15 @@ What Python code counts into `CBRT` is described in
 +++ f_add_cbrt
   .L0:
 - ldr  %d0, [%x0], #8
-- fadd  %d1, %d1, %d0
++ ldr  %x0, [%x1]
++ ldr  %d0, [%x2], #8
+  fadd  %d1, %d1, %d0
 - str  %d1, [%x1], #8
 - subs  %x2, %x2, #1
-- b.ne  .L0
-+ subs  %x0, %x0, #1
-+ b.le  .L1
-+ .L2:
-+ mov  %x1, %x2
-+ mov  %x3, %x4
-+ mov  %x5, %x6
-+ mov.16b  %v0, %v1
-+ b  .L3
-+ .L4:
-+ blr  %x7
-+ .L5:
-+ str  %d0, [%x5], #8
-+ subs  %x1, %x1, #1
-+ b.eq  .L0
-+ .L3:
-+ ldr  %d2, [%x3], #8
-+ fadd  %d0, %d0, %d2
-+ fcmp  %d0, %d0
-+ b.vs  .L6
-+ fcmp  %d0, #0.0
-+ b.ge  .L4
-+ fneg  %d0, %d0
-+ blr  %x7
-+ fneg  %d0, %d0
-+ b  .L5
++ blr  %x0
++ str  %d1, [%x3], #8
++ subs  %x4, %x4, #1
+  b.ne  .L0
 ```
 <!-- END generated: kernel-asm-cbrt-diff -->
 
@@ -52,7 +34,7 @@ What Python code counts into `CBRT` is described in
 
 <!-- BEGIN generated: kernel-asm-cbrt-structure -->
 - `f_add` -- 2 innermost loop(s): 30 instructions, 6 instructions
-- `f_add_cbrt` -- 1 innermost loop(s): 26 instructions
+- `f_add_cbrt` -- 1 innermost loop(s): 8 instructions
 
 The listings below are the complete compiled functions the benchmark times, raw as numba
 emits them (the cpython call wrappers around them are omitted -- they never run inside the
@@ -165,10 +147,10 @@ amount of work -- see the discussion below.
       .cfi_offset b9, -112
       mov  x19, x0
       cmp  x2, #1
-      b.lt  LBB0_11
+      b.lt  LBB0_6
       mov  x20, x3
       cmp  x3, #1
-      b.lt  LBB0_11
+      b.lt  LBB0_6
       mov  x21, x2
       ldr  x22, [sp, #168]
       ldr  x23, [sp, #112]
@@ -178,41 +160,25 @@ amount of work -- see the discussion below.
       movk  x8, #16389, lsl #48
       fmov  d8, x8
     Lloh0:
-      adrp  x24, _cbrt@GOTPAGE
+      adrp  x24, _numba.dynamic.globals.<addr>@GOTPAGE
     Lloh1:
-      ldr  x24, [x24, _cbrt@GOTPAGEOFF]
-      b  LBB0_4
+      ldr  x24, [x24, _numba.dynamic.globals.<addr>@GOTPAGEOFF]
     LBB0_3:
-      subs  x21, x21, #1
-      b.le  LBB0_11
-    LBB0_4:
       mov  x25, x20
       mov  x26, x23
       mov  x27, x22
       mov.16b  v0, v8
-      b  LBB0_7
-    LBB0_5:
-      blr  x24
-    LBB0_6:
-      str  d0, [x27], #8
-      subs  x25, x25, #1
-      b.eq  LBB0_3
-    LBB0_7:
+    LBB0_4:
+      ldr  x8, [x24]
       ldr  d1, [x26], #8
       fadd  d0, d0, d1
-      fcmp  d0, d0
-      b.vs  LBB0_10
-      fcmp  d0, #0.0
-      b.ge  LBB0_5
-      fneg  d0, d0
-      blr  x24
-      fneg  d0, d0
-      b  LBB0_6
-    LBB0_10:
-      mov  x8, #9221120237041090560
-      fmov  d0, x8
-      b  LBB0_6
-    LBB0_11:
+      blr  x8
+      str  d0, [x27], #8
+      subs  x25, x25, #1
+      b.ne  LBB0_4
+      subs  x21, x21, #1
+      b.gt  LBB0_3
+    LBB0_6:
       str  xzr, [x19]
       mov  w0, #0
       ldp  x29, x30, [sp, #96]
@@ -230,18 +196,20 @@ amount of work -- see the discussion below.
 
 ## Discussion
 
-**The subtraction isolates one `cbrt` call plus numba's NaN/sign wrapper around it.**
+**The subtraction isolates exactly one call to libm's `cbrt`.**
 
-1. *What the diff shows*: the loop compiled to a *rotated* form — its cycle closes through
-   forward branches and fallthrough rather than one backward branch, so it appears as a single
-   merged region and the diff aligns almost nothing with `f_add`. Reading the `+` side as a
-   whole: load and `fadd` as usual, then a NaN check (`fcmp %d0, %d0` + `b.vs`), then either a
-   direct `cbrt` call for non-negative arguments or a `fneg` → `cbrt` → `fneg` sequence for
-   negative ones (`cbrt(-x) = -cbrt(x)`). The region also carries the outer loop's reset code,
-   entangled by the rotation. The priced work is therefore call + compare/branch wrapper — a
-   faithful account of what `np.cbrt` costs under numba, slightly more than a bare libm call.
-2. *In the dependency chain*: the NaN check, the sign branches and the call all depend on the
-   accumulator and feed its next value, so the whole wrapper sits in the serialized chain. The
-   kernel's mixed-sign input range exercises both sign paths.
-3. *Loop-structure symmetry*: `f_add` unrolls 8×; the branchy cbrt loop cannot unroll. As on
-   the [SQRT page](sqrt.md), both sides remain latency-bound, so the subtraction holds.
+1. *Intended call, and nothing else*: the structural additions are the `blr` — the `cbrt`
+   call — plus one integer load per iteration re-fetching the call-target pointer from the
+   ctypes closure (the libm kernels numba compiles directly keep their target in a register;
+   the ctypes route reloads it). That load is a stride-0 L1 hit on the integer side. The
+   remaining `-`/`+` pairs are the canonical-index shift described on the
+   [index page](index.md). No NaN check and no sign branches: numba's `np.cbrt` would add
+   those around the call, which is exactly why the kernel binds libm directly — CPython's
+   `math.cbrt` executes the bare call.
+2. *In the dependency chain*: the accumulator flows through the call — `fadd` produces the
+   argument, the call returns the result the next iteration's `fadd` consumes. The pointer
+   reload is integer-side work that runs off the chain, overlapping earlier latency rather
+   than extending it.
+3. *Loop-structure symmetry*: same asymmetry as the [SQRT page](sqrt.md) — `f_add` unrolls
+   8×, `f_add_cbrt` does not; the diff shows `f_add`'s scalar remainder loop. As there, both
+   sides stay latency-bound through the accumulator chain, so the subtraction holds.

--- a/docs/kernel_asm/cos.md
+++ b/docs/kernel_asm/cos.md
@@ -2,7 +2,7 @@
 
 The `COS` cost is the latency difference between a kernel chaining `math.cos(tmp + x[i])` and
 one chaining only `tmp + x[i]` — kernels `f_add_cos` and `f_add`. Like most libm-backed functions,
-`math.cos` compiles to a call into the math library. The kernel's moderate input range targets the general-case cost: tiny arguments would skip argument reduction and underprice the call, huge ones would price the expensive large-argument reduction instead.
+`math.cos` compiles to a call into the math library. The probe's moderate input range targets the general-case cost: tiny arguments would skip argument reduction and underprice the call, huge ones would price the expensive large-argument reduction instead.
 
 What Python code counts into `COS` is described in
 [FLOP types](../flop_types.md#flop-cos).

--- a/docs/kernel_asm/cos.md
+++ b/docs/kernel_asm/cos.md
@@ -2,7 +2,7 @@
 
 The `COS` cost is the latency difference between a kernel chaining `math.cos(tmp + x[i])` and
 one chaining only `tmp + x[i]` — kernels `f_add_cos` and `f_add`. Like most libm-backed functions,
-`math.cos` compiles to a call into the math library.
+`math.cos` compiles to a call into the math library. The kernel's moderate input range targets the general-case cost: tiny arguments would skip argument reduction and underprice the call, huge ones would price the expensive large-argument reduction instead.
 
 What Python code counts into `COS` is described in
 [FLOP types](../flop_types.md#flop-cos).

--- a/docs/kernel_asm/cosh.md
+++ b/docs/kernel_asm/cosh.md
@@ -3,7 +3,9 @@
 The `COSH` cost is the latency difference between a kernel chaining
 `cosh(acosh(tmp + x[i]))` and one chaining `acosh(tmp + x[i])` — kernels `f_add_acosh_cosh`
 and `f_add_acosh`. Chained-base pair: `acosh` is `cosh`'s inverse for arguments ≥ 1,
-keeping the chain bounded, and the `acosh`-only kernel is subtracted so its cost cancels.
+keeping the chain bounded, and the `acosh`-only kernel is subtracted so its cost cancels. The two kernels share their
+input range, and its moderate magnitude keeps the chained `cosh` argument in the
+general-case regime.
 
 What Python code counts into `COSH` is described in
 [FLOP types](../flop_types.md#flop-cosh).

--- a/docs/kernel_asm/cosh.md
+++ b/docs/kernel_asm/cosh.md
@@ -3,7 +3,7 @@
 The `COSH` cost is the latency difference between a kernel chaining
 `cosh(acosh(tmp + x[i]))` and one chaining `acosh(tmp + x[i])` — kernels `f_add_acosh_cosh`
 and `f_add_acosh`. Chained-base pair: `acosh` is `cosh`'s inverse for arguments ≥ 1,
-keeping the chain bounded, and the `acosh`-only kernel is subtracted so its cost cancels. The two kernels share their
+keeping the chain bounded, and the `acosh`-only probe is subtracted so its cost cancels. The two probes share their
 input range, and its moderate magnitude keeps the chained `cosh` argument in the
 general-case regime.
 

--- a/docs/kernel_asm/sin.md
+++ b/docs/kernel_asm/sin.md
@@ -2,7 +2,7 @@
 
 The `SIN` cost is the latency difference between a kernel chaining `math.sin(tmp + x[i])` and
 one chaining only `tmp + x[i]` — kernels `f_add_sin` and `f_add`. Like most libm-backed functions,
-`math.sin` compiles to a call into the math library. The kernel's moderate input range targets the general-case cost: tiny arguments would skip argument reduction and underprice the call, huge ones would price the expensive large-argument reduction instead.
+`math.sin` compiles to a call into the math library. The probe's moderate input range targets the general-case cost: tiny arguments would skip argument reduction and underprice the call, huge ones would price the expensive large-argument reduction instead.
 
 What Python code counts into `SIN` is described in
 [FLOP types](../flop_types.md#flop-sin).

--- a/docs/kernel_asm/sin.md
+++ b/docs/kernel_asm/sin.md
@@ -2,7 +2,7 @@
 
 The `SIN` cost is the latency difference between a kernel chaining `math.sin(tmp + x[i])` and
 one chaining only `tmp + x[i]` — kernels `f_add_sin` and `f_add`. Like most libm-backed functions,
-`math.sin` compiles to a call into the math library.
+`math.sin` compiles to a call into the math library. The kernel's moderate input range targets the general-case cost: tiny arguments would skip argument reduction and underprice the call, huge ones would price the expensive large-argument reduction instead.
 
 What Python code counts into `SIN` is described in
 [FLOP types](../flop_types.md#flop-sin).

--- a/docs/kernel_asm/sinh.md
+++ b/docs/kernel_asm/sinh.md
@@ -3,8 +3,8 @@
 The `SINH` cost is the latency difference between a kernel chaining
 `sinh(asinh(tmp + x[i]))` and one chaining `asinh(tmp + x[i])` — kernels `f_add_asinh_sinh`
 and `f_add_asinh`. Chained-base pair: `asinh` is `sinh`'s inverse, keeping the chain
-bounded where a bare `sinh` chain would overflow, and the `asinh`-only kernel is subtracted
-so its cost cancels. The two kernels share their input range, and its moderate magnitude
+bounded where a bare `sinh` chain would overflow, and the `asinh`-only probe is subtracted
+so its cost cancels. The two probes share their input range, and its moderate magnitude
 keeps the chained `sinh` argument in the general-case regime.
 
 What Python code counts into `SINH` is described in

--- a/docs/kernel_asm/sinh.md
+++ b/docs/kernel_asm/sinh.md
@@ -4,7 +4,8 @@ The `SINH` cost is the latency difference between a kernel chaining
 `sinh(asinh(tmp + x[i]))` and one chaining `asinh(tmp + x[i])` — kernels `f_add_asinh_sinh`
 and `f_add_asinh`. Chained-base pair: `asinh` is `sinh`'s inverse, keeping the chain
 bounded where a bare `sinh` chain would overflow, and the `asinh`-only kernel is subtracted
-so its cost cancels.
+so its cost cancels. The two kernels share their input range, and its moderate magnitude
+keeps the chained `sinh` argument in the general-case regime.
 
 What Python code counts into `SINH` is described in
 [FLOP types](../flop_types.md#flop-sinh).

--- a/docs/kernel_asm/tan.md
+++ b/docs/kernel_asm/tan.md
@@ -2,7 +2,7 @@
 
 The `TAN` cost is the latency difference between a kernel chaining `math.tan(tmp + x[i])` and
 one chaining only `tmp + x[i]` — kernels `f_add_tan` and `f_add`. Like most libm-backed functions,
-`math.tan` compiles to a call into the math library.
+`math.tan` compiles to a call into the math library. The kernel's moderate input range targets the general-case cost: tiny arguments would skip argument reduction and underprice the call, huge ones would price the expensive large-argument reduction instead.
 
 What Python code counts into `TAN` is described in
 [FLOP types](../flop_types.md#flop-tan).

--- a/docs/kernel_asm/tan.md
+++ b/docs/kernel_asm/tan.md
@@ -2,7 +2,7 @@
 
 The `TAN` cost is the latency difference between a kernel chaining `math.tan(tmp + x[i])` and
 one chaining only `tmp + x[i]` — kernels `f_add_tan` and `f_add`. Like most libm-backed functions,
-`math.tan` compiles to a call into the math library. The kernel's moderate input range targets the general-case cost: tiny arguments would skip argument reduction and underprice the call, huge ones would price the expensive large-argument reduction instead.
+`math.tan` compiles to a call into the math library. The probe's moderate input range targets the general-case cost: tiny arguments would skip argument reduction and underprice the call, huge ones would price the expensive large-argument reduction instead.
 
 What Python code counts into `TAN` is described in
 [FLOP types](../flop_types.md#flop-tan).

--- a/docs/math_patching.md
+++ b/docs/math_patching.md
@@ -91,7 +91,7 @@ context report these calls as it meets them — the not-instrumented set and
 it exists — on older interpreters there is no such function to call, and a
 multiply-add written as `a*b + c` counts MUL + ADD there as everywhere else. It is
 the one place a fused multiply-add is observable at the Python level, which is why
-it is also the only place one is counted; see [FLOP types](flop_types.md#floptypefma-xyz)
+it is also the only place one is counted; see [FLOP types](flop_types.md#flop-fma)
 for its counting rules and [Known limitations](known_limitations.md) for what
 operator-level fusion still costs.
 

--- a/scripts/generate_kernel_asm_docs.py
+++ b/scripts/generate_kernel_asm_docs.py
@@ -254,7 +254,7 @@ PAGES: list[KernelAsmPage] = [
         extended_kernel="f_add_cbrt",
         rationale=(
             "numba's `np.cbrt` wraps the libm call in NaN/sign handling CPython's `math.cbrt` never executes, "
-            "so the kernel calls libm through a ctypes binding -- the bare call CPython executes"
+            "so the probe calls libm through a ctypes binding -- the bare call CPython executes"
         ),
     ),
     KernelAsmPage("cos", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_cos", range_sensitive=True),

--- a/scripts/generate_kernel_asm_docs.py
+++ b/scripts/generate_kernel_asm_docs.py
@@ -243,9 +243,9 @@ PAGES: list[KernelAsmPage] = [
     KernelAsmPage("acos", kind=KIND_LIBM, base_kernel="f_add_sin", extended_kernel="f_add_sin_acos"),
     KernelAsmPage("acosh", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_acosh", range_sensitive=True),
     KernelAsmPage("asin", kind=KIND_LIBM, base_kernel="f_add_sin", extended_kernel="f_add_sin_asin"),
-    KernelAsmPage("asinh", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_asinh"),
-    KernelAsmPage("atan", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_atan"),
-    KernelAsmPage("atan2", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_atan2"),
+    KernelAsmPage("asinh", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_asinh", range_sensitive=True),
+    KernelAsmPage("atan", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_atan", range_sensitive=True),
+    KernelAsmPage("atan2", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_atan2", range_sensitive=True),
     KernelAsmPage("atanh", kind=KIND_LIBM, base_kernel="f_add_halfsin", extended_kernel="f_add_halfsin_atanh"),
     KernelAsmPage(
         "cbrt",
@@ -253,12 +253,14 @@ PAGES: list[KernelAsmPage] = [
         base_kernel="f_add",
         extended_kernel="f_add_cbrt",
         rationale=(
-            "a known deviation from rule 2.2: measured through numba's `np.cbrt`, whose NaN/sign handling "
-            "around the libm call is included in the weight (CPython's `math.cbrt` calls libm directly)"
+            "numba's `np.cbrt` wraps the libm call in NaN/sign handling CPython's `math.cbrt` never executes, "
+            "so the kernel calls libm through a ctypes binding -- the bare call CPython executes"
         ),
     ),
-    KernelAsmPage("cos", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_cos"),
-    KernelAsmPage("cosh", kind=KIND_LIBM, base_kernel="f_add_acosh", extended_kernel="f_add_acosh_cosh"),
+    KernelAsmPage("cos", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_cos", range_sensitive=True),
+    KernelAsmPage(
+        "cosh", kind=KIND_LIBM, base_kernel="f_add_acosh", extended_kernel="f_add_acosh_cosh", range_sensitive=True
+    ),
     KernelAsmPage("erf", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_erf", range_sensitive=True),
     KernelAsmPage("erfc", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_erfc", range_sensitive=True),
     KernelAsmPage("exp", kind=KIND_LIBM, base_kernel="f_add_log", extended_kernel="f_add_log_exp"),
@@ -312,9 +314,11 @@ PAGES: list[KernelAsmPage] = [
         ),
         range_sensitive=True,
     ),
-    KernelAsmPage("sin", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_sin"),
-    KernelAsmPage("sinh", kind=KIND_LIBM, base_kernel="f_add_asinh", extended_kernel="f_add_asinh_sinh"),
-    KernelAsmPage("tan", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_tan"),
+    KernelAsmPage("sin", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_sin", range_sensitive=True),
+    KernelAsmPage(
+        "sinh", kind=KIND_LIBM, base_kernel="f_add_asinh", extended_kernel="f_add_asinh_sinh", range_sensitive=True
+    ),
+    KernelAsmPage("tan", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_tan", range_sensitive=True),
     KernelAsmPage("tanh", kind=KIND_LIBM, base_kernel="f_add", extended_kernel="f_add_tanh", range_sensitive=True),
     # --- arity-scaled algorithms -----------------
     KernelAsmPage(

--- a/src/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
+++ b/src/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
@@ -220,6 +220,9 @@ class FlopsBenchmarkSuite:
                 (FBT.ADD_ROUND, kernels.f_add_round, ArrayGenerator.lin_range(min_value=-1e16, max_value=1e16)),
                 (FBT.ADD_SQRT, kernels.f_add_sqrt, ArrayGenerator.lin_range(min_value=0.0, max_value=1e16)),
                 (FBT.ADD_CBRT, kernels.f_add_cbrt, ArrayGenerator.lin_range(min_value=-1e16, max_value=1e16)),
+                # log family (and the chained exp partners, which must share the range so the log
+                # cost cancels): measured flat across 2..1000 vs 1e10..1e100, so the range is not
+                # load-bearing -- kept as registered
                 (FBT.ADD_LOG, kernels.f_add_log, ArrayGenerator.lin_range(min_value=1e10, max_value=1e100)),
                 (FBT.ADD_LOG_EXP, kernels.f_add_log_exp, ArrayGenerator.lin_range(min_value=1e10, max_value=1e100)),
                 (FBT.ADD_LOG2, kernels.f_add_log2, ArrayGenerator.lin_range(min_value=1e10, max_value=1e100)),
@@ -230,11 +233,26 @@ class FlopsBenchmarkSuite:
                     kernels.f_add_log10_exp10,
                     ArrayGenerator.lin_range(min_value=1e10, max_value=1e100),
                 ),
-                (FBT.ADD_SIN, kernels.f_add_sin, ArrayGenerator.lin_range(min_value=-1e6, max_value=1e6)),
-                (FBT.ADD_COS, kernels.f_add_cos, ArrayGenerator.lin_range(min_value=-1e6, max_value=1e6)),
-                (FBT.ADD_TAN, kernels.f_add_tan, ArrayGenerator.lin_range(min_value=-1e6, max_value=1e6)),
-                (FBT.ADD_SIN_ASIN, kernels.f_add_sin_asin, ArrayGenerator.lin_range(min_value=-1e6, max_value=1e6)),
-                (FBT.ADD_SIN_ACOS, kernels.f_add_sin_acos, ArrayGenerator.lin_range(min_value=-1e6, max_value=1e6)),
+                # sin/cos/tan: +/-100 targets the flat general-case plateau (+/-16 .. +/-1e4 measured
+                # flat) -- +/-2 would underprice (sub-reduction regime), +/-1e6 would overprice
+                # (huge-argument reduction regime, ~5-7% above the plateau).  The asin/acos chains
+                # share sin's range so the sin cost cancels in their subtraction
+                (FBT.ADD_SIN, kernels.f_add_sin, ArrayGenerator.lin_range(min_value=-100.0, max_value=100.0)),
+                (FBT.ADD_COS, kernels.f_add_cos, ArrayGenerator.lin_range(min_value=-100.0, max_value=100.0)),
+                (FBT.ADD_TAN, kernels.f_add_tan, ArrayGenerator.lin_range(min_value=-100.0, max_value=100.0)),
+                (
+                    FBT.ADD_SIN_ASIN,
+                    kernels.f_add_sin_asin,
+                    ArrayGenerator.lin_range(min_value=-100.0, max_value=100.0),
+                ),
+                (
+                    FBT.ADD_SIN_ACOS,
+                    kernels.f_add_sin_acos,
+                    ArrayGenerator.lin_range(min_value=-100.0, max_value=100.0),
+                ),
+                # atan/atan2: cost steps up once |arg| clears ~1 (atan's reciprocal branch) and is
+                # then flat through +/-1e6 (no periodic reduction), so the registered range already
+                # prices the general case -- kept.  hypot: measured flat (+/-2 vs +/-1e6) -- kept
                 (FBT.ADD_ATAN, kernels.f_add_atan, ArrayGenerator.lin_range(min_value=-1e6, max_value=1e6)),
                 (FBT.ADD_ATAN2, kernels.f_add_atan2, ArrayGenerator.lin_range(min_value=-1e6, max_value=1e6)),
                 (FBT.ADD_HYPOT, kernels.f_add_hypot, ArrayGenerator.lin_range(min_value=-1e6, max_value=1e6)),
@@ -265,17 +283,23 @@ class FlopsBenchmarkSuite:
                 # tanh saturates to +/-1 via a cheap early-return for |arg| > ~20, so (unlike the
                 # periodic sin/cos/tan) keep inputs small to measure its real, exp-based cost
                 (FBT.ADD_TANH, kernels.f_add_tanh, ArrayGenerator.lin_range(min_value=-5.0, max_value=5.0)),
-                (FBT.ADD_ASINH, kernels.f_add_asinh, ArrayGenerator.lin_range(min_value=1e10, max_value=1e100)),
+                # asinh/acosh: moderate arguments price the general case -- huge arguments
+                # (1e10..1e100) would land in the asymptotic asinh(x) ~ log(2x) shortcut regime,
+                # measured ~35-40% cheaper than the flat 0.5..1e6 plateau.  The sinh/cosh chains
+                # share the range so the asinh/acosh cost cancels in their subtraction (their own
+                # arguments are the moderate asinh/acosh outputs).  acosh's positive range also
+                # keeps its argument >= 1 (acosh's domain)
+                (FBT.ADD_ASINH, kernels.f_add_asinh, ArrayGenerator.lin_range(min_value=0.5, max_value=3.0)),
                 (
                     FBT.ADD_ASINH_SINH,
                     kernels.f_add_asinh_sinh,
-                    ArrayGenerator.lin_range(min_value=1e10, max_value=1e100),
+                    ArrayGenerator.lin_range(min_value=0.5, max_value=3.0),
                 ),
-                (FBT.ADD_ACOSH, kernels.f_add_acosh, ArrayGenerator.lin_range(min_value=1e10, max_value=1e100)),
+                (FBT.ADD_ACOSH, kernels.f_add_acosh, ArrayGenerator.lin_range(min_value=2.0, max_value=10.0)),
                 (
                     FBT.ADD_ACOSH_COSH,
                     kernels.f_add_acosh_cosh,
-                    ArrayGenerator.lin_range(min_value=1e10, max_value=1e100),
+                    ArrayGenerator.lin_range(min_value=2.0, max_value=10.0),
                 ),
                 (FBT.ADD_HALFSIN, kernels.f_add_halfsin, ArrayGenerator.lin_range(min_value=-1e6, max_value=1e6)),
                 (
@@ -304,6 +328,8 @@ class FlopsBenchmarkSuite:
                 # x>~27), so -- like tanh -- keep the argument small to measure their real, polynomial cost
                 (FBT.ADD_ERF, kernels.f_add_erf, ArrayGenerator.lin_range(min_value=0.5, max_value=2.0)),
                 (FBT.ADD_ERFC, kernels.f_add_erfc, ArrayGenerator.lin_range(min_value=0.5, max_value=2.5)),
+                # pow: measured flat (log 0.5..2 vs log 0.1..10) -- kept; the geomean-1 log range
+                # also keeps the chained tmp ** x bounded
                 (FBT.POW, kernels.f_pow, ArrayGenerator.log_range(min_value=0.1, max_value=10.0)),
                 (FBT.POW_POW, kernels.f_pow_pow, ArrayGenerator.log_range(min_value=0.1, max_value=10.0)),
                 (FBT.SUB, kernels.f_sub, ArrayGenerator.lin_range(min_value=-1e16, max_value=1e16)),

--- a/src/counted_float/_core/benchmarking/flops/_flops_kernels.py
+++ b/src/counted_float/_core/benchmarking/flops/_flops_kernels.py
@@ -13,7 +13,7 @@ from counted_float._core.compatibility import numba
 
 from ._libm_bindings import libm_cbrt, libm_remainder
 
-# the two kernels that measure through a ctypes binding rather than a numba-compiled call --
+# the two probes that measure through a ctypes binding rather than a numba-compiled call --
 # see _libm_bindings for the mechanism and the admission criterion
 c_cbrt = libm_cbrt()
 c_remainder = libm_remainder()

--- a/src/counted_float/_core/benchmarking/flops/_flops_kernels.py
+++ b/src/counted_float/_core/benchmarking/flops/_flops_kernels.py
@@ -5,24 +5,18 @@ walks the input array in a dependent chain, so the measurement reflects operatio
 than the CPU's ability to overlap independent work.
 """
 
-import ctypes
-import ctypes.util
 import math
-import sys
 
 import numpy as np
 
 from counted_float._core.compatibility import numba
 
-# numba has no math.remainder, so the remainder kernel calls libm directly through ctypes --
-# numba compiles a ctypes function into a plain indirect call (same loop shape as the other
-# libm-backed kernels, plus one integer-side pointer reload per iteration), and without numba
-# the ctypes function is just as callable from the pure-Python fallback path.  On Windows the
-# C99 math functions live in the UCRT rather than a separate libm.
-_libm = ctypes.CDLL("ucrtbase" if sys.platform == "win32" else ctypes.util.find_library("m"))
-c_remainder = _libm.remainder
-c_remainder.restype = ctypes.c_double
-c_remainder.argtypes = [ctypes.c_double, ctypes.c_double]
+from ._libm_bindings import libm_cbrt, libm_remainder
+
+# the two kernels that measure through a ctypes binding rather than a numba-compiled call --
+# see _libm_bindings for the mechanism and the admission criterion
+c_cbrt = libm_cbrt()
+c_remainder = libm_remainder()
 
 
 @numba.njit(parallel=False)
@@ -109,10 +103,12 @@ def f_add_sqrt(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, o
 
 @numba.njit(parallel=False)
 def f_add_cbrt(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
+    # libm cbrt via ctypes (see _libm_bindings): numba's np.cbrt would wrap the call in NaN/sign
+    # handling that CPython's math.cbrt never executes, so the bare call is what gets priced
     for _ in range(n_executions):
         tmp = math.e
         for i in range(n):
-            tmp = np.cbrt(tmp + in_f[i])
+            tmp = c_cbrt(tmp + in_f[i])
             out_f[i] = tmp
 
 
@@ -432,7 +428,8 @@ def f_add_asinh_sinh(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndar
 
 @numba.njit(parallel=False)
 def f_add_acosh(n_executions: int, n: int, in_f: np.ndarray, out_f: np.ndarray, out_i: np.ndarray) -> None:
-    # the large positive range keeps the argument >= 1 (acosh's domain)
+    # the positive range keeps the argument >= 1 (acosh's domain); see the suite registration for
+    # why its magnitude is moderate
     for _ in range(n_executions):
         tmp = math.e
         for i in range(n):

--- a/src/counted_float/_core/benchmarking/flops/_libm_bindings.py
+++ b/src/counted_float/_core/benchmarking/flops/_libm_bindings.py
@@ -1,11 +1,11 @@
-"""ctypes bindings to the C math library, for the benchmark kernels that need the bare call.
+"""ctypes bindings to the C math library, for the benchmark probes that need the bare call.
 
 numba compiles a ctypes function into a plain indirect call -- the same loop shape as the
-libm-backed kernels it compiles directly, plus one integer-side pointer reload per iteration --
+libm-backed probes it compiles directly, plus one integer-side pointer reload per iteration --
 and without numba the ctypes function is just as callable from the pure-Python fallback path.
 On Windows the C99 math functions live in the UCRT rather than a separate libm.
 
-Admission criterion -- a kernel goes through a ctypes binding only where numba's own route to
+Admission criterion -- a probe goes through a ctypes binding only where numba's own route to
 the function either does not exist (`math.remainder` has no numba implementation) or inserts
 wrapper code around the libm call that CPython's own call never executes (`np.cbrt` adds
 NaN/sign handling; CPython's `math.cbrt` calls libm directly).  Everywhere else the

--- a/src/counted_float/_core/benchmarking/flops/_libm_bindings.py
+++ b/src/counted_float/_core/benchmarking/flops/_libm_bindings.py
@@ -1,0 +1,43 @@
+"""ctypes bindings to the C math library, for the benchmark kernels that need the bare call.
+
+numba compiles a ctypes function into a plain indirect call -- the same loop shape as the
+libm-backed kernels it compiles directly, plus one integer-side pointer reload per iteration --
+and without numba the ctypes function is just as callable from the pure-Python fallback path.
+On Windows the C99 math functions live in the UCRT rather than a separate libm.
+
+Admission criterion -- a kernel goes through a ctypes binding only where numba's own route to
+the function either does not exist (`math.remainder` has no numba implementation) or inserts
+wrapper code around the libm call that CPython's own call never executes (`np.cbrt` adds
+NaN/sign handling; CPython's `math.cbrt` calls libm directly).  Everywhere else the
+numba-compiled call already is the bare libm call or instruction, and switching it to ctypes
+would only add the per-iteration pointer reload.
+"""
+
+import ctypes
+import ctypes.util
+import sys
+from collections.abc import Callable
+
+
+def _load_libm() -> ctypes.CDLL:
+    """Load the C math library (the UCRT on Windows, libm elsewhere)."""
+    return ctypes.CDLL("ucrtbase" if sys.platform == "win32" else ctypes.util.find_library("m"))
+
+
+_libm = _load_libm()
+
+
+def libm_cbrt() -> Callable[[float], float]:
+    """The C99 ``double cbrt(double)`` function, as a ctypes function object."""
+    fn = _libm.cbrt
+    fn.restype = ctypes.c_double
+    fn.argtypes = [ctypes.c_double]
+    return fn
+
+
+def libm_remainder() -> Callable[[float, float], float]:
+    """The C99 ``double remainder(double, double)`` function, as a ctypes function object."""
+    fn = _libm.remainder
+    fn.restype = ctypes.c_double
+    fn.argtypes = [ctypes.c_double, ctypes.c_double]
+    return fn

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import operator
+from math import frexp as _frexp  # the raw builtin: math.frexp may later carry a reporting wrapper
 from typing import TYPE_CHECKING, SupportsIndex
 
 from ._thread_counter import _TLS, _create_thread_state
@@ -53,6 +55,33 @@ def count_pow_with_constant_exponent(exponent: float) -> None:
             cnt.DIV += 1
         return
     cnt.POW += 1
+
+
+def count_div_with_constant_divisor(divisor: float) -> None:
+    """Register the flops a compiled port would execute for ``x / divisor`` with a constant divisor.
+
+    Constants are folded by value (an int and an equal-valued plain float compile identically):
+    a divisor of 1 counts nothing (``x / 1.0`` folds away entirely — a compiled port emits no
+    instruction, mirroring ``x ** 1``), and any other power-of-two divisor with a finite
+    reciprocal counts MUL — for exactly those divisors ``x * (1/c)`` is bit-identical to
+    ``x / c``, so a standard-C compiler applies the reciprocal fold at plain ``-O2``. Every
+    other divisor counts DIV.
+    """
+    if divisor == 1.0:
+        return
+    try:
+        cnt: CountsTarget = _TLS.flop_counts
+    except AttributeError:  # first counted op on this thread
+        cnt: CountsTarget = _create_thread_state()
+    mantissa, exponent = _frexp(divisor)
+    # power of two iff the mantissa is exactly +/-0.5; the divisor is then 2**(exponent-1), whose
+    # reciprocal 2**(1-exponent) stays finite iff exponent >= -1022 (below that it overflows and
+    # the fold would not be value-preserving)
+    if mantissa in (0.5, -0.5) and exponent >= -1022:
+        cnt.note("power-of-two constant divisor -> reciprocal multiply")
+        cnt.MUL += 1
+    else:
+        cnt.DIV += 1
 
 
 def count_pow_with_constant_base(base: float) -> None:
@@ -208,20 +237,35 @@ class CountedFloat(float):
     ) -> int | float:
         """Round to n decimal places, i.e. round(x, n).
 
-        n = None -> round to nearest integer and return int
-        n = 0    -> round to nearest integer and return float
-        n > 0    -> round to n decimal places and return float.
+        n = None -> round to nearest integer and return int (F2I)
+        n = 0    -> round to nearest integer and return float (RND)
+        n != 0   -> round to n decimal places and return float: a compiled port scales into
+                    the digit position, rounds, and scales back -- MUL + RND + DIV. The
+                    unscale is a true divide (the scale factor is a power of ten, whose
+                    reciprocal is not exact), so no reciprocal fold applies. Stated gap: the
+                    port price knowingly omits the correctly-rounded decimal machinery
+                    CPython itself runs (David Gay's algorithm), which has no fixed
+                    instruction cost to price.
         """
         if n is None:
             try:
                 _TLS.flop_counts.F2I += 1  # will round and return int
             except AttributeError:  # first counted op on this thread
                 _create_thread_state().F2I += 1
-        else:
+        elif operator.index(n) == 0:
             try:
                 _TLS.flop_counts.RND += 1  # will round and return float
             except AttributeError:  # first counted op on this thread
                 _create_thread_state().RND += 1
+        else:
+            try:
+                cnt: CountsTarget = _TLS.flop_counts
+            except AttributeError:  # first counted op on this thread
+                cnt: CountsTarget = _create_thread_state()
+            cnt.note("nonzero ndigits -> scale, round, unscale")
+            cnt.MUL += 1
+            cnt.RND += 1
+            cnt.DIV += 1
 
         return float.__round__(self, n)
 
@@ -324,18 +368,26 @@ class CountedFloat(float):
         return float.__new__(CountedFloat, result)
 
     def __truediv__(self, other: float) -> CountedFloat:
-        """x/other."""
+        """x/other.
+
+        A constant (non-CountedFloat) divisor enables the folds a compiled port applies — see
+        count_div_with_constant_divisor: a divisor of 1 counts nothing, any other power-of-two
+        constant divisor with a finite reciprocal counts MUL, everything else counts DIV.
+        """
         result = float.__truediv__(self, other)
         if result is NotImplemented:
             return NotImplemented
-        try:
-            _TLS.flop_counts.DIV += 1
-        except AttributeError:  # first counted op on this thread
-            _create_thread_state().DIV += 1
+        if isinstance(other, CountedFloat):
+            try:
+                _TLS.flop_counts.DIV += 1  # genuinely runtime divisor
+            except AttributeError:  # first counted op on this thread
+                _create_thread_state().DIV += 1
+        else:
+            count_div_with_constant_divisor(other)
         return float.__new__(CountedFloat, result)
 
     def __rtruediv__(self, other: float) -> CountedFloat:
-        """other/x."""
+        """other/x. The divisor is this CountedFloat — dynamic, so always DIV (no fold applies)."""
         result = float.__rtruediv__(self, other)
         if result is NotImplemented:
             return NotImplemented

--- a/tests/benchmarking/flops/test_flops_benchmark_suite.py
+++ b/tests/benchmarking/flops/test_flops_benchmark_suite.py
@@ -82,6 +82,29 @@ def test_remainder_kernel_matches_math_remainder():
 
 
 @pytest.mark.skipif(not is_numba_installed(), reason="kernel execution needs real numba, not the shim")
+def test_cbrt_kernel_matches_math_cbrt():
+    """The ctypes-bound libm call must compute exactly what math.cbrt computes.
+
+    The kernel calls libm through ctypes rather than through numba's np.cbrt, whose NaN/sign
+    wrapper CPython's math.cbrt never executes -- this pins that the bound symbol is the right
+    function, negative arguments included.
+    """
+    # --- arrange -----------------------------------------
+    n = 50
+    in_f = np.linspace(-1e16, 1e16, n)
+    out_f, out_i = np.zeros(n), np.zeros(n, dtype=int)
+
+    # --- act ---------------------------------------------
+    kernels.f_add_cbrt(1, n, in_f, out_f, out_i)
+
+    # --- assert ------------------------------------------
+    tmp = math.e
+    for i in range(n):
+        tmp = math.cbrt(tmp + in_f[i])
+        assert out_f[i] == tmp
+
+
+@pytest.mark.skipif(not is_numba_installed(), reason="kernel execution needs real numba, not the shim")
 @pytest.mark.parametrize("kernel", [kernels.f_add_gammabase_gamma, kernels.f_add_gammabase_lgamma])
 def test_gamma_kernels_never_overflow_even_on_a_wild_input_range(kernel):
     """The sin bound must keep the gamma/lgamma chain finite regardless of the input magnitudes.

--- a/tests/benchmarking/flops/test_flops_benchmark_suite.py
+++ b/tests/benchmarking/flops/test_flops_benchmark_suite.py
@@ -85,7 +85,7 @@ def test_remainder_kernel_matches_math_remainder():
 def test_cbrt_kernel_matches_math_cbrt():
     """The ctypes-bound libm call must compute exactly what math.cbrt computes.
 
-    The kernel calls libm through ctypes rather than through numba's np.cbrt, whose NaN/sign
+    The probe calls libm through ctypes rather than through numba's np.cbrt, whose NaN/sign
     wrapper CPython's math.cbrt never executes -- this pins that the bound symbol is the right
     function, negative arguments included.
     """

--- a/tests/counting/test_count_parity_property.py
+++ b/tests/counting/test_count_parity_property.py
@@ -6,10 +6,16 @@ on the left, the flops silently vanished while the result type recovered downstr
 asserted over the operand types the counting model deliberately supports — ``float``, ``int``,
 and ``np.float64`` (a plain C double flowing through the ordinary float path). ``Fraction`` is
 deliberately absent: its asymmetry is a documented boundary of the model, not a target.
+
+One asymmetry is the model's own: division's reciprocal fold keys on the *divisor* being a
+power-of-two constant, so ``cf / 2.0`` counts MUL while ``2.0 / cf`` (dynamic divisor) counts
+DIV — and ``cf / 1.0`` folds away entirely. The parity test asserts exactly those splits for
+such operands instead of blind equality.
 """
 
 import operator
 from collections.abc import Callable
+from math import frexp
 
 import numpy as np
 import pytest
@@ -36,6 +42,12 @@ def _counts_of(op: Callable, left: object, right: object) -> FlopCounts:
     return fcc.flop_counts()
 
 
+def _is_foldable_power_of_two(value: float) -> bool:
+    """Whether a constant divisor of this value takes the reciprocal-multiply fold (counts MUL)."""
+    mantissa, exponent = frexp(value)
+    return mantissa in (0.5, -0.5) and exponent >= -1022
+
+
 @pytest.mark.parametrize("op", _ARITHMETIC)
 @pytest.mark.parametrize(("operand_type", "convert"), _OPERAND_CONVERTERS, ids=[t[0] for t in _OPERAND_CONVERTERS])
 @settings(deadline=None)
@@ -52,10 +64,23 @@ def test_operand_side_does_not_change_the_count(
     counts_counted_right = _counts_of(op, other, counted)
 
     # --- assert ------------------------------------------
-    assert counts_counted_left == counts_counted_right, (
-        f"{op.__name__} with a {operand_type} operand counts differently per side"
-    )
+    if op is operator.truediv and float(other) == 1.0:
+        # a constant divisor of 1 folds away entirely; as a dividend the division is real
+        assert counts_counted_left.total_count() == 0
+        assert counts_counted_right.DIV == 1
+        assert counts_counted_right.total_count() == 1
+        return
+    if op is operator.truediv and _is_foldable_power_of_two(float(other)):
+        # the model's own side-dependence (see module docstring): constant power-of-two
+        # divisor folds to MUL, while as a dividend the divisor is dynamic and counts DIV
+        assert counts_counted_left.MUL == 1
+        assert counts_counted_right.DIV == 1
+    else:
+        assert counts_counted_left == counts_counted_right, (
+            f"{op.__name__} with a {operand_type} operand counts differently per side"
+        )
     assert counts_counted_left.total_count() == 1
+    assert counts_counted_right.total_count() == 1
 
 
 @pytest.mark.parametrize("op", _ARITHMETIC)

--- a/tests/counting/test_counted_float.py
+++ b/tests/counting/test_counted_float.py
@@ -644,14 +644,16 @@ def test_counted_float_counts_ge(thread_counter):
 
 
 @pytest.mark.parametrize(
-    ("ndigits", "expected_n_rnd", "expected_n_f2i"),
+    ("ndigits", "expected_counts"),
     [
-        (None, 0, 1),  # round to int -> F2I
-        (0, 1, 0),  # round to float -> RND
-        (1, 1, 0),  # round to float -> RND
+        (None, {"F2I": 1}),  # round to int -> F2I
+        (0, {"RND": 1}),  # round to nearest integer, return float -> RND
+        (1, {"MUL": 1, "RND": 1, "DIV": 1}),  # scale, round, unscale
+        (2, {"MUL": 1, "RND": 1, "DIV": 1}),
+        (-3, {"MUL": 1, "RND": 1, "DIV": 1}),  # negative digit counts scale the other way
     ],
 )
-def test_counted_float_counts_round(thread_counter, ndigits, expected_n_rnd: int, expected_n_f2i: int):
+def test_counted_float_counts_round(thread_counter, ndigits, expected_counts: dict[str, int]):
     # --- arrange -----------------------------------------
     cf = CountedFloat(1.23456)
 
@@ -659,9 +661,9 @@ def test_counted_float_counts_round(thread_counter, ndigits, expected_n_rnd: int
     _ = round(cf, ndigits)
 
     # --- assert ------------------------------------------
-    assert thread_counter.total_count() == 1
-    assert expected_n_rnd == thread_counter.RND
-    assert expected_n_f2i == thread_counter.F2I
+    assert thread_counter.total_count() == sum(expected_counts.values())
+    for field, expected in expected_counts.items():
+        assert getattr(thread_counter, field) == expected
 
 
 def test_counted_float_counts_floor(thread_counter):
@@ -842,6 +844,53 @@ def test_counted_float_counts_div_int(thread_counter):
     assert thread_counter.total_count() == 5
     assert thread_counter.DIV == 5
     assert thread_counter.I2F == 0
+
+
+@pytest.mark.parametrize(
+    ("divisor", "expected_counts"),
+    [
+        (2.0, {"MUL": 1}),
+        (0.5, {"MUL": 1}),
+        (-8.0, {"MUL": 1}),  # sign carries into the reciprocal; the fold still applies
+        (4, {"MUL": 1}),  # an int and an equal-valued plain float compile identically
+        (1.0, {}),  # folds away entirely, like x ** 1
+        (1, {}),
+        (-1.0, {"MUL": 1}),  # only exact identity folds to nothing; the sign flip keeps its MUL
+        (2.0**-1023, {"MUL": 1}),  # smallest power of two whose reciprocal is finite
+        (2.0**-1024, {"DIV": 1}),  # reciprocal overflows -> fold not value-preserving
+        (3.0, {"DIV": 1}),
+        (0.1, {"DIV": 1}),
+        (6.0, {"DIV": 1}),  # even, but not a power of two
+        (float("inf"), {"DIV": 1}),
+        (float("nan"), {"DIV": 1}),
+    ],
+)
+def test_counted_float_counts_div_by_constant(thread_counter, divisor, expected_counts: dict[str, int]):
+    """x / c with a power-of-two constant c counts the reciprocal multiply a compiler emits."""
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(1.23456)
+
+    # --- act ---------------------------------------------
+    _ = cf / divisor
+
+    # --- assert ------------------------------------------
+    assert thread_counter.total_count() == sum(expected_counts.values())
+    for field, expected in expected_counts.items():
+        assert getattr(thread_counter, field) == expected
+
+
+def test_counted_float_counts_div_by_dynamic_power_of_two_as_div(thread_counter):
+    """The reciprocal fold keys on the divisor being constant: a CountedFloat divisor stays DIV."""
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(1.23456)
+
+    # --- act ---------------------------------------------
+    _ = cf / CountedFloat(2.0)  # dynamic divisor, even though its value is a power of two
+    _ = 2.0 / cf  # reflected form: the divisor is the CountedFloat, dynamic as well
+
+    # --- assert ------------------------------------------
+    assert thread_counter.total_count() == 2
+    assert thread_counter.DIV == 2
 
 
 def test_counted_float_counts_pow_1(thread_counter):


### PR DESCRIPTION
Applies the actionable findings of the benchmark-consistency audit, each fix citing its cost-model rule:

- **CBRT** now measures the bare libm call via a new `_libm_bindings` ctypes module (admission criterion documented), dropping numba's NaN/sign wrapper from the measured loop — the deviation marker comes off the cost-model table. Locally the weight moves ~4% (20.7× → 19.9× ADD).
- **`round(x, n != 0)`** counts the value-preserving port MUL + RND + DIV (scale, round, unscale), with the CPython decimal-machinery gap stated; `round(x)` → F2I and `round(x, 0)` → RND unchanged.
- **Division by a power-of-two constant** counts MUL (the exact reciprocal fold compilers apply at plain -O2); `x / 1.0` counts nothing. Overhead measured on 3.13 + 3.14: dynamic divisors +5–9%, constant divisors ~65 ns for the check; the README overhead band is unchanged.
- **Input-range sensitivity sweep**: sin/cos/tan move to ±100 (the flat general-case plateau; ±1e6 priced the huge-argument reduction regime) and asinh/acosh to moderate ranges (the huge range priced the asymptotic log-shortcut regime, ~35–40% below the flat plateau); log family, pow, hypot, atan/atan2 measured flat and keep their ranges — every swept range now carries a why-comment, and the cost-model table's rule-4 markers follow.

Also fixes a broken `#flop-fma` anchor in the math-patching page surfaced by the docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)