### PR TITLE
feat: count dist and n-ary hypot via the arity-scaled flop types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dividing by a power-of-two constant now counts MUL instead of DIV, matching the exact reciprocal multiplication a compiler emits; dividing by 1.0 now counts nothing, as the division folds away entirely
 - the trig (sin/cos/tan/atan/atan2) and asinh/acosh benchmarks now draw their inputs from general-case argument ranges, instead of extreme magnitudes that priced a costlier or cheaper special regime
 - re-collected the built-in flop-weight dataset across all automatically reachable CPUs (12 EC2 instance types and 5 CI runners), shipping real weights for every measured flop type — including the new hypot/dist arity, special-function and remainder types
+- `math.dist` and 3+-argument `math.hypot` are now counted as per-call + per-extra-coordinate flop types measured on the real overflow-safe algorithm, instead of decomposed flop chains
 
 ### Deprecated
 

--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -147,6 +147,7 @@ rule 3's documented gaps:
 - `math.degrees` / `math.radians` → MUL, `math.prod` → one MUL per chained multiply.
 - `math.fsum` → (n−1) ADD under rule 3: the compensation machinery is input-dependent and
   knowingly not modeled.
+
 `math.dist` and n-ary `math.hypot` are *not* decompositions: they count the dedicated
 `DIST` + (n−2) `DIST_XARG` and `HYPOT` + (n−2) `HYPOT_XARG` types, measured on the real
 overflow-safe algorithm the calls execute (rule 2).

--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -134,8 +134,8 @@ rule that governs it, and — for grey-zone cases — why the choice is what it 
 
 Some Python operations have no `FlopType` of their own and count as a composition of the
 types above (see [FLOP types](flop_types.md#coverage-at-a-glance) for the full operation
-table). Most follow rule 1 at the operation level; the last two entries are **known
-deviations** from the rule that governs them, stated here explicitly:
+table). Most follow rule 1 at the operation level; `math.fsum` and `round(x, n)` carry
+rule 3's documented gaps:
 
 - `x // y` → DIV + RND, `x % y` / `divmod` → DIV + RND + MUL + SUB — the floored-division
   sequences a port emits.
@@ -147,10 +147,6 @@ deviations** from the rule that governs them, stated here explicitly:
 - `math.degrees` / `math.radians` → MUL, `math.prod` → one MUL per chained multiply.
 - `math.fsum` → (n−1) ADD under rule 3: the compensation machinery is input-dependent and
   knowingly not modeled.
-- `math.dist` → n SUB + n MUL + (n−1) ADD + SQRT. *Known deviation from rule 2: the
-  counting uses this naive decomposition even though the `DIST`/`DIST_XARG` weights
-  measuring the real overflow-safe algorithm are already benchmarked — the two layers
-  currently disagree.*
-- `math.hypot` with 3+ arguments → n MUL + (n−1) ADD + SQRT. *Known deviation from rule 2,
-  same situation as `math.dist`: the `HYPOT`/`HYPOT_XARG` weights exist, the counting does
-  not use them yet.* (The 2-argument form counts `HYPOT` and follows rule 2.)
+`math.dist` and n-ary `math.hypot` are *not* decompositions: they count the dedicated
+`DIST` + (n−2) `DIST_XARG` and `HYPOT` + (n−2) `HYPOT_XARG` types, measured on the real
+overflow-safe algorithm the calls execute (rule 2).

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -147,14 +147,16 @@ weighted total prices every operation as if it waited for the previous one to
 finish. That is a good match for dependency-chained code — recursive filters
 and scalar iterations, the kind of algorithm this library exists for, where
 each step needs the previous step's result. For code with instruction-level
-parallelism (independent multiplies in a wide expression, the coordinate
-subtractions inside `math.dist`, an n-ary `math.hypot`), real hardware
-overlaps work that the weighted sum prices sequentially — read weighted
-totals for such structures as upper-ish estimates rather than expected
-latencies. The current model prices a function identically to its
-hand-written expansion and does not model the overlap; how much of that
-internal parallelism a weight *should* capture is a modeling choice, not a
-law of the counting model. Counts themselves are unaffected; this nuance
+parallelism (independent multiplies in a wide expression, a hand-written
+sum of squares), real hardware overlaps work that the weighted sum prices
+sequentially — read weighted totals for such structures as upper-ish
+estimates rather than expected latencies. The current model prices a
+decomposed operation identically to its hand-written expansion and does not
+model the overlap; how much of that internal parallelism a weight *should*
+capture is a modeling choice, not a law of the counting model.
+(`math.dist` and n-ary `math.hypot` are the counterexamples: their
+arity-scaled weights are measured on the real algorithm, internal overlap
+included.) Counts themselves are unaffected; this nuance
 applies only to the weighted totals.
 
 Weights are also **normalized**: every cost is expressed relative to the ADD

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -40,13 +40,13 @@ documented fallback) are stated in [Cost-model principles](cost_model.md).
 | `math.sin`/`cos`/`tan(x)` | `SIN`, `COS`, `TAN` | patch | benchmarked | yes |
 | `math.asin`/`acos`/`atan(x)` | `ASIN`, `ACOS`, `ATAN` | patch | benchmarked | yes |
 | `math.atan2(y, x)` | `ATAN2` | patch | benchmarked | yes |
