### PR TITLE
feat: count math.sumprod via the arity-scaled flop types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - the trig (sin/cos/tan/atan/atan2) and asinh/acosh benchmarks now draw their inputs from general-case argument ranges, instead of extreme magnitudes that priced a costlier or cheaper special regime
 - re-collected the built-in flop-weight dataset across all automatically reachable CPUs (12 EC2 instance types and 5 CI runners), shipping real weights for every measured flop type — including the new hypot/dist arity, special-function, remainder and sumprod types; the Linux x86 CI runner's silicon changed from Intel Emerald Rapids to AMD EPYC 9V74, swapping that source 1-for-1
 - `math.dist` and 3+-argument `math.hypot` are now counted as per-call + per-extra-coordinate flop types measured on the real overflow-safe algorithm, instead of decomposed flop chains
-- `math.gamma`, `math.lgamma`, `math.erf`, `math.erfc` and `math.remainder` are now counted; the uninstrumented remainder of the `math` module is exactly the float-representation helpers and `sumprod`
+- `math.gamma`, `math.lgamma`, `math.erf`, `math.erfc` and `math.remainder` are now counted; the uninstrumented remainder of the `math` module is exactly the float-representation helpers
+- `math.sumprod` is now counted, as a per-call + per-extra-element price measured on the extended-precision algorithm it really runs
 
 ### Deprecated
 
@@ -37,7 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `math.sumprod` on counted values now computes the same extended-precision result as on plain floats, and no longer silently miscounts it as a naive multiply-add chain
 - `show-data` group headers are now legible on every terminal theme; the docs' screenshots and data-derived content are now regenerated from live output and drift-tested
-- verbosity level `WARNING` now also reports uncounted `math.sumprod` calls (Python 3.12+), which were previously missed entirely
 
 ### Security
 

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -154,9 +154,10 @@ estimates rather than expected latencies. The current model prices a
 decomposed operation identically to its hand-written expansion and does not
 model the overlap; how much of that internal parallelism a weight *should*
 capture is a modeling choice, not a law of the counting model.
-(`math.dist` and n-ary `math.hypot` are the counterexamples: their
-arity-scaled weights are measured on the real algorithm, internal overlap
-included.) Counts themselves are unaffected; this nuance
+(`math.dist`, n-ary `math.hypot` and `math.sumprod` are the counterexamples:
+their arity-scaled weights are measured on the real algorithm, internal
+overlap included — most starkly `sumprod`, whose ~24-instruction compensated
+per-element sequence prices at a few ADDs because its lanes overlap.) Counts themselves are unaffected; this nuance
 applies only to the weighted totals.
 
 Weights are also **normalized**: every cost is expressed relative to the ADD

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -52,7 +52,7 @@ documented fallback) are stated in [Cost-model principles](cost_model.md).
 | `math.dist(p, q)` | `DIST` + (n−2) `DIST_XARG` | patch | benchmarked | yes |
 | `math.prod(xs)` | one `MUL` per chained multiply *(decomposed)* | patch | — | yes |
 | `math.fsum(xs)` | (n−1) `ADD` *(decomposed; compensation machinery not modeled)* | patch | — | yes |
-| `math.sumprod(p, q)` (3.12+) | *(uncounted; delegated on plain floats so the extended-precision algorithm runs)* | patch | — | no |
+| `math.sumprod(p, q)` (3.12+) | `SUMPROD` + (n−2) `SUMPROD_XELEM` | patch | benchmarked | yes |
 | `numpy.*` and other non-stdlib math | *(uncounted)* | — | — | no |
 
 - **Mechanism** — *operator*: a `CountedFloat` dunder, counted everywhere.
@@ -426,6 +426,37 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
   `math.dist` call: an n-dimensional call counts `DIST` + (n−2) `DIST_XARG`
 - **Not counted:** 1- and 2-dimensional calls (they cost the base `DIST` alone)
 - **Weight measurement:** [the machine code behind the `DIST_XARG` weight](machine_code/dist_xarg.md)
