### PR TITLE
chore: tighten construction contract docs, annotations and libm-binding robustness

### DIFF
--- a/src/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
+++ b/src/counted_float/_core/benchmarking/flops/_flops_benchmark_suite.py
@@ -15,7 +15,6 @@ from counted_float._core.models import (
 )
 from counted_float._core.utils import get_cpu_frequency_mhz_current
 
-from . import _flops_probes as probes
 from ._array_generator import ArrayGenerator
 from ._flops_micro_benchmark import FlopsMicroBenchmark
 
@@ -221,6 +220,11 @@ class FlopsBenchmarkSuite:
                 f"array_size must be >= {FlopsBenchmarkSuite.MIN_ARRAY_SIZE}: the arity probes read up to "
                 f"{FlopsBenchmarkSuite.MIN_ARRAY_SIZE - 1} elements behind the current index"
             )
+        # imported here rather than at module level: the probes bind libm ctypes functions when
+        # imported, which fails loudly on platforms without a locatable C math library -- that
+        # failure belongs to running the flops benchmark, not to importing the benchmarking API
+        from . import _flops_probes as probes
+
         # --- assemble the registry -----------------------
         return {
             key: FlopsMicroBenchmark(name=str(key), size=size, f=f, array_init=array_init)

--- a/src/counted_float/_core/benchmarking/flops/_libm_bindings.py
+++ b/src/counted_float/_core/benchmarking/flops/_libm_bindings.py
@@ -19,17 +19,38 @@ import sys
 from collections.abc import Callable
 
 
-def _load_libm() -> ctypes.CDLL:
-    """Load the C math library (the UCRT on Windows, libm elsewhere)."""
-    return ctypes.CDLL("ucrtbase" if sys.platform == "win32" else ctypes.util.find_library("m"))
+def _load_libm() -> ctypes.CDLL | None:
+    """Load the C math library (the UCRT on Windows, libm elsewhere), or None if unlocatable.
+
+    ``ctypes.util.find_library`` needs ldconfig-style machinery that platforms like musl or
+    Android may lack; returning None instead of crashing defers the failure to the getters
+    below, which raise a clear error at flops-benchmark time rather than at import time.
+    """
+    name = "ucrtbase" if sys.platform == "win32" else ctypes.util.find_library("m")
+    if name is None:
+        return None
+    try:
+        return ctypes.CDLL(name)
+    except OSError:
+        return None
 
 
 _libm = _load_libm()
 
 
+def _require_libm() -> ctypes.CDLL:
+    """The loaded C math library, or a clear error naming the feature that needs it."""
+    if _libm is None:
+        raise RuntimeError(
+            "the flops benchmark needs the C math library for its cbrt/remainder probes, "
+            "and none could be located on this platform"
+        )
+    return _libm
+
+
 def libm_cbrt() -> Callable[[float], float]:
     """The C99 ``double cbrt(double)`` function, as a ctypes function object."""
-    fn = _libm.cbrt
+    fn = _require_libm().cbrt
     fn.restype = ctypes.c_double
     fn.argtypes = [ctypes.c_double]
     return fn
@@ -37,7 +58,7 @@ def libm_cbrt() -> Callable[[float], float]:
 
 def libm_remainder() -> Callable[[float, float], float]:
     """The C99 ``double remainder(double, double)`` function, as a ctypes function object."""
-    fn = _libm.remainder
+    fn = _require_libm().remainder
     fn.restype = ctypes.c_double
     fn.argtypes = [ctypes.c_double, ctypes.c_double]
     return fn

--- a/src/counted_float/_core/benchmarking/flops/_libm_bindings.py
+++ b/src/counted_float/_core/benchmarking/flops/_libm_bindings.py
@@ -17,14 +17,17 @@ import ctypes
 import ctypes.util
 import sys
 from collections.abc import Callable
+from functools import cache
 
 
+@cache
 def _load_libm() -> ctypes.CDLL | None:
     """Load the C math library (the UCRT on Windows, libm elsewhere), or None if unlocatable.
 
     ``ctypes.util.find_library`` needs ldconfig-style machinery that platforms like musl or
     Android may lack; returning None instead of crashing defers the failure to the getters
     below, which raise a clear error at flops-benchmark time rather than at import time.
+    Cached, so the library is loaded once on first use and never at import.
     """
     name = "ucrtbase" if sys.platform == "win32" else ctypes.util.find_library("m")
     if name is None:
@@ -35,17 +38,15 @@ def _load_libm() -> ctypes.CDLL | None:
         return None
 
 
-_libm = _load_libm()
-
-
 def _require_libm() -> ctypes.CDLL:
     """The loaded C math library, or a clear error naming the feature that needs it."""
-    if _libm is None:
+    libm = _load_libm()
+    if libm is None:
         raise RuntimeError(
             "the flops benchmark needs the C math library for its cbrt/remainder probes, "
             "and none could be located on this platform"
         )
-    return _libm
+    return libm
 
 
 def libm_cbrt() -> Callable[[float], float]:

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -150,6 +150,12 @@ class CountedFloat(float):
     #  CONSTRUCTOR
     # -------------------------------------------------------------------------
     def __new__(cls, value: float | int) -> CountedFloat:
+        """Construct from a numeric source, counting I2F for int inputs.
+
+        Numeric-source construction is the supported contract: counted code converts numbers,
+        it does not parse them. Strings happen to work (the delegation to ``float(value)``
+        accepts them) but that is incidental, not part of the contract -- hence the annotation.
+        """
         if isinstance(value, int):
             try:
                 _TLS.flop_counts.I2F += 1

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -608,7 +608,7 @@ def math_dist(p: Iterable[float], q: Iterable[float]) -> float | CountedFloat:
     return float.__new__(CountedFloat, result)
 
 
-def math_prod(iterable: Iterable[float], /, *, start: float = 1) -> float | CountedFloat:
+def math_prod(iterable: Iterable[float], /, *, start: float = 1) -> object:
     """Patch math.prod: stdlib contract, counted as the multiply chain it computes.
 
     The product is folded left-to-right with real multiplications, so counting and contagion

--- a/src/counted_float/_core/counting/config/_config.py
+++ b/src/counted_float/_core/counting/config/_config.py
@@ -42,6 +42,8 @@ class Config:
 
         Returns a fresh deep copy; mutating it does not affect the configured weights.
         """
+        # benign race by design: two threads hitting the lazy init both compute the same default
+        # and one write wins -- idempotent, so no lock is warranted for a rarely-cold path
         if cls.__weights is None:
             cls.__weights = get_default_consensus_flop_weights()
         return cls.__weights.model_copy(deep=True)

--- a/tests/benchmarking/flops/test_libm_bindings.py
+++ b/tests/benchmarking/flops/test_libm_bindings.py
@@ -25,7 +25,7 @@ def test_importing_the_benchmarking_api_does_not_load_libm():
 @pytest.mark.parametrize("getter", [_libm_bindings.libm_cbrt, _libm_bindings.libm_remainder])
 def test_getters_raise_a_clear_error_when_libm_is_unlocatable(monkeypatch, getter):
     # --- arrange -----------------------------------------
-    monkeypatch.setattr(_libm_bindings, "_libm", None)  # what _load_libm returns on musl/Android
+    monkeypatch.setattr(_libm_bindings, "_load_libm", lambda: None)  # musl/Android: no locatable libm
 
     # --- act / assert ------------------------------------
     with pytest.raises(RuntimeError, match="C math library"):
@@ -34,7 +34,13 @@ def test_getters_raise_a_clear_error_when_libm_is_unlocatable(monkeypatch, gette
 
 def test_load_libm_survives_an_unlocatable_library(monkeypatch):
     # --- arrange -----------------------------------------
+    # find_library returning None is the musl/Android case; clear the cache so this call re-runs
+    # the loader rather than returning a real library some earlier test cached
     monkeypatch.setattr(_libm_bindings.ctypes.util, "find_library", lambda name: None)
+    _libm_bindings._load_libm.cache_clear()
 
     # --- act / assert ------------------------------------
-    assert _libm_bindings._load_libm() is None or sys.platform == "win32"
+    try:
+        assert _libm_bindings._load_libm() is None or sys.platform == "win32"
+    finally:
+        _libm_bindings._load_libm.cache_clear()  # drop the None so later real calls reload

--- a/tests/benchmarking/flops/test_libm_bindings.py
+++ b/tests/benchmarking/flops/test_libm_bindings.py
@@ -1,0 +1,40 @@
+import subprocess
+import sys
+
+import pytest
+
+from counted_float._core.benchmarking.flops import _libm_bindings
+
+
+def test_importing_the_benchmarking_api_does_not_load_libm():
+    """The libm ctypes load must stay confined to running the flops benchmark.
+
+    On platforms without a locatable C math library (musl, Android) the load fails; that
+    failure must not break `import counted_float.benchmarking`, whose other entry point
+    (run_counted_float_benchmark) never touches libm. Run in a fresh interpreter so the
+    check is independent of what this test session already imported.
+    """
+    code = (
+        "import sys; import counted_float; import counted_float.benchmarking; "
+        "assert 'counted_float._core.benchmarking.flops._libm_bindings' not in sys.modules, "
+        "'importing the benchmarking API must not bind libm'"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)  # noqa: S603 -- fixed interpreter, literal code
+
+
+@pytest.mark.parametrize("getter", [_libm_bindings.libm_cbrt, _libm_bindings.libm_remainder])
+def test_getters_raise_a_clear_error_when_libm_is_unlocatable(monkeypatch, getter):
+    # --- arrange -----------------------------------------
+    monkeypatch.setattr(_libm_bindings, "_libm", None)  # what _load_libm returns on musl/Android
+
+    # --- act / assert ------------------------------------
+    with pytest.raises(RuntimeError, match="C math library"):
+        getter()
+
+
+def test_load_libm_survives_an_unlocatable_library(monkeypatch):
+    # --- arrange -----------------------------------------
+    monkeypatch.setattr(_libm_bindings.ctypes.util, "find_library", lambda name: None)
+
+    # --- act / assert ------------------------------------
+    assert _libm_bindings._load_libm() is None or sys.platform == "win32"


### PR DESCRIPTION
Four small cleanups, batched:

- `CountedFloat.__new__` documents its construction contract: numeric sources are supported, string acceptance is incidental — the narrow annotation is deliberate.
- `math_prod` returns `-> object`, matching its int-preserving wholesale-delegation path (the same fix `math_sumprod` already carries).
- The libm ctypes bindings no longer break `import counted_float.benchmarking` on platforms where no C math library can be located (musl, Android): the load degrades to `None`, the probes import moved out of the API import path, and the getters raise a clear `RuntimeError` at flops-benchmark time. Tests pin the no-load-at-import property in a fresh interpreter, plus the error path.
- The flop-weights lazy init documents its benign race by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)