### PR TITLE
test: cover the lazy-init handler of every operator and math patch

### DIFF
--- a/tests/counting/test_fresh_thread_first_op.py
+++ b/tests/counting/test_fresh_thread_first_op.py
@@ -1,0 +1,198 @@
+"""Fresh-thread first-op coverage of the lazy-init increment idiom.
+
+Every instrumented operator and every patched ``math.*`` replacement inlines a lazy-init
+handler for a thread's first counted op:
+
+    try:
+        _TLS.flop_counts.<field> += 1
+    except AttributeError:  # first counted op on this thread
+        _create_thread_state().<field> += 1
+
+That ``except`` branch fires ONLY on a thread's very first counted op: a FlopCountingContext
+otherwise creates the thread state on entry, so an op run inside one always takes the ``try``
+branch.  A malformed handler in a single site -- wrong field, missing ``except`` -- therefore
+stays invisible unless that specific op is the first counted op on a brand-new thread, which the
+rest of the suite never arranges (pytest-xdist reuses workers, so some other op warms the thread
+first).
+
+Each case here spawns a pristine thread whose first action is exactly one op, and asserts it
+counts what the same op counts on the (warm) main thread -- so the ``except`` branch is checked
+against the ``try`` branch, per site.  The op list is the arithmetic/comparison/unary operators
+and the patch registry's own keys, so a newly instrumented op or patch is covered automatically.
+"""
+
+import math
+import threading
+from collections.abc import Callable
+
+import pytest
+
+from counted_float import CountedFloat, FlopCountingContext
+from counted_float._core.counting import _math_patching
+from counted_float._core.counting._thread_counter import THREAD_COUNTER
+
+CF = CountedFloat
+_PATCH_NAMES = sorted(_math_patching._PATCHES.keys())  # excludes fma/sumprod on interpreters without them
+
+
+# =================================================================================================
+#  Helpers
+# =================================================================================================
+def _counts_as_dict(fc) -> dict[str, int]:
+    """The non-zero flop-count fields of a FlopCounts, as a plain dict for comparison."""
+    return {name: getattr(fc, name) for name in fc.field_names() if getattr(fc, name)}
+
+
+def _first_op_counts_on_fresh_thread(call: Callable[[], object]) -> dict[str, int]:
+    """Run ``call`` as the very first counter-touching action on a pristine thread; return its counts.
+
+    Freshness is guaranteed by construction: each call spawns a brand-new ``threading.Thread``, i.e.
+    a new OS thread with its own ``threading.local`` storage, so the module-level ``_TLS`` holds no
+    ``flop_counts`` for it (unlike the pytest-xdist workers, which are reused and quickly warm). The
+    op is therefore unavoidably that thread's first counter access -- which is the whole point: it
+    forces the per-op ``except AttributeError`` lazy-init handler, the branch a warm thread (or a
+    context entry) never reaches.  A raise inside the thread is re-raised on the main thread so it
+    fails the test rather than hanging or vanishing.
+    """
+    captured: dict[str, object] = {}
+
+    def target() -> None:
+        try:
+            call()  # first counted op on this thread -> hits the except branch
+            captured["counts"] = _counts_as_dict(THREAD_COUNTER.flop_counts())
+        except BaseException as exc:  # noqa: BLE001 -- surfaced on the main thread below
+            captured["error"] = exc
+
+    thread = threading.Thread(target=target)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]  # type: ignore[misc]
+    return captured["counts"]  # type: ignore[return-value]
+
+
+# =================================================================================================
+#  Operators
+# =================================================================================================
+# reflected forms use an int left operand so the reflected dunder is actually reached (a float left
+# would be handled by float.__op__ directly); non-folding operands so every op registers a count
+_OPERATORS: list[tuple[str, Callable[[], object]]] = [
+    ("add", lambda: CF(1.5) + CF(2.5)),
+    ("radd", lambda: 2 + CF(2.5)),
+    ("sub", lambda: CF(1.5) - CF(2.5)),
+    ("rsub", lambda: 2 - CF(2.5)),
+    ("mul", lambda: CF(1.5) * CF(2.5)),
+    ("rmul", lambda: 2 * CF(2.5)),
+    ("truediv", lambda: CF(1.5) / CF(2.5)),
+    ("rtruediv", lambda: 2 / CF(2.5)),
+    ("floordiv", lambda: CF(7.0) // CF(2.5)),
+    ("rfloordiv", lambda: 7 // CF(2.5)),
+    ("mod", lambda: CF(7.0) % CF(2.5)),
+    ("rmod", lambda: 7 % CF(2.5)),
+    ("divmod", lambda: divmod(CF(7.0), CF(2.5))),
+    ("rdivmod", lambda: divmod(7, CF(2.5))),
+    ("pow", lambda: CF(2.0) ** CF(3.0)),
+    ("pow_const_exponent", lambda: CF(2.5) ** 2),
+    ("rpow", lambda: 3 ** CF(2.5)),
+    ("abs", lambda: abs(CF(-2.5))),
+    ("neg", lambda: -CF(2.5)),
+    ("round", lambda: round(CF(2.5))),
+    ("round_ndigits", lambda: round(CF(2.567), 2)),
+    ("floor", lambda: math.floor(CF(2.5))),
+    ("ceil", lambda: math.ceil(CF(2.5))),
+    ("trunc", lambda: math.trunc(CF(2.5))),
+    ("int", lambda: int(CF(2.5))),
+    ("new_from_int", lambda: CF(3)),
+    ("eq", lambda: CF(1.5) == CF(2.5)),
+    ("ne", lambda: CF(1.5) != CF(2.5)),
+    ("lt", lambda: CF(1.5) < CF(2.5)),
+    ("le", lambda: CF(1.5) <= CF(2.5)),
+    ("gt", lambda: CF(1.5) > CF(2.5)),
+    ("ge", lambda: CF(1.5) >= CF(2.5)),
+]
+
+
+@pytest.mark.parametrize(("op_id", "call"), _OPERATORS, ids=[op_id for op_id, _ in _OPERATORS])
+def test_operator_first_op_on_fresh_thread(op_id: str, call: Callable[[], object]) -> None:
+    # --- arrange (reference: the same op on the warm main thread) ---
+    with FlopCountingContext() as ctx:
+        call()
+        reference = _counts_as_dict(ctx.flop_counts())
+
+    # --- act (first op on a pristine thread hits the lazy-init handler) ---
+    fresh = _first_op_counts_on_fresh_thread(call)
+
+    # --- assert -----------------------------
+    assert reference, f"{op_id} counted nothing on the main thread -- not an instrumented op"
+    assert fresh == reference
+
+
+# =================================================================================================
+#  Patched math.* functions
+# =================================================================================================
+# one in-domain call per registered patch, with CountedFloat args so counting actually fires;
+# fma/sumprod are listed unconditionally but only exercised where _PATCHES registers them
+_PATCH_ARGS: dict[str, tuple[object, ...]] = {
+    "sqrt": (CF(2.0),),
+    "cbrt": (CF(2.0),),
+    "log": (CF(2.0),),
+    "log2": (CF(2.0),),
+    "log10": (CF(2.0),),
+    "exp": (CF(0.5),),
+    "exp2": (CF(0.5),),
+    "pow": (CF(2.0), CF(3.0)),
+    "sin": (CF(0.5),),
+    "cos": (CF(0.5),),
+    "tan": (CF(0.5),),
+    "asin": (CF(0.5),),
+    "acos": (CF(0.5),),
+    "atan": (CF(0.5),),
+    "atan2": (CF(1.0), CF(2.0)),
+    "hypot": (CF(3.0), CF(4.0)),
+    "expm1": (CF(0.5),),
+    "log1p": (CF(0.5),),
+    "fmod": (CF(5.0), CF(3.0)),
+    "fabs": (CF(-2.0),),
+    "sinh": (CF(0.5),),
+    "cosh": (CF(0.5),),
+    "tanh": (CF(0.5),),
+    "asinh": (CF(0.5),),
+    "acosh": (CF(2.0),),
+    "atanh": (CF(0.5),),
+    "degrees": (CF(2.0),),
+    "radians": (CF(90.0),),
+    "dist": ([CF(1.0), CF(2.0)], [CF(4.0), CF(6.0)]),
+    "prod": ([CF(2.0), CF(3.0), CF(4.0)],),
+    "fsum": ([CF(0.1)] * 4,),
+    "copysign": (CF(3.0), CF(-2.0)),
+    "gamma": (CF(2.0),),
+    "lgamma": (CF(2.0),),
+    "erf": (CF(0.5),),
+    "erfc": (CF(0.5),),
+    "remainder": (CF(5.0), CF(3.0)),
+    "fma": (CF(2.0), CF(3.0), CF(4.0)),
+    "sumprod": ([CF(2.0)], [CF(3.0)]),
+}
+
+
+@pytest.mark.parametrize("fname", _PATCH_NAMES)
+def test_math_patch_first_op_on_fresh_thread(fname: str) -> None:
+    def call() -> object:
+        return getattr(math, fname)(*_PATCH_ARGS[fname])
+
+    # a context installs the patch module-wide, so the pristine thread below sees the patch too
+    # --- arrange / act ---------------------
+    with FlopCountingContext() as ctx:
+        call()  # reference on the warm main thread (try branch)
+        reference = _counts_as_dict(ctx.flop_counts())
+        fresh = _first_op_counts_on_fresh_thread(call)  # pristine thread (except branch)
+
+    # --- assert -----------------------------
+    assert reference, f"math.{fname} counted nothing -- its argument fixture may be wrong"
+    assert fresh == reference
+
+
+def test_patch_args_cover_every_registered_patch() -> None:
+    # a newly registered patch must gain a _PATCH_ARGS entry, or its fresh-thread case would KeyError
+    # --- assert -----------------------------
+    assert set(_math_patching._PATCHES) <= set(_PATCH_ARGS)


### PR DESCRIPTION
The per-op lazy-init handler

    try:
        _TLS.flop_counts.<field> += 1
    except AttributeError:  # first counted op on this thread
        _create_thread_state().<field> += 1

is inlined at every instrumented operator and every patched math.* function. Its except branch fires ONLY on the very first counted op of a thread -- a FlopCountingContext creates the thread state on entry, so an op run inside one always takes the try branch. A malformed handler (wrong field, missing except) is therefore invisible to the entire existing suite, which never arranges for a given op to be the first on a brand-new thread.

Each case spawns a pristine thread whose first action is one op, and asserts it counts exactly what the same op counts on the warm main thread -- checking the except branch against the try branch, per site. The op list is the arithmetic/comparison/unary operators plus the patch registry keys, so newly instrumented ops and patches are covered automatically (and version-gated fma/sumprod are included only where registered).

Validated by deliberately breaking two handlers (__add__ and math_erfc): only their fresh-thread cases failed, while all 714 warm-thread operator/patch tests still passed -- confirming the gap is real and this closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)