### PR TITLE
chore: tighten ty to reject bare generics and blanket ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,10 @@ include = ["src/counted_float"]
 # extra is absent from the env; flagging them as unused in the other env would
 # make `ty check` results depend on which extras happen to be installed.
 unused-ignore-comment = "ignore"
+# Tightened beyond ty defaults: keep the py.typed surface fully parametrized (no bare
+# generics), and require every `ty: ignore` to name the rule it suppresses.
+missing-type-argument = "error"
+blanket-ignore-comment = "error"
 
 [tool.coverage.run]
 source = ["counted_float"]

--- a/src/counted_float/_core/benchmarking/flops/_flops_micro_benchmark.py
+++ b/src/counted_float/_core/benchmarking/flops/_flops_micro_benchmark.py
@@ -48,7 +48,7 @@ class FlopsMicroBenchmark(MicroBenchmark):
     # of a benchmark uses pool slot r mod INPUT_POOL_SIZE (see prepare_suite/prepare_slice)
     INPUT_POOL_SIZE = 4
 
-    def __init__(self, name: str, size: int, array_init: ArrayGenerator, f: Callable) -> None:
+    def __init__(self, name: str, size: int, array_init: ArrayGenerator, f: Callable[..., object]) -> None:
         super().__init__(name=name, single_execution=f"{size} iterations")
         self.size = size
         self.array_init = array_init

--- a/src/counted_float/_core/benchmarking/flops/_sumprod_port.py
+++ b/src/counted_float/_core/benchmarking/flops/_sumprod_port.py
@@ -40,7 +40,7 @@ def _make_fma_single() -> Callable[[float, float, float], float]:
     def fma_intrinsic(typingctx: object, x: object, y: object, z: object) -> object:
         sig = types.float64(types.float64, types.float64, types.float64)
 
-        def codegen(context: object, builder: ir.IRBuilder, signature: object, args: tuple) -> object:
+        def codegen(context: object, builder: ir.IRBuilder, signature: object, args: tuple[object, ...]) -> object:
             fnty = ir.FunctionType(ir.DoubleType(), [ir.DoubleType()] * 3)
             fn = builder.module.declare_intrinsic("llvm.fma", [ir.DoubleType()], fnty)
             return builder.call(fn, args)

--- a/src/counted_float/_core/compatibility/_numba.py
+++ b/src/counted_float/_core/compatibility/_numba.py
@@ -1,4 +1,7 @@
 from collections.abc import Callable
+from typing import TypeVar, overload
+
+_ProbeFn = TypeVar("_ProbeFn", bound=Callable[..., object])
 
 try:
     import numba  # ty: ignore[unresolved-import] -- numba is an optional dependency; shimmed below if absent
@@ -7,15 +10,20 @@ try:
 except ImportError:
     NUMBA_AVAILABLE = False
 
-    # dummy decorator that will replace numba.jit and numba.njit
-    def dummy_decorator(*args: object, **kwargs: object) -> Callable:
-        # dummy decorator that does nothing and can be used with or without arguments
+    # dummy decorator replacing numba.jit / numba.njit: identity in both call forms, so that
+    # without numba the decorated probe keeps its original callable type rather than `object`
+    @overload
+    def dummy_decorator(func: _ProbeFn, /) -> _ProbeFn: ...
+    @overload
+    def dummy_decorator(*args: object, **kwargs: object) -> Callable[[_ProbeFn], _ProbeFn]: ...
+    def dummy_decorator(*args: object, **kwargs: object) -> object:
+        # does nothing and can be used with or without arguments
         if len(args) == 1 and isinstance(args[0], Callable):
             # decorator used without arguments
             return args[0]
 
         # decorator used with arguments
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: Callable[..., object]) -> Callable[..., object]:
             return func
 
         return decorator

--- a/src/counted_float/_core/counting/_builtin_data.py
+++ b/src/counted_float/_core/counting/_builtin_data.py
@@ -31,6 +31,11 @@ PRECOMPUTED_DIR = "precomputed"
 PRECOMPUTED_WEIGHTS_FILE = "consensus_flop_weights.json"
 
 
+# a source tree is str-keyed all the way down: each level maps a name to either a deeper level or a
+# leaf FlopWeights. Recursive so the isinstance-driven descent below type-checks against itself.
+NestedFlopWeights = dict[str, "NestedFlopWeights | FlopWeights"]
+
+
 def _data_sources_root() -> Traversable:
     """Return the root of the built-in source data tree; source keys are relative to it."""
     return files(DATA_PACKAGE) / SOURCES_DIR
@@ -138,7 +143,7 @@ def _precomputed_flop_weights() -> dict[str, FlopWeights]:
     return {key_filter: FlopWeights.model_validate({"weights": weights}) for key_filter, weights in raw.items()}
 
 
-def _compute_nested_average_flop_weights(nested_flop_weights_dict: dict[str, dict | FlopWeights]) -> FlopWeights:
+def _compute_nested_average_flop_weights(nested_flop_weights_dict: NestedFlopWeights) -> FlopWeights:
     # make sure all values of the dict are FlopWeights instances
     for key, value in nested_flop_weights_dict.items():
         if isinstance(value, dict):
@@ -149,7 +154,7 @@ def _compute_nested_average_flop_weights(nested_flop_weights_dict: dict[str, dic
     return FlopWeights.as_geo_mean(list(nested_flop_weights_dict.values()))  # ty: ignore[invalid-argument-type]
 
 
-def _flat_to_nested_dict(flat_dict: dict) -> dict:
+def _flat_to_nested_dict(flat_dict: dict[str, FlopWeights]) -> NestedFlopWeights:
     """Convert a flat dict with .-separated keys to a nested dict.
 
     E.g. {'a.b.c': 1, 'a.b.d': 2, 'a.e': 3} -> {'a': {'b': {'c': 1, 'd': 2}, 'e': 3}}.
@@ -353,7 +358,7 @@ class FlopWeightsTreeView:
     #  Factory methods
     # -------------------------------------------------------------------------
     @classmethod
-    def from_nested_dict(cls, name: str, nested_dict: dict[str, dict | FlopWeights]) -> FlopWeightsTreeView:
+    def from_nested_dict(cls, name: str, nested_dict: NestedFlopWeights) -> FlopWeightsTreeView:
         members = []
         for key in sorted(nested_dict.keys()):
             value = nested_dict[key]


### PR DESCRIPTION
Tightens the ty ruleset beyond its defaults, keeping the checker native (no second, slower type-checker lane).

Two rules promoted to error in the ty config:
- missing-type-argument -- no bare generics on the py.typed surface. Parametrizes the nine it flags: three Callable in the numba shim, one Callable and one tuple in benchmark helpers, and four nested flop-weight dicts. The numba shim gains identity-preserving overloads so a decorated probe keeps its callable type when numba is absent (rather than collapsing to object); the nested dicts gain a recursive NestedFlopWeights alias so the isinstance-driven descent type-checks against itself.
- blanket-ignore-comment -- every ty ignore must name the rule it suppresses. Zero current violations; this only locks it in.

Verified with ty in both the numba-present and numba-absent environments (ty results are extras-dependent). No runtime change; the full suite and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)