### PR TITLE
chore: key per-combo coverage data on the runner OS

### DIFF
--- a/.github/actions/unit_test/action.yml
+++ b/.github/actions/unit_test/action.yml
@@ -53,8 +53,11 @@ runs:
           RES: ${{ inputs.dependency_resolution }}
           EXTRAS: ${{ inputs.include_all_extra_deps }}
           COV: ${{ inputs.coverage }}
-          # distinct per-combo data file so the coverage job combines rather than overwrites
-          COVERAGE_FILE: .coverage.${{ inputs.python_version }}-${{ inputs.dependency_resolution }}-${{ inputs.include_all_extra_deps }}
+          # distinct per-combo data file so the coverage job combines rather than overwrites;
+          # the runner OS is part of the key because the same python/resolution/extras combo runs
+          # on several OSes (ubuntu/macOS/windows), whose data files would otherwise share a name
+          # and overwrite each other at combine time -- silently dropping those legs' coverage
+          COVERAGE_FILE: .coverage.${{ runner.os }}-${{ inputs.python_version }}-${{ inputs.dependency_resolution }}-${{ inputs.include_all_extra_deps }}
         run: |
           EXTRA_FLAG=""
           [ "$EXTRAS" = "true" ] && EXTRA_FLAG="--all-extras"
@@ -77,13 +80,13 @@ runs:
           # each combo records its own collected set so the coverage job can union them.
           uv run --python "$PY" --resolution "$RES" $EXTRA_FLAG --group dev \
             pytest ./tests --collect-only -q -o addopts="" \
-            | grep '::' > "test-ids-${PY}-${RES}-${EXTRAS}.txt"
+            | grep '::' > "test-ids-${RUNNER_OS}-${PY}-${RES}-${EXTRAS}.txt"
 
       - name: Upload coverage + node-id data
         if: inputs.coverage == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: coverage-data-${{ inputs.python_version }}-${{ inputs.dependency_resolution }}-extras-${{ inputs.include_all_extra_deps }}
+          name: coverage-data-${{ runner.os }}-${{ inputs.python_version }}-${{ inputs.dependency_resolution }}-extras-${{ inputs.include_all_extra_deps }}
           path: |
             .coverage.*
             test-ids-*.txt


### PR DESCRIPTION
The unit-test composite action derived each matrix combo coverage data file, collected-node-id dump and upload artifact from {python, resolution, extras} only -- not the OS. The matrix runs py3.13 / highest / extras-true on ubuntu, macOS and windows, so those three legs produced identical names, collided, and overwrote each other when the coverage job merged all artifacts into one directory. The combine therefore saw 9 data files for 11 legs, and the macOS/Windows coverage was silently and nondeterministically dropped from the cumulative total.

Keying every per-combo name on the runner OS gives each leg a distinct identity end-to-end, so coverage from every leg survives the combine. The download pattern, combine step and metrics glob still match the new names, so none of them changed.

Verification: on this branch the coverage job should now combine one data file per matrix leg (11) instead of the previous 9, and the reported cumulative percentage may shift as the macOS and Windows legs are included for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)