-| `math.hypot(x, y)` | `HYPOT` (2 args; 3+ decompose to n MUL + (n−1) ADD + SQRT, 1 to ABS) | patch | benchmarked | yes |
+| `math.hypot(x, y, ...)` | `HYPOT` + (n−2) `HYPOT_XARG` (1 arg → `ABS`) | patch | benchmarked | yes |
 | `math.expm1(x)`, `math.log1p(x)` | `EXPM1`, `LOG1P` | patch | benchmarked | yes |
 | `math.fmod(x, y)` | `FMOD` | patch | benchmarked | yes |
 | `math.sinh`/`cosh`/`tanh(x)`, `asinh`/`acosh`/`atanh(x)` | `SINH`, `COSH`, `TANH`, `ASINH`, `ACOSH`, `ATANH` | patch | benchmarked | yes |
 | `math.copysign(x, y)` | `COPYSIGN` | patch | benchmarked | yes |
 | `math.degrees(x)`, `math.radians(x)` | `MUL` *(decomposed)* | patch | — | yes |
-| `math.dist(p, q)` | n `SUB` + n `MUL` + (n−1) `ADD` + `SQRT` *(decomposed)* | patch | — | yes |
+| `math.dist(p, q)` | `DIST` + (n−2) `DIST_XARG` | patch | benchmarked | yes |
 | `math.prod(xs)` | one `MUL` per chained multiply *(decomposed)* | patch | — | yes |
 | `math.fsum(xs)` | (n−1) `ADD` *(decomposed; compensation machinery not modeled)* | patch | — | yes |
 | `math.sumprod(p, q)` (3.12+) | *(uncounted)* | — | — | no |
@@ -375,19 +375,54 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
 - **Not counted:** `atan2` on plain floats only, `numpy.arctan2`
 - **Weight measurement:** [the machine code behind the `ATAN2` weight](machine_code/atan2.md)
 
-## FlopType.HYPOT (`hypot(x, y)`) { #flop-hypot }
+## FlopType.HYPOT (`hypot(x, y, ...)`) { #flop-hypot }
 
 - Relevant CPU instructions
     - **ARM:** (software)
     - **x86:** (software)
