### PR TITLE
fix: load built-in data via the Traversable API; allow None core counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- the built-in flop-weight data now loads under zipimport / zipapp / frozen installs (previously raised `AttributeError` there)
+
 ### Security
 
 ## 2.0.0 (2026-07-23)

--- a/src/counted_float/_core/counting/_builtin_data.py
+++ b/src/counted_float/_core/counting/_builtin_data.py
@@ -180,7 +180,7 @@ def _load_json_files_as_dict(resource_root: Traversable) -> dict[str, str]:
             for key, value in sub_dir_json_dict.items():
                 result[f"{entry.name}.{key}"] = value
         elif entry.is_file() and entry.name.endswith(".json"):
-            result[entry.stem] = entry.read_text(encoding="utf-8")  # ty: ignore[unresolved-attribute] -- Path-like
+            result[entry.name.removesuffix(".json")] = entry.read_text(encoding="utf-8")
     return result
 
 

--- a/src/counted_float/_core/models/_flops_benchmark_meta_data.py
+++ b/src/counted_float/_core/models/_flops_benchmark_meta_data.py
@@ -57,8 +57,8 @@ class SystemInfo(JsonReprModel):
 class ProcessorInfo(JsonReprModel):
     description: str
     architecture: str
-    n_logical_core_count: int
-    n_physical_core_count: int
+    n_logical_core_count: int | None
+    n_physical_core_count: int | None
     min_freq_mhz: int | None
     max_freq_mhz: int | None
 

--- a/tests/counting/test_built_in_data.py
+++ b/tests/counting/test_built_in_data.py
@@ -1,6 +1,6 @@
 import pytest
 
-from counted_float._core.counting._builtin_data import BuiltInData, _flat_to_nested_dict
+from counted_float._core.counting._builtin_data import BuiltInData, _flat_to_nested_dict, _load_json_files_as_dict
 from counted_float._core.models import FlopsBenchmarkResults, FlopWeights
 
 
@@ -96,3 +96,48 @@ def test_builtin_data_flat_to_nested_dict():
 
     # --- assert ------------------------------------------
     assert nested_dict == expected_nested_dict
+
+
+class _FakeTraversable:
+    """Stand-in for a zip/frozen-backed importlib.resources Traversable.
+
+    Exposes only the guaranteed contract (name / is_dir / is_file / iterdir / read_text) and
+    deliberately no `.stem`, so the loader is pinned to the pathlib-free Traversable surface.
+    """
+
+    def __init__(self, name, *, text=None, children=()):
+        self.name = name
+        self._text = text
+        self._children = children
+
+    def is_dir(self):
+        return self._text is None
+
+    def is_file(self):
+        return self._text is not None
+
+    def iterdir(self):
+        return iter(self._children)
+
+    def read_text(self, encoding="utf-8"):
+        assert self._text is not None
+        return self._text
+
+
+def test_load_json_files_as_dict_uses_only_the_traversable_contract():
+    # a resource backend without pathlib's `.stem` (zip / frozen installs) must still load
+    # --- arrange -----------------------------------------
+    root = _FakeTraversable(
+        "sources",
+        children=(
+            _FakeTraversable("apple_m4_pro.json", text='{"cpu": "m4"}'),
+            _FakeTraversable("notes.md", text="ignored"),
+            _FakeTraversable("arm", children=(_FakeTraversable("graviton.json", text='{"cpu": "g"}'),)),
+        ),
+    )
+
+    # --- act ---------------------------------------------
+    result = _load_json_files_as_dict(root)
+
+    # --- assert ------------------------------------------
+    assert result == {"apple_m4_pro": '{"cpu": "m4"}', "arm.graviton": '{"cpu": "g"}'}

--- a/tests/models/test_flops_benchmark_meta_data.py
+++ b/tests/models/test_flops_benchmark_meta_data.py
@@ -1,3 +1,5 @@
+import psutil
+
 from counted_float._core.models._flops_benchmark_meta_data import (
     BenchmarkSettings,
     OSInfo,
@@ -28,6 +30,20 @@ def test_processor_info():
 
     # --- assert ------------------------------------------
     assert isinstance(processor_info, ProcessorInfo)
+
+
+def test_processor_info_records_undetectable_core_count_as_none(monkeypatch):
+    # psutil.cpu_count() returns None when the count can't be determined; from_system must
+    # record that as None instead of raising a validation error
+    # --- arrange -----------------------------------------
+    monkeypatch.setattr(psutil, "cpu_count", lambda logical=True: None)
+
+    # --- act ---------------------------------------------
+    processor_info = ProcessorInfo.from_system()
+
+    # --- assert ------------------------------------------
+    assert processor_info.n_logical_core_count is None
+    assert processor_info.n_physical_core_count is None
 
 
 def test_os_info():


### PR DESCRIPTION
Two small robustness fixes on the built-in-data path and benchmark metadata.

1. The data-tree loader keyed each source file on entry.stem, a pathlib attribute that importlib.resources Traversable does not guarantee. That works on the usual filesystem install but raises AttributeError under zipimport, zipapp and frozen builds, which breaks loading the built-in flop-weight dataset entirely. It now keys on the guaranteed .name attribute (stripping the .json suffix the filter already requires), so only the Traversable contract is used. A regression test loads through a fake Traversable that has no .stem.

2. The benchmark-metadata core-count fields were typed plain int but filled from psutil.cpu_count, which returns None when the count cannot be determined; on such a machine metadata collection raised a validation error. The fields are now int-or-None, matching the neighboring frequency fields; a test drives from_system with cpu_count patched to None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)