### PR TITLE
docs: pin the cost model's reference-toolchain semantics

### DIFF
--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -6,11 +6,48 @@ Every flop weight and every counting decision in `counted-float` answers the sam
 executes). This page states the rules used to pick one, so that every pricing choice in the
 package can name the rule it follows — and the few that deviate can say so explicitly.
 
-One convention underlies everything below: in counted code, a **plain `float` operand is a
-compile-time [constant](glossary.md#constant)** — something the hypothetical compiled
-program would know while being compiled — while a **`CountedFloat` operand is dynamic
-algorithm input**. Rules that depend on an operand being constant (strength reduction,
-reciprocal multiplication) key on exactly this distinction.
+## How the imaginary port gets made
+
+Two conventions anchor every rule below.
+
+**First: in counted code, a plain `float` operand is a compile-time
+[constant](glossary.md#constant)** — something the imaginary compiled program would know
+while being compiled — while a **`CountedFloat` operand is dynamic algorithm input**.
+Rules that treat constants specially (strength reduction, reciprocal multiplication) key
+on exactly this distinction.
+
+**Second: the port is made in two stages, by two different actors, playing by two
+different rules.**
+
+- **The author** — a competent numerical programmer — rewrites the Python code in C. The
+  author sees the constants in the source and makes the choices working numerical code
+  makes: faced with `x ** 5`, they write the square-and-multiply chain
+  (`x2 = x*x; x4 = x2*x2; x4*x`) rather than calling `pow(x, 5.0)`, because that is how
+  performance-conscious C code raises to a small constant power. There is no
+  bit-exactness bar to clear at this stage, because none *exists*: even the "obvious"
+  port that calls libm's `pow` gets different last bits on glibc, Apple's libm and
+  Microsoft's UCRT. What the author owes is **algorithmic faithfulness** — the same
+  mathematical computation, written the way such code is really written. Every judgment
+  call the author is assumed to make is declared in the rules below, together with its
+  bound (for exponent chains, `|n| ≤ 16`): a stated, bounded persona — not a claim about
+  what all programmers everywhere would do.
+- **The compiler** then translates that C source into machine code, and its rule *is*
+  mechanical bit-exactness: it may rewrite the source's arithmetic only when the rewrite
+  provably never changes any computed value. Replacing `x / 8.0` by `x * 0.125` qualifies
+  — the reciprocal is exact, so every result is bit-identical. Fusing `x*y + z` into a
+  single fused multiply-add does not: the fused form rounds once where the source rounds
+  twice — faster, and slightly *different*. One subtlety is pinned explicitly: on some
+  CPUs (notably 64-bit ARM) compilers apply that fusion **by default** at ordinary
+  optimization levels, no fast-math flag involved — the model's compiler has it switched
+  off (`-ffp-contract=off`), so the priced instruction stream is the same on every
+  architecture.
+
+Every pricing decision below is an application of one question: **who produced this
+operation — the author, writing it into the source, or the compiler, translating the
+source?** Author-written operations are priced as written; compiler rewrites are admitted
+only when bit-exact. Whenever the rules mention what real compilers do at plain `-O2`,
+that is *corroboration* that an admitted rewrite is real-world practice — never the
+admission criterion itself.
 
 ## The rules
 
@@ -20,20 +57,52 @@ as a value-preserving [compiled port](glossary.md#compiled-port).**
 - **1.1** *(scope)* — covers arithmetic written in operators (`+`, `*`, `%`,
   `round(x, n)`, ...) *and* the named calls that reduce to single instructions
   (`math.sqrt` → `FSQRT`, `abs`/`math.fabs` → `FABS`, `math.copysign`).
-- **1.2** *(definition)* — "value-preserving" means the port must produce bit-identical
-  results; transformations a compiler only applies under fast-math flags are out.
-- **1.3** *(consequence)* — no FP [contraction](glossary.md#fp-contraction): `x*y + z`
-  counts MUL + ADD, not FMA — fusing changes rounding.
-- **1.4** *(consequence)* — [strength reduction](glossary.md#strength-reduction) applies
-  only where the reduced form is value-identical *and* is what a standard-C port genuinely
-  emits.
+- **1.2** *(definition)* — "value-preserving" is the compiler-stage rule from above: the
+  emitted machine code computes exactly the values the authored source defines. Any
+  rewrite that changes a computed value — whatever fast-math flag or platform default
+  would enable it — is out.
+- **1.3** *(consequence)* — no [FP contraction](glossary.md#fp-contraction): `x*y + z`
+  counts MUL + ADD, not FMA, because fusing is a compiler rewrite that changes values —
+  excluded even where it is a platform default (see
+  [known limitations](known_limitations.md) for what this over-estimates on real builds).
+  The one way to have a fused multiply-add *counted* is to write one: `math.fma(x, y, z)`
+  (Python 3.13+) is the author explicitly asking for the fused operation. `fma` can carry
+  that meaning because it is special in exactly one way: it has no operator spelling, so
+  writing the call is unambiguous intent.
+- **1.4** *(consequence)* — [strength reduction](glossary.md#strength-reduction) comes in
+  both stages, and the stage decides the test. Bit-exact reductions (`x / 8.0` →
+  `x * 0.125`, `x ** 2` → `x * x`) are compiler rewrites, admitted by 1.2. Value-changing
+  reductions can only enter as author decisions, declared case by case in the rules below
+  — never silently.
 - **1.5** *(example)* — constant exponents: `x ** 2` → MUL, `2 ** x` → C99 `exp2`; but
-  `10 ** x` → `pow(10, x)`, since `exp10` is not standard C.
+  `10 ** x` → `pow(10, x)`, since `exp10` is not standard C. The square-and-multiply
+  chain for `3 ≤ |n| ≤ 16` is the canonical *author* decision: no bit-identity to libm's
+  `pow` is owed, because nothing was rewritten — the chain **is** the source the author
+  wrote (real compilers agree it is not theirs to make: they only expand `pow` with
+  constant exponents beyond 2 under fast-math flags). The `|n| ≤ 16` cutoff bounds the
+  claim to exponents where hand-written chains are genuinely how such code gets written;
+  beyond it the author calls `pow`, and the generic POW price applies. The reduction keys
+  on the constant's *value*, never on the spelling: `math.pow(x, 5.0)` and `x ** 5` are
+  two spellings of the same intent and price identically.
 - **1.6** *(example)* — reciprocal multiplication for division only where it is exact: a
   power-of-two constant divisor with a finite reciprocal — there, and only there,
   `x * (1/c)` is bit-identical to `x / c`, and compilers apply the fold at plain `-O2` —
   so `x / c` counts MUL for exactly those divisors, and DIV for every other. The one
   stronger fold: `x / 1.0` disappears entirely and counts nothing, like `x ** 1`.
+- **1.7** *(example)* — the compiler-stage test also admits the identity folds for
+  constant operands: `x * 1.0` and `x - 0.0` fold away entirely, and so does `x + (-0.0)`
+  (exact for every `x`); `x * -1.0`, `x / -1.0` and `(-0.0) - x` reduce to a bare sign
+  flip and count MINUS. The test is sharp, not sloppy — the near-misses stay counted
+  because a signed zero makes them value-*changing*: `x + 0.0` counts ADD (for
+  `x = -0.0` the result is `+0.0`, not `x`), `x - (-0.0)` counts SUB (it *is*
+  `x + 0.0`), and `0.0 - x` counts SUB (`0.0 - 0.0` gives `+0.0`, where a sign flip
+  would give `-0.0`). Inside the decomposed operations the same folds apply to the
+  division step: a power-of-two constant divisor turns `x // c`'s and `x % c`'s DIV
+  component into MUL.
+  *Known deviation: the folds of this bullet are not yet implemented — counted-float
+  currently counts `x * 1.0` and `x * -1.0` as MUL, `x - 0.0` and `(-0.0) - x` as SUB,
+  `x + (-0.0)` as ADD, `x / -1.0` as MUL (via 1.6), and the decompositions' division step
+  as DIV regardless of the divisor.*
 
 **Rule 2 — operations that compile to a library call are priced as the call's real
 algorithm, contract included.**

--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -16,8 +16,8 @@ while being compiled — while a **`CountedFloat` operand is dynamic algorithm i
 Rules that treat constants specially (strength reduction, reciprocal multiplication) key
 on exactly this distinction.
 
-**Second: the port is made in two stages, by two different actors, playing by two
-different rules.**
+**Second: the [port](glossary.md#compiled-port) is made in two stages, by two different
+actors, playing by two different rules.**
 
 - **The author** — a competent numerical programmer — rewrites the Python code in C. The
   author sees the constants in the source and makes the choices working numerical code
@@ -38,9 +38,9 @@ different rules.**
   single fused multiply-add does not: the fused form rounds once where the source rounds
   twice — faster, and slightly *different*. One subtlety is pinned explicitly: on some
   CPUs (notably 64-bit ARM) compilers apply that fusion **by default** at ordinary
-  optimization levels, no fast-math flag involved — the model's compiler has it switched
-  off (`-ffp-contract=off`), so the priced instruction stream is the same on every
-  architecture.
+  optimization levels, no fast-math flag involved — the model's assumed compiler has it
+  switched off (`-ffp-contract=off`), so the priced instruction stream is the same on
+  every architecture.
 
 Every pricing decision below is an application of one question: **who produced this
 operation — the author, writing it into the source, or the compiler, translating the

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -128,7 +128,11 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
     - **x86:** `(U)COMISD`
 - **Counted Python operations:** `x == y`, `x != y`, `x <= y`, ... and
   `min(x,y)`, `max(x,y)` for `CountedFloat`
-- **Not counted:** Comparisons on non-CountedFloat, numpy comparisons
+- **Not counted:** Comparisons on non-CountedFloat, numpy comparisons, and
+  truthiness (`bool(x)`, `if x:`) — deliberately uncounted as pervasive
+  bookkeeping; write an algorithmic zero-test as `x != 0.0` to have it counted
+  (see the predicates row in
+  [Math patching semantics](math_patching.md#coverage-of-the-math-module))
 - **Weight measurement:** [the machine code behind the `COMP` weight](machine_code/comp.md)
 
 ## FlopType.RND (`round`) { #flop-rnd }

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -30,12 +30,10 @@ contracting is the compiler default at ordinary optimization levels). The two st
 different rules: the compiler's arithmetic is bit-exact against the authored source, while
 the author's porting choices (which library calls, whether a small constant power becomes
 a multiply chain) have no bit-target to hit — different libms already differ in last bits
-— and owe algorithmic faithfulness instead. See
-[Cost-model principles](cost_model.md#how-the-imaginary-port-gets-made) for the full
-story. The
-cost model prices operator arithmetic as what this port would execute, rather than what the
-much slower Python interpreter happens to do — see
-[Cost-model principles](cost_model.md).
+— and owe algorithmic faithfulness instead. The cost model prices operator arithmetic as
+what this port would execute, rather than what the much slower Python interpreter happens
+to do. See
+[Cost-model principles](cost_model.md#how-the-imaginary-port-gets-made) for the full story.
 
 ## Constant { #constant }
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -21,9 +21,18 @@ avoids the collision with the operating-system sense of the word.)
 
 ## Compiled port { #compiled-port }
 
-The hypothetical result of rewriting the Python code in C and compiling it at ordinary
-optimization levels, without accuracy-trading flags (no fast-math): a program that produces
-bit-identical results, as fast as a compiler can make it without changing any of them. The
+The imaginary program the cost model prices: a competent numerical programmer (the
+*author*) rewrites the Python code in C, and a compiler translates that C to machine code
+without changing any computed value — strict IEEE-754 evaluation, with
+[FP contraction](#fp-contraction) pinned off (`-ffp-contract=off`; merely saying
+"no fast-math" would not exclude it, since on some targets — aarch64 notably —
+contracting is the compiler default at ordinary optimization levels). The two stages obey
+different rules: the compiler's arithmetic is bit-exact against the authored source, while
+the author's porting choices (which library calls, whether a small constant power becomes
+a multiply chain) have no bit-target to hit — different libms already differ in last bits
+— and owe algorithmic faithfulness instead. See
+[Cost-model principles](cost_model.md#how-the-imaginary-port-gets-made) for the full
+story. The
 cost model prices operator arithmetic as what this port would execute, rather than what the
 much slower Python interpreter happens to do — see
 [Cost-model principles](cost_model.md).
@@ -79,8 +88,10 @@ Operations in that category are priced by benchmarking the actual libm call.
 
 ## Strength reduction { #strength-reduction }
 
-A compiler transformation replacing an expensive operation with a cheaper one that yields
-the same result, enabled when part of the expression is [constant](#constant): `x ** 2`
-becomes a single multiply, `x / 2.0` becomes `x * 0.5` (exact, since `0.5` is exactly
-representable). The cost model applies it only where the replacement is bit-identical *and*
-a standard C compiler genuinely performs it ([cost-model rule 1](cost_model.md#the-rules)).
+Replacing an expensive operation with a cheaper one that computes the same thing, enabled
+when part of the expression is [constant](#constant): `x ** 2` becomes a single multiply,
+`x / 2.0` becomes `x * 0.5` (exact, since `0.5` is exactly representable). In the cost
+model it happens at either stage of the [compiled port](#compiled-port): bit-exact
+reductions are compiler rewrites; value-changing ones (the multiply chain for `x ** 5`)
+can only be *author* decisions, declared and bounded in
+[cost-model rule 1](cost_model.md#the-rules).

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -34,9 +34,12 @@ counted region.
   count that is quietly missing them says so — see
   [watching what gets counted](counting_flops.md#watching-what-gets-counted)
 - operator-level fused multiply-add is not modeled: `a*b + c` counts as separate
-  MUL + ADD, but a compiled port on any modern target (x86 FMA3, ARMv8) commonly
-  fuses it into a single FMA instruction with a single rounding, so flop counts
-  over-estimate fusable multiply-add sequences (dot products, Horner evaluation).
+  MUL + ADD, matching the contraction-off reference semantics the
+  [cost model](cost_model.md) pins. Real builds routinely contract: on aarch64,
+  FP contraction is the compiler *default* at plain `-O2` (no fast-math flag
+  involved), and x86 FMA3 targets fuse under the same defaults — so on such
+  builds, flop counts over-estimate fusable multiply-add sequences (dot
+  products, Horner evaluation) by up to the fused sequences' MUL share.
   Python cannot observe operator-level fusion, so the library cannot count it.
   `math.fma` (Python 3.13+) is the one place a fusion *is* observable, and it is
   counted as a single `FMA`; expressing a multiply-add that way is therefore the

--- a/docs/math_patching.md
+++ b/docs/math_patching.md
@@ -71,7 +71,7 @@ Every commonly used `math` function, and how it participates in counting:
 | **Instrumented, counted as a decomposition** (patched, counts the flops a compiled port would execute) | `degrees` / `radians` → MUL; `prod` → one MUL per chained multiply; `fsum` → (n−1) ADD; 1-argument `hypot` → ABS |
 | **Counted via dunder** (no patch needed — do not expect these in the patch list) | `math.floor` / `math.ceil` / `math.trunc` → F2I through `__floor__`/`__ceil__`/`__trunc__`; the builtins `abs()` → ABS and `round()` → RND/F2I likewise count through their dunders |
 | **Not instrumented** (returns a plain, uncounted `float`) | exactly the float-representation helpers — `frexp`, `ldexp`, `modf`, `nextafter`, `ulp` |
-| **Predicates** (uncounted, return a `bool`) | `isnan`, `isinf`, `isfinite`, `isclose` |
+| **Predicates** (uncounted, return a `bool`) | `isnan`, `isinf`, `isfinite`, `isclose` — and truthiness itself (`bool(x)`, `if x:`, `assert x`), which a compiled port would test against zero but which fires pervasively in bookkeeping; an *algorithmic* zero-test can be written as `x != 0.0`, which counts `COMP` |
 
 The not-instrumented set breaks contagion: the plain-`float` result silently
 stops all downstream counting, so convert back with `CountedFloat(...)` if a

--- a/docs/math_patching.md
+++ b/docs/math_patching.md
@@ -71,7 +71,7 @@ Every commonly used `math` function, and how it participates in counting:
 | **Instrumented, counted as a decomposition** (patched, counts the flops a compiled port would execute) | `degrees` / `radians` → MUL; `prod` → one MUL per chained multiply; `fsum` → (n−1) ADD; 1-argument `hypot` → ABS |
 | **Counted via dunder** (no patch needed — do not expect these in the patch list) | `math.floor` / `math.ceil` / `math.trunc` → F2I through `__floor__`/`__ceil__`/`__trunc__`; the builtins `abs()` → ABS and `round()` → RND/F2I likewise count through their dunders |
 | **Not instrumented** (returns a plain, uncounted `float`) | exactly the float-representation helpers — `frexp`, `ldexp`, `modf`, `nextafter`, `ulp` |
-| **Predicates** (uncounted, return a `bool`) | `isnan`, `isinf`, `isfinite`, `isclose` — and truthiness itself (`bool(x)`, `if x:`, `assert x`), which a compiled port would test against zero but which fires pervasively in bookkeeping; an *algorithmic* zero-test can be written as `x != 0.0`, which counts `COMP` |
+| **Predicates** (uncounted, return a `bool`) | `isnan`, `isinf`, `isfinite`, `isclose` — and truthiness (`bool(x)`, `if x:`, `assert x`), which a compiled port would test against zero. It is left uncounted because it appears constantly in ordinary control flow rather than in the arithmetic being measured; an *algorithmic* zero-test can be written `x != 0.0`, which counts `COMP` |
 
 The not-instrumented set breaks contagion: the plain-`float` result silently
 stops all downstream counting, so convert back with `CountedFloat(...)` if a

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -20,7 +20,10 @@ def count_pow_with_constant_exponent(exponent: float) -> None:
       - integer 2 <= |n| <= 16   -> square-and-multiply MULs (x**3 -> 2 MUL, x**8 -> 3 MUL, ...),
                                     plus one DIV when negative; the |n| <= 16 cutoff keeps the
                                     model honest — beyond it real compilers' powi expansion
-                                    varies and a generic POW is a fair stand-in
+                                    varies and a generic POW is a fair stand-in.  The chain is a
+                                    source-level porting decision, priced as written — not a
+                                    toolchain transformation needing bit-identity to libm pow;
+                                    see the constant-exponent rule in docs/cost_model.md
       - anything else            -> POW
     """
     value = float(exponent)


### PR DESCRIPTION
Restructures the cost-model page around the story every rule was implicitly assuming: the imaginary port is made in **two stages by two actors** — an *author* (a competent numerical programmer who sees the constants and makes declared, bounded judgment calls: the `x ** 5` multiply chain, `|n| ≤ 16`) and a *compiler* (which may only apply rewrites that provably never change a computed value — strict IEEE-754, FP contraction pinned off via `-ffp-contract=off`). Every pricing decision reduces to one question: who produced the operation, the author writing it or the compiler translating it?

This resolves two inconsistencies flagged by review:

- **The `-O2` double-standard**: rule 1.6 cited compiler defaults approvingly while rule 1.3 rejected contraction as "fast-math" — factually wrong on aarch64, where contracting is the default at plain `-O2`. Now `-O2` behavior is corroboration only, never the admission criterion; contraction is excluded by the pinned semantics, stated as such, with the ARM-default fact in `known_limitations.md` so the over-estimate on real builds is honest.
- **Bit-identity vs. strength reduction**: the multiply chain for `x ** 5` is not bit-identical to libm `pow` — and owes no such identity, because nothing was rewritten: the chain *is* the source the author wrote (real compilers agree — they only expand constant-exponent `pow` beyond 2 under fast-math). Bit-identity governs the compiler stage alone; authorship has no bit-target (libms already differ in last bits) and owes algorithmic faithfulness. The reduction keys on the constant's value, never the spelling (`math.pow(x, 5.0)` ≡ `x ** 5`); `math.fma` counts FMA because it is the one *unambiguous* spelling of fusion (no operator twin).

Riding along: truthiness (`bool(x)`, `if x:`) documented as deliberately uncounted with the `x != 0.0` counted alternative; a new rule bullet stating the sign-exact identity folds the compiler-stage test admits (`x * 1.0`, `x - 0.0`, `x + (-0.0)` fold; `x * -1.0`, `x / -1.0`, `(-0.0) - x` → MINUS; power-of-two divisor folds inside `//` and `%`) with their signed-zero near-misses that must keep counting — carried as an explicitly marked known deviation until the counting change lands; and the glossary's `compiled port` / `strength reduction` entries rewritten to the same two-stage frame.

Target register throughout: developers with math affinity, no compiler or ISA expertise assumed — flag names appear once, parenthesized, never load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