-- **Counted Python operations:** `math.hypot(x, y, ...)` for `CountedFloat` —
-  counted once when *any* coordinate is a `CountedFloat`
+- **Counted Python operations:** `math.hypot(...)` for `CountedFloat` — counted
+  once per call when *any* coordinate is a `CountedFloat`; coordinates beyond
+  the second each add a [`HYPOT_XARG`](#flop-hypot-xarg), and a 1-argument call
+  counts `ABS` instead (it computes `|x|`)
 - **Not counted:** `hypot` on plain floats only, `numpy.hypot`
-- **Arity assumption:** `HYPOT` is modeled as a 2D primitive. `math.hypot`
-  accepts any number of coordinates, but an n-D call still counts a single
-  `HYPOT` — under-counting vs. the n·MUL + (n−1)·ADD + SQRT a port would
-  execute. Decompose manually if n-D `hypot` cost matters.
 - **Weight measurement:** [the machine code behind the `HYPOT` weight](machine_code/hypot.md)
+
+## FlopType.HYPOT_XARG (`hypot(x, y, z, ...)`) { #flop-hypot-xarg }
+
+- Relevant CPU instructions
+    - **ARM:** (software)
+    - **x86:** (software)
+- **Counted Python operations:** one per coordinate beyond the second of a
+  `math.hypot` call: an n-ary call counts `HYPOT` + (n−2) `HYPOT_XARG`
+- **Not counted:** 2-argument calls (they cost the base `HYPOT` alone)
+- **Note:** the per-extra-coordinate slope of the overflow-safe scaled
+  algorithm `math.hypot` executes — far cheaper than a whole extra call, since
+  the extra coordinate's squares overlap the shared scaling and `sqrt`
+- **Weight measurement:** [the machine code behind the `HYPOT_XARG` weight](machine_code/hypot_xarg.md)
+
+## FlopType.DIST (`dist(p, q)`) { #flop-dist }
+
+- Relevant CPU instructions
+    - **ARM:** (software)
+    - **x86:** (software)
+- **Counted Python operations:** `math.dist(p, q)` for `CountedFloat` — counted
+  once per call when *any* coordinate is a `CountedFloat`; coordinates beyond
+  the second each add a [`DIST_XARG`](#flop-dist-xarg)
+- **Not counted:** `dist` on plain floats only, numpy norms/distances
+- **Note:** the 2-D base price of the overflow-safe algorithm `math.dist`
+  executes; it sits above `HYPOT` by the per-coordinate subtraction work its
+  offset carries
+- **Weight measurement:** [the machine code behind the `DIST` weight](machine_code/dist.md)
+
+## FlopType.DIST_XARG (`dist(p, q)`, 3+ dimensions) { #flop-dist-xarg }
+
+- Relevant CPU instructions
+    - **ARM:** (software)
+    - **x86:** (software)
+- **Counted Python operations:** one per dimension beyond the second of a
+  `math.dist` call: an n-dimensional call counts `DIST` + (n−2) `DIST_XARG`
+- **Not counted:** 1- and 2-dimensional calls (they cost the base `DIST` alone)
+- **Weight measurement:** [the machine code behind the `DIST_XARG` weight](machine_code/dist_xarg.md)
 
 ## FlopType.EXPM1 (`expm1(x)`) { #flop-expm1 }
 

--- a/docs/machine_code/dist.md
+++ b/docs/machine_code/dist.md
@@ -8,6 +8,9 @@ dimensionality. The probe hand-rolls the scaled algorithm a faithful `math.dist`
 executes: per-coordinate deltas, scaling by the largest magnitude so no square overflows, then
 `sqrt` and rescale. Why the overflow-safe flavor is the one being priced is covered in the [benchmark design rationale](../analysis_methodology.md#16-benchmark-design-rationale).
 
+What Python code counts into `DIST` is described in
+[FLOP types](../flop_types.md#flop-dist).
+
 ## Inner-loop diff
 
 <!-- BEGIN generated: machine-code-dist-diff -->

--- a/docs/machine_code/dist_xarg.md
+++ b/docs/machine_code/dist_xarg.md
@@ -7,6 +7,9 @@ construction as [HYPOT_XARG](hypot_xarg.md): the two sides are the same algorith
 so the diff is expected to be large — what must hold is that every added line belongs to the six
 extra coordinates, and nothing shared changed shape. Why the slope is measured on a hand-rolled overflow-safe port is covered in the [benchmark design rationale](../analysis_methodology.md#16-benchmark-design-rationale).
 
+What Python code counts into `DIST_XARG` is described in
+[FLOP types](../flop_types.md#flop-dist-xarg).
+
 ## Inner-loop diff
 
 <!-- BEGIN generated: machine-code-dist-xarg-diff -->

--- a/docs/machine_code/hypot_xarg.md
+++ b/docs/machine_code/hypot_xarg.md
@@ -7,6 +7,9 @@ an **arity-scaled pair**: the two sides are not "same loop ± one instruction" b
 algorithm at two sizes, so the diff is expected to be large — what must hold is that every added
 line belongs to the six extra coordinates and their scaling, and nothing shared changed shape. Why the slope is measured on a hand-rolled overflow-safe port is covered in the [benchmark design rationale](../analysis_methodology.md#16-benchmark-design-rationale).
 
+What Python code counts into `HYPOT_XARG` is described in
+[FLOP types](../flop_types.md#flop-hypot-xarg).
+
 ## Inner-loop diff
 
 <!-- BEGIN generated: machine-code-hypot-xarg-diff -->

--- a/docs/math_patching.md
+++ b/docs/math_patching.md
@@ -67,8 +67,8 @@ Every commonly used `math` function, and how it participates in counting:
 
 | Coverage | Functions |
 |---|---|
-| **Instrumented** (patched, counts its FlopType) | `sqrt`, `cbrt`, `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `pow`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `hypot`, `fmod`, `fabs`, `copysign`, `fma` (Python 3.13+) |
-| **Instrumented, counted as a decomposition** (patched, counts the flops a compiled port would execute) | `degrees` / `radians` → MUL; `dist` → n SUB + n MUL + (n−1) ADD + SQRT; `prod` → one MUL per chained multiply; `fsum` → (n−1) ADD; n-ary `hypot` → per arity (2 → HYPOT, 3+ → the naive norm, 1 → ABS) |
+| **Instrumented** (patched, counts its FlopType) | `sqrt`, `cbrt`, `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `pow`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `hypot` (+ `HYPOT_XARG` per coordinate beyond the second), `dist` (+ `DIST_XARG` likewise), `fmod`, `fabs`, `copysign`, `fma` (Python 3.13+) |
+| **Instrumented, counted as a decomposition** (patched, counts the flops a compiled port would execute) | `degrees` / `radians` → MUL; `prod` → one MUL per chained multiply; `fsum` → (n−1) ADD; 1-argument `hypot` → ABS |
 | **Counted via dunder** (no patch needed — do not expect these in the patch list) | `math.floor` / `math.ceil` / `math.trunc` → F2I through `__floor__`/`__ceil__`/`__trunc__`; the builtins `abs()` → ABS and `round()` → RND/F2I likewise count through their dunders |
 | **Not instrumented** (returns a plain, uncounted `float`) | `remainder`, `frexp`, `ldexp`, `modf`, `gamma`, `lgamma`, `erf`, `erfc`, `nextafter`, `ulp`, `sumprod` (Python 3.12+) |
 | **Predicates** (uncounted, return a `bool`) | `isnan`, `isinf`, `isfinite`, `isclose` |

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -357,16 +357,12 @@ def math_atan2(y: float, x: float) -> float | CountedFloat:
 def math_hypot(*coordinates: float) -> float | CountedFloat:
     """Patch math.hypot: stdlib contract (n-ary since Python 3.8), counted per arity.
 
-    Each arity models the code a compiled port would emit — the same port-fidelity rule as
-    math_dist's naive decomposition:
-      - 2 coordinates  -> HYPOT: the libm hypot(x, y) call the source explicitly made (and what
-                          the HYPOT weight is benchmarked from)
-      - 3+ coordinates -> n MUL + (n-1) ADD + SQRT: C has no n-ary hypot, so a port writes the
-                          loop
+    Counted as the real overflow-safe algorithm the call executes, at every arity:
+      - 2+ coordinates -> HYPOT + (n-2) HYPOT_XARG: the benchmarked 2-argument base cost plus
+                          the measured per-extra-coordinate slope of the scaled algorithm
       - 1 coordinate   -> ABS: it computes |x|, and a port emits fabs
-    Accepted asymmetry, deliberate: 2-D dist counts SUB + naive norm while hypot(dx, dy) counts
-    a single HYPOT — different prices for the same mathematics, because they model different
-    emitted code.
+    A 2-argument call counts exactly one HYPOT, unchanged from when that was the only
+    benchmarked form.
     """
     if not any(isinstance(c, CountedFloat) for c in coordinates):
         return original_math_hypot(*coordinates)
@@ -378,12 +374,10 @@ def math_hypot(*coordinates: float) -> float | CountedFloat:
         cnt: CountsTarget = _create_thread_state()
     if n == 1:
         cnt.ABS += 1
-    elif n == 2:
-        cnt.HYPOT += 1
     else:
-        cnt.MUL += n
-        cnt.ADD += n - 1
-        cnt.SQRT += 1
+        cnt.HYPOT += 1
+        if n > 2:
+            cnt.HYPOT_XARG += n - 2
     return float.__new__(CountedFloat, result)
 
 
@@ -515,12 +509,13 @@ def math_radians(x: float) -> float | CountedFloat:
 
 
 def math_dist(p: Iterable[float], q: Iterable[float]) -> float | CountedFloat:
-    """Patch math.dist: stdlib contract, counted as the naive Euclidean loop a port would write.
+    """Patch math.dist: stdlib contract, counted as the overflow-safe algorithm it executes.
 
-    Counted as n SUB + n MUL + (n-1) ADD + SQRT for n-dimensional inputs — deliberately not
-    routed through HYPOT: a compiled port of n-dimensional distance is a loop plus sqrt, not a
-    hypot call. Iterator inputs are materialized up front (the stdlib accepts them too), so the
-    coordinates can be inspected after computing the result.
+    Counted as DIST + (n-2) DIST_XARG for n-dimensional inputs: the benchmarked 2-D base cost
+    (which carries the per-coordinate subtractions in its offset) plus the measured
+    per-extra-coordinate slope. 1-D inputs count the base cost alone. Iterator inputs are
+    materialized up front (the stdlib accepts them too), so the coordinates can be inspected
+    after computing the result.
     """
     p_seq = list(p)
     q_seq = list(q)
@@ -533,10 +528,9 @@ def math_dist(p: Iterable[float], q: Iterable[float]) -> float | CountedFloat:
         cnt: CountsTarget = _TLS.flop_counts
     except AttributeError:  # first counted op on this thread
         cnt: CountsTarget = _create_thread_state()
-    cnt.SUB += n
-    cnt.MUL += n
-    cnt.ADD += n - 1
-    cnt.SQRT += 1
+    cnt.DIST += 1
+    if n > 2:
+        cnt.DIST_XARG += n - 2
     return float.__new__(CountedFloat, result)
 
 

--- a/tests/counting/test_math_patching.py
+++ b/tests/counting/test_math_patching.py
@@ -412,7 +412,7 @@ def test_degrees_radians_count_one_mul(thread_counter, fname):
 
 
 @pytest.mark.parametrize("n_dims", [1, 2, 3, 5])
-def test_dist_counts_the_naive_euclidean_decomposition(thread_counter, n_dims):
+def test_dist_counts_the_arity_scaled_types(thread_counter, n_dims):
     # --- arrange -----------------------------------------
     p = [CountedFloat(float(i)) for i in range(n_dims)]
     q = [float(2 * i + 1) for i in range(n_dims)]
@@ -422,10 +422,9 @@ def test_dist_counts_the_naive_euclidean_decomposition(thread_counter, n_dims):
 
     # --- assert ------------------------------------------
     assert isinstance(result, CountedFloat)
-    assert n_dims == thread_counter.SUB
-    assert n_dims == thread_counter.MUL
-    assert n_dims - 1 == thread_counter.ADD
-    assert thread_counter.SQRT == 1
+    assert thread_counter.DIST == 1
+    assert max(0, n_dims - 2) == thread_counter.DIST_XARG
+    assert thread_counter.total_count() == 1 + max(0, n_dims - 2)
 
 
 def test_dist_accepts_iterator_inputs_and_mismatched_lengths_raise(thread_counter):
@@ -436,7 +435,7 @@ def test_dist_accepts_iterator_inputs_and_mismatched_lengths_raise(thread_counte
 
     with pytest.raises(ValueError):  # noqa: PT011 -- stdlib wording ("both points must have the same dimension")
         math.dist([CountedFloat(1.0)], [1.0, 2.0])
-    assert thread_counter.SQRT == 1  # only the successful call above counted anything
+    assert thread_counter.DIST == 1  # only the successful call above counted anything
 
 
 @pytest.mark.parametrize("n_values", [1, 2, 4])
@@ -513,8 +512,8 @@ def test_copysign_counts_its_own_flop_type(thread_counter):
     [
         (1, {"ABS": 1}),  # |x|: a port emits fabs
         (2, {"HYPOT": 1}),  # the libm hypot(x, y) call, as benchmarked
-        (3, {"MUL": 3, "ADD": 2, "SQRT": 1}),  # no n-ary hypot in C: a port writes the loop
-        (5, {"MUL": 5, "ADD": 4, "SQRT": 1}),
+        (3, {"HYPOT": 1, "HYPOT_XARG": 1}),  # base cost + measured per-extra-coordinate slope
+        (5, {"HYPOT": 1, "HYPOT_XARG": 3}),
     ],
 )
 def test_hypot_counts_per_arity(thread_counter, n_args, expected):


### PR DESCRIPTION
The data-gated counting flip for the arity-scaled types, unblocked by the dataset re-collection: `math.dist` counts `DIST + (n−2)·DIST_XARG` and 3+-argument `math.hypot` counts `HYPOT + (n−2)·HYPOT_XARG` — both measured on the real overflow-safe algorithm the calls execute. The 2-argument `hypot` still counts exactly one `HYPOT` and 1-argument still counts `ABS`, so existing counts only change where the old decomposed chains applied.

Docs follow: the last two known-deviation markers come out of the cost-model page (none remain), flop_types gains sections for `HYPOT_XARG`/`DIST`/`DIST_XARG` cross-linked with their machine-code pages, and the instruction-level-parallelism caveat now cites these weights as the case where internal overlap *is* measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)