+
+## FlopType.SUMPROD (`sumprod(p,q)`) { #flop-sumprod }
+
+- Relevant CPU instructions
+    - **ARM:** (software)
+    - **x86:** (software)
+- **Counted Python operations:** `math.sumprod(p, q)` (Python 3.12+) for
+  `CountedFloat` — counted once per call when *any* element is a
+  `CountedFloat`; elements beyond the second each add a
+  [`SUMPROD_XELEM`](#flop-sumprod-xelem)
+- **Not counted:** `sumprod` on plain floats only, `numpy.dot` and friends
+- **Note:** the 2-element base price (close-out included) of the
+  extended-precision (TripleLength) accumulation `math.sumprod` executes;
+  counted inputs are unboxed to plain floats before delegating, so the
+  exact-float production algorithm runs — a `CountedFloat` element would
+  otherwise silently reroute the call to a naive object path
+- **Weight measurement:** [the machine code behind the `SUMPROD` weight](machine_code/sumprod.md)
+
+## FlopType.SUMPROD_XELEM (`sumprod(p,q)`, 3+ elements) { #flop-sumprod-xelem }
+
+- Relevant CPU instructions
+    - **ARM:** (software)
+    - **x86:** (software)
+- **Counted Python operations:** one per element beyond the second of a
+  `math.sumprod` call: an n-element call counts `SUMPROD` + (n−2)
+  `SUMPROD_XELEM`
+- **Not counted:** 1- and 2-element calls (they cost the base `SUMPROD` alone)
+- **Note:** far below the per-element cost a decomposed compensation chain
+  would suggest — the algorithm's lanes overlap, and the measured slope
+  captures that overlap
+- **Weight measurement:** [the machine code behind the `SUMPROD_XELEM` weight](machine_code/sumprod_xelem.md)
 
 ## FlopType.EXPM1 (`expm1(x)`) { #flop-expm1 }
 

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -24,12 +24,9 @@ counted region.
 
 ## Other limitations
 
-- a few Python built-in math operations remain uncounted — the
+- the only uncounted Python built-in math operations are the
   float-representation helpers (`frexp`, `ldexp`, `modf`, `nextafter`,
-  `ulp`), which manipulate rather than compute, and `sumprod`
-  (Python 3.12+), whose counted inputs are unboxed so its
-  extended-precision algorithm runs (the result is exact but plain and
-  uncounted); see the
+  `ulp`), which manipulate rather than compute; see the
   [`math` coverage table](math_patching.md#coverage-of-the-math-module) for
   the full per-function status and the
   [FLOP types reference](flop_types.md) for per-operation counting rules. A

--- a/docs/machine_code/sumprod.md
+++ b/docs/machine_code/sumprod.md
@@ -12,6 +12,9 @@ The compensated sequence has real instruction-level parallelism (only the hi-lan
 accumulation is serial), which is why the cost is measured on the whole algorithm rather than
 decomposed into a per-operation chain — see [Cost-model principles](../cost_model.md).
 
+What Python code counts into `SUMPROD` is described in
+[FLOP types](../flop_types.md#flop-sumprod).
+
 ## Inner-loop diff
 
 <!-- BEGIN generated: machine-code-sumprod-diff -->

--- a/docs/machine_code/sumprod_xelem.md
+++ b/docs/machine_code/sumprod_xelem.md
@@ -9,6 +9,9 @@ every added line belongs to the six extra elements, and nothing shared changed s
 probes port CPython's compensated (TripleLength) accumulation, error terms emitted through
 the `llvm.fma` intrinsic — see the [SUMPROD page](sumprod.md) for the algorithm.
 
+What Python code counts into `SUMPROD_XELEM` is described in
+[FLOP types](../flop_types.md#flop-sumprod-xelem).
+
 ## Inner-loop diff
 
 <!-- BEGIN generated: machine-code-sumprod-xelem-diff -->

--- a/docs/math_patching.md
+++ b/docs/math_patching.md
@@ -67,10 +67,10 @@ Every commonly used `math` function, and how it participates in counting:
 
 | Coverage | Functions |
 |---|---|
-| **Instrumented** (patched, counts its FlopType) | `sqrt`, `cbrt`, `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `pow`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `hypot` (+ `HYPOT_XARG` per coordinate beyond the second), `dist` (+ `DIST_XARG` likewise), `fmod`, `remainder`, `gamma`, `lgamma`, `erf`, `erfc`, `fabs`, `copysign`, `fma` (Python 3.13+) |
+| **Instrumented** (patched, counts its FlopType) | `sqrt`, `cbrt`, `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `pow`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `hypot` (+ `HYPOT_XARG` per coordinate beyond the second), `dist` (+ `DIST_XARG` likewise), `fmod`, `remainder`, `gamma`, `lgamma`, `erf`, `erfc`, `fabs`, `copysign`, `fma` (Python 3.13+), `sumprod` (Python 3.12+; + `SUMPROD_XELEM` per element beyond the second — counted inputs are unboxed so the extended-precision algorithm runs) |
 | **Instrumented, counted as a decomposition** (patched, counts the flops a compiled port would execute) | `degrees` / `radians` → MUL; `prod` → one MUL per chained multiply; `fsum` → (n−1) ADD; 1-argument `hypot` → ABS |
 | **Counted via dunder** (no patch needed — do not expect these in the patch list) | `math.floor` / `math.ceil` / `math.trunc` → F2I through `__floor__`/`__ceil__`/`__trunc__`; the builtins `abs()` → ABS and `round()` → RND/F2I likewise count through their dunders |
-| **Not instrumented** (returns a plain, uncounted `float`) | the float-representation helpers — `frexp`, `ldexp`, `modf`, `nextafter`, `ulp` — plus `sumprod` (Python 3.12+), which *is* patched: counted inputs are unboxed to plain floats so CPython's extended-precision path runs (a `CountedFloat` element would silently reroute it to the naive object path), but the result stays plain and uncounted |
+| **Not instrumented** (returns a plain, uncounted `float`) | exactly the float-representation helpers — `frexp`, `ldexp`, `modf`, `nextafter`, `ulp` |
 | **Predicates** (uncounted, return a `bool`) | `isnan`, `isinf`, `isfinite`, `isclose` |
 
 The not-instrumented set breaks contagion: the plain-`float` result silently

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -654,26 +654,34 @@ def math_fsum(seq: Iterable[float]) -> float | CountedFloat:
 
 
 def math_sumprod(p: Iterable[float], q: Iterable[float], /) -> object:
-    """Patch math.sumprod: unbox counted values so the extended-precision path runs; uncounted.
+    """Patch math.sumprod: stdlib contract, counted as the extended-precision algorithm it runs.
 
-    CPython's compensated (TripleLength) accumulation is gated on exact-float elements, so a
-    CountedFloat anywhere in the inputs silently reroutes the whole call to the generic object
-    path -- computing the *naive* sum of products. Unboxing to plain floats before delegating
-    restores the production algorithm and its extended-precision result. The result is
-    deliberately a plain float and nothing is counted: sumprod's cost cannot be expressed in
-    the decomposed flop types (its compensation has real instruction-level parallelism), so
-    the call is reported as uncounted at WARNING verbosity instead. Both iterables are
-    materialized up front (the stdlib accepts one-shot iterators too) so the elements can be
-    inspected.
+    CPython's compensated (TripleLength) accumulation is gated on exact-float elements, so
+    counted inputs are unboxed to plain floats before delegating -- a CountedFloat anywhere in
+    the inputs would silently reroute the whole call to the generic object path, computing the
+    *naive* sum of products. Counted as SUMPROD + (n-2) SUMPROD_XELEM for n-element inputs:
+    the benchmarked 2-element base (close-out included) plus the measured per-extra-element
+    slope; a 1-element call counts the base alone. Both iterables are materialized up front
+    (the stdlib accepts one-shot iterators too), and inputs without any CountedFloat are
+    delegated to the original wholesale (preserving its int-exactness and fast paths).
     """
     p_values = list(p)
     q_values = list(q)
-    if any(isinstance(v, CountedFloat) for v in (*p_values, *q_values)):
-        if thread_is_reporting():
-            warn_uncounted_call("sumprod", _BREAKS_CONTAGION)
-        p_values = [float(v) if isinstance(v, CountedFloat) else v for v in p_values]
-        q_values = [float(v) if isinstance(v, CountedFloat) else v for v in q_values]
-    return original_math_sumprod(p_values, q_values)
+    if not any(isinstance(v, CountedFloat) for v in (*p_values, *q_values)):
+        return original_math_sumprod(p_values, q_values)
+    p_plain = [float(v) if isinstance(v, CountedFloat) else v for v in p_values]
+    q_plain = [float(v) if isinstance(v, CountedFloat) else v for v in q_values]
+    # computed first: raises per stdlib contract (unequal lengths, non-numbers) before counting
+    result = original_math_sumprod(p_plain, q_plain)
+    n = len(p_values)
+    try:
+        cnt: CountsTarget = _TLS.flop_counts
+    except AttributeError:  # first counted op on this thread
+        cnt: CountsTarget = _create_thread_state()
+    cnt.SUMPROD += 1
+    if n > 2:
+        cnt.SUMPROD_XELEM += n - 2
+    return float.__new__(CountedFloat, result)
 
 
 def math_copysign(x: float, y: float) -> float | CountedFloat:
@@ -739,8 +747,6 @@ def _make_uncounted_wrapper(name: str, consequence: str) -> Callable[..., object
 # Kept out of _PATCHES deliberately: these are installed only while some thread is reporting (see
 # apply_uncounted_math_patches), so a run at the default verbosity leaves these functions exactly
 # as it found them rather than routing every call through a replacement that has nothing to say.
-# math.sumprod is not among them: unboxing its counted elements matters for the computed *value*,
-# so its replacement lives in _PATCHES and is installed whenever counting is (see math_sumprod).
 _UNCOUNTED_PATCHES: dict[str, Callable[..., object]] = {
     name: _make_uncounted_wrapper(name, consequence) for name, consequence in _UNCOUNTED_MATH.items()
 }

--- a/tests/counting/test_math_patching.py
+++ b/tests/counting/test_math_patching.py
@@ -536,7 +536,7 @@ def test_hypot_counts_per_arity(thread_counter, n_args, expected):
 
 
 # =================================================================================================
-#  Patched math functions - sumprod (unboxed delegation, deliberately uncounted)
+#  Patched math functions - sumprod (unboxed delegation, arity-scaled counting)
 # =================================================================================================
 needs_sumprod = pytest.mark.skipif(not hasattr(math, "sumprod"), reason="math.sumprod exists from Python 3.12")
 
@@ -557,19 +557,37 @@ def test_sumprod_computes_the_extended_precision_result_for_counted_inputs(threa
     result = math.sumprod(p, q)
 
     # --- assert ------------------------------------------
-    assert result == 1.0
-    assert type(result) is float, "the result deliberately breaks contagion"
-    assert thread_counter.total_count() == 0, "sumprod is reported at WARNING verbosity, never counted"
+    assert float(result) == 1.0
+    assert isinstance(result, CountedFloat)
 
 
 @needs_sumprod
-def test_sumprod_accepts_one_shot_iterators(thread_counter):
+@pytest.mark.parametrize(("n_elements", "expected_xelem"), [(1, 0), (2, 0), (3, 1), (8, 6)])
+def test_sumprod_counts_the_arity_scaled_types(thread_counter, n_elements, expected_xelem):
+    # --- arrange -----------------------------------------
+    p = [CountedFloat(float(i + 1)) for i in range(n_elements)]
+    q = [float(2 * i + 1) for i in range(n_elements)]
+
     # --- act ---------------------------------------------
-    result = math.sumprod((CountedFloat(v) for v in (1.0, 2.0)), (v for v in (3.0, 4.0)))
+    result = math.sumprod(p, q)
 
     # --- assert ------------------------------------------
-    assert result == 11.0
-    assert thread_counter.total_count() == 0
+    assert isinstance(result, CountedFloat)
+    assert thread_counter.SUMPROD == 1
+    assert expected_xelem == thread_counter.SUMPROD_XELEM
+    assert thread_counter.total_count() == 1 + expected_xelem
+
+
+@needs_sumprod
+def test_sumprod_accepts_one_shot_iterators_and_mismatched_lengths_raise(thread_counter):
+    # --- act / assert ------------------------------------
+    result = math.sumprod((CountedFloat(v) for v in (1.0, 2.0)), (v for v in (3.0, 4.0)))
+    assert float(result) == 11.0
+    assert isinstance(result, CountedFloat)
+
+    with pytest.raises(ValueError):  # noqa: PT011 -- stdlib wording ("inputs are not the same length")
+        math.sumprod([CountedFloat(1.0)], [1.0, 2.0])
+    assert thread_counter.SUMPROD == 1  # only the successful call above counted anything
 
 
 @needs_sumprod

--- a/tests/counting/verbosity/test_uncounted_warnings.py
+++ b/tests/counting/verbosity/test_uncounted_warnings.py
@@ -43,19 +43,17 @@ def test_a_counted_value_in_a_keyword_argument_is_reported(logged_lines):
 
 
 @pytest.mark.skipif(not hasattr(math, "sumprod"), reason="math.sumprod exists from Python 3.12")
-def test_sumprod_with_one_shot_iterators_is_reported_and_computes_correctly(logged_lines):
-    # --- arrange -----------------------------------------
-    p = (CountedFloat(v) for v in (1.0, 2.0))  # generators: the wrapper must not consume them twice
-    q = (v for v in (3.0, 4.0))
-
+def test_sumprod_is_counted_not_reported(logged_lines):
+    # sumprod graduated from the uncounted list: at WARNING verbosity (which stays silent about
+    # counted flops) a counted sumprod call must produce no report at all
     # --- act ---------------------------------------------
-    with FlopCountingContext(verbosity=Verbosity.WARNING):
-        result = math.sumprod(p, q)
+    with FlopCountingContext(verbosity=Verbosity.WARNING) as ctx:
+        result = math.sumprod((CountedFloat(v) for v in (1.0, 2.0)), (v for v in (3.0, 4.0)))
 
     # --- assert ------------------------------------------
-    (line,) = logged_lines()
-    assert line.split()[:2] == ["WARN", "sumprod"]
-    assert result == 11.0
+    assert logged_lines() == []
+    assert float(result) == 11.0
+    assert ctx.flop_counts().SUMPROD == 1
 
 
 def test_a_call_without_counted_values_is_not_reported(logged_lines):


### PR DESCRIPTION
The last counting flip, unblocked by the dataset re-collection: `math.sumprod` now counts `SUMPROD` + (n−2) `SUMPROD_XELEM` — the benchmarked 2-element base plus the measured per-extra-element slope — and its result is a `CountedFloat` again. Counted inputs are still unboxed to plain floats before delegating, so CPython's extended-precision algorithm keeps running; the call leaves the WARNING-verbosity uncounted list.

With this, the uninstrumented remainder of the `math` module is exactly the float-representation helpers (`frexp`/`ldexp`/`modf`/`nextafter`/`ulp`), and the coverage tables, flop-type sections and known-limitations text now say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
