### PR TITLE
test: cover every remaining line and raise the coverage gate to 100%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,14 +208,10 @@ relative_files = true  # so per-combo matrix data files combine without a [paths
 
 [tool.coverage.report]
 precision = 2
-fail_under = 95        # cumulative gate, enforced on the combined matrix data
+fail_under = 100       # cumulative gate, enforced on the combined matrix data
 exclude_also = [
     "@abstractmethod",
     "@abc.abstractmethod",
-    # thread-local lazy-init handlers: each runs at most once per thread (on its very first
-    # counted op at that specific site), so per-site coverage is not meaningful; the init
-    # mechanism itself is covered by the fresh-thread tests
-    "except AttributeError:  # first counted op on this thread",
 ]
 
 [tool.codespell]

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -623,10 +623,10 @@ def math_prod(iterable: Iterable[float], /, *, start: float = 1) -> object:
         return original_math_prod(values, start=start)
     if isinstance(start, CountedFloat) or start != 1:
         acc, remaining = start, values
-    elif values:
-        acc, remaining = values[0], values[1:]
     else:
-        return start
+        # start is plain 1 (folds away); the guard above guarantees a CountedFloat is present, and a
+        # plain-1 start means it is in `values`, so `values` is non-empty here
+        acc, remaining = values[0], values[1:]
     for value in remaining:
         acc = acc * value
     return acc

--- a/tests/benchmarking/flops/test_libm_bindings.py
+++ b/tests/benchmarking/flops/test_libm_bindings.py
@@ -1,3 +1,4 @@
+import ctypes
 import subprocess
 import sys
 
@@ -42,5 +43,22 @@ def test_load_libm_survives_an_unlocatable_library(monkeypatch):
     # --- act / assert ------------------------------------
     try:
         assert _libm_bindings._load_libm() is None or sys.platform == "win32"
+    finally:
+        _libm_bindings._load_libm.cache_clear()  # drop the None so later real calls reload
+
+
+def test_load_libm_returns_none_when_the_library_fails_to_load(monkeypatch):
+    # find_library locates a name but the CDLL load raises OSError -> None, deferring to the clear
+    # RuntimeError _require_libm raises at flops-benchmark time
+    # --- arrange -----------------------------------------
+    def _raise_oserror(*_args, **_kwargs):
+        raise OSError("simulated libm load failure")
+
+    monkeypatch.setattr(ctypes, "CDLL", _raise_oserror)
+    _libm_bindings._load_libm.cache_clear()
+
+    # --- act / assert ------------------------------------
+    try:
+        assert _libm_bindings._load_libm() is None
     finally:
         _libm_bindings._load_libm.cache_clear()  # drop the None so later real calls reload

--- a/tests/benchmarking/micro/test_interleaved_runner.py
+++ b/tests/benchmarking/micro/test_interleaved_runner.py
@@ -230,3 +230,13 @@ def test_runner_schedule_is_reproducible_with_seed():
     # same warmup + measurement schedule (calibration length may differ: it adapts to timing)
     n_recorded = 5 * 3  # (1 warmup + 4 measure) rounds x 3 benchmarks
     assert first[-n_recorded:] == second[-n_recorded:]
+
+
+def test_slice_controller_target_is_the_common_target_before_per_exec_timing():
+    # before any per-execution timing is recorded, the N_MIN_EXECUTIONS floor cannot apply yet,
+    # so the effective target is just the common target
+    # --- arrange / act -----------------------------------
+    controller = SliceController(t_slice_target_nsecs=1234.0)
+
+    # --- assert ------------------------------------------
+    assert controller.t_slice_target_nsecs == 1234.0

--- a/tests/benchmarking/micro/test_micro_benchmark.py
+++ b/tests/benchmarking/micro/test_micro_benchmark.py
@@ -234,3 +234,16 @@ def test_run_many_measures_the_real_clock():
 
     # --- assert ------------------------------------------
     assert results.summary_stats_nsecs_per_exec().q25 >= nsecs_per_execution
+
+
+def test_prepare_slice_defaults_to_the_full_per_run_preparation(fake_clock):
+    # the base prepare_slice just runs the full per-run preparation; only subclasses that
+    # pre-allocate override it with a cheaper variant
+    # --- arrange -----------------------------------------
+    benchmark = ClockAdvancingBenchmark(fake_clock, nsecs_per_execution=10.0)
+
+    # --- act ---------------------------------------------
+    benchmark.prepare_slice(n_executions=7, round_index=0)
+
+    # --- assert ------------------------------------------
+    assert benchmark.n_executions_per_run == [7]  # delegated to _prepare_benchmark(7)

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -37,3 +37,20 @@ def test_main_exits_with_guidance_when_click_missing(monkeypatch, capsys):
         _cli_main.main()
     assert exc_info.value.code == 1
     assert 'pip install "counted-float[cli]"' in capsys.readouterr().err
+
+
+def test_main_reraises_a_non_click_import_error(monkeypatch):
+    # only a missing `click` becomes install guidance; any other ModuleNotFoundError propagates
+    # --- arrange -----------------------------------------
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "counted_float._core._cli":
+            raise ModuleNotFoundError("simulated missing dependency", name="numpy")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    # --- act & assert ------------------------------------
+    with pytest.raises(ModuleNotFoundError, match="simulated missing dependency"):
+        _cli_main.main()

--- a/tests/counting/test_built_in_data.py
+++ b/tests/counting/test_built_in_data.py
@@ -1,6 +1,12 @@
 import pytest
 
-from counted_float._core.counting._builtin_data import BuiltInData, _flat_to_nested_dict, _load_json_files_as_dict
+from counted_float._core.counting._builtin_data import (
+    BuiltInData,
+    FlopWeightsTreeView,
+    _construct_flop_weights_from_json_str,
+    _flat_to_nested_dict,
+    _load_json_files_as_dict,
+)
 from counted_float._core.models import FlopsBenchmarkResults, FlopWeights
 
 
@@ -141,3 +147,20 @@ def test_load_json_files_as_dict_uses_only_the_traversable_contract():
 
     # --- assert ------------------------------------------
     assert result == {"apple_m4_pro": '{"cpu": "m4"}', "arm.graviton": '{"cpu": "g"}'}
+
+
+def test_construct_flop_weights_rejects_unknown_json():
+    # JSON that matches none of the supported data schemas raises rather than degrading silently
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match="known data structure"):
+        _construct_flop_weights_from_json_str('{"not": "a known schema"}')
+
+
+def test_show_renders_integer_weights():
+    # nearest-int rounding yields int weights; the tree renderer must format those as plain integers
+    # --- arrange -----------------------------------------
+    int_weights = BuiltInData.get_flop_weights(key_filter=".").round("nearest_int")
+    tree = FlopWeightsTreeView.from_nested_dict(name="ALL", nested_dict={"cpus": int_weights})
+
+    # --- act / assert (must not raise; exercises the int-weight branch) ---
+    tree.show()

--- a/tests/counting/test_counted_float.py
+++ b/tests/counting/test_counted_float.py
@@ -1266,3 +1266,14 @@ def test_counted_float_pow_runtime_counted_exponent_counts_pow(thread_counter):
     # --- assert ------------------------------------------
     assert thread_counter.total_count() == 1
     assert thread_counter.POW == 1
+
+
+@pytest.mark.parametrize("method", ["__rfloordiv__", "__rmod__", "__rdivmod__", "__rpow__"])
+def test_reflected_op_returns_notimplemented_for_unsupported_operand(method: str) -> None:
+    # a reflected dunder must defer (return NotImplemented) when the underlying float op cannot
+    # handle the other operand, so Python can fall through to the operand's own handling / a TypeError
+    # --- act ---------------------------------------------
+    result = getattr(CountedFloat(2.0), method)("not a number")
+
+    # --- assert ------------------------------------------
+    assert result is NotImplemented

--- a/tests/counting/test_fresh_thread_first_op.py
+++ b/tests/counting/test_fresh_thread_first_op.py
@@ -109,6 +109,16 @@ _OPERATORS: list[tuple[str, Callable[[], object]]] = [
     ("le", lambda: CF(1.5) <= CF(2.5)),
     ("gt", lambda: CF(1.5) > CF(2.5)),
     ("ge", lambda: CF(1.5) >= CF(2.5)),
+    # constant-operand fold paths keep their own lazy-init sites, distinct from the generic
+    # branches above (which take a CountedFloat or int operand)
+    ("truediv_const_divisor", lambda: CF(1.5) / 3.0),
+    # divisor 1.0 folds in count_div (no counter access), so __floordiv__'s own RND increment is
+    # the first access on the thread -- exercising its handler rather than count_div's
+    ("floordiv_by_one", lambda: CF(7.0) // 1.0),
+    ("mul_minus_one", lambda: CF(2.5) * -1.0),
+    ("round_ndigits_zero", lambda: round(CF(2.567), 0)),
+    ("rsub_minus_zero", lambda: CF(2.0).__rsub__(-0.0)),
+    ("rpow_countedfloat_base", lambda: CF(2.0).__rpow__(CF(3.0))),
 ]
 
 
@@ -196,3 +206,25 @@ def test_patch_args_cover_every_registered_patch() -> None:
     # a newly registered patch must gain a _PATCH_ARGS entry, or its fresh-thread case would KeyError
     # --- assert -----------------------------
     assert set(_math_patching._PATCHES) <= set(_PATCH_ARGS)
+
+
+# alternate patch code paths the registry-keyed test above misses (it uses one argument tuple per
+# function): math.log's two-arg runtime-base form, and math.fma's constant-product (z-only) branch
+_ALT_PATCH_CASES: list[tuple[str, Callable[[], object]]] = [
+    ("log_runtime_base", lambda: math.log(CF(8.0), CF(2.0))),
+]
+if hasattr(math, "fma"):
+    _ALT_PATCH_CASES.append(("fma_constant_product", lambda: math.fma(2.0, 3.0, CF(4.0))))
+
+
+@pytest.mark.parametrize(("case_id", "call"), _ALT_PATCH_CASES, ids=[c[0] for c in _ALT_PATCH_CASES])
+def test_math_patch_alternate_path_first_op_on_fresh_thread(case_id: str, call: Callable[[], object]) -> None:
+    # --- arrange / act (a context installs the patch module-wide, so the pristine thread sees it) ---
+    with FlopCountingContext() as ctx:
+        call()
+        reference = _counts_as_dict(ctx.flop_counts())
+        fresh = _first_op_counts_on_fresh_thread(call)
+
+    # --- assert -----------------------------
+    assert reference, f"{case_id} counted nothing"
+    assert fresh == reference

--- a/tests/counting/test_math_patching.py
+++ b/tests/counting/test_math_patching.py
@@ -89,6 +89,13 @@ def test_math_module_patched_inside_context_only(fname):
         ("copysign", (3.0, -2.0)),
         ("hypot", (1.0, 2.0, 2.0)),
         ("hypot", (-3.0,)),
+        # plain-float delegation paths for the special functions (their CountedFloat counting
+        # paths are exercised separately in test_new_math_ops_count_and_are_contagious)
+        ("gamma", (2.0,)),
+        ("lgamma", (2.0,)),
+        ("erf", (0.5,)),
+        ("erfc", (0.5,)),
+        ("remainder", (5.0, 3.0)),
     ],
 )
 def test_patched_math_functions_match_stdlib_for_plain_floats(thread_counter, fname, args):
@@ -767,3 +774,29 @@ def test_capture_originals_keeps_both_original_tables_in_sync():
         assert delegation_target is _math_patching._saved_originals[name], (
             f"original_math_{name} does not match the restoration snapshot for '{name}'"
         )
+
+
+# =================================================================================================
+#  Version-gated stand-ins and teardown guard
+# =================================================================================================
+def test_fma_unavailable_stand_in_raises() -> None:
+    # the stand-in exists so original_math_fma is callable pre-3.13; calling it must raise
+    # --- act / assert ------------------------------------
+    with pytest.raises(NotImplementedError, match=r"math\.fma"):
+        _math_patching._math_fma_unavailable(1.0, 2.0, 3.0)
+
+
+def test_sumprod_unavailable_stand_in_raises() -> None:
+    # --- act / assert ------------------------------------
+    with pytest.raises(NotImplementedError, match=r"math\.sumprod"):
+        _math_patching._math_sumprod_unavailable([1.0], [2.0])
+
+
+def test_remove_uncounted_math_patches_is_a_noop_when_none_installed() -> None:
+    # the guard returns early when no thread is reporting, so there is nothing to undo
+    # --- arrange -----------------------------------------
+    assert _math_patching._reporting_thread_count == 0
+
+    # --- act / assert (must not raise or touch the math module) ---
+    _math_patching.remove_uncounted_math_patches()
+    assert _math_patching._reporting_thread_count == 0

--- a/tests/models/test_flop_type.py
+++ b/tests/models/test_flop_type.py
@@ -1,6 +1,7 @@
 import pytest
 
 from counted_float._core.models import FlopType
+from counted_float._core.models._flop_type import normalize_flop_type_keyed_dict
 
 
 def test_flop_type_long_name():
@@ -40,3 +41,12 @@ def test_from_serialized_key_rejects_display_labels():
     # pre-2.0.0 files keyed on display labels; those are deliberately no longer readable
     with pytest.raises(ValueError, match="unrecognized flop-type key"):
         FlopType.from_serialized_key(FlopType.ADD.label)
+
+
+def test_normalize_flop_type_keyed_dict_passes_non_dict_through():
+    # a non-dict is handed straight back so pydantic raises its own type error, unmasked
+    # --- act ---------------------------------------------
+    result = normalize_flop_type_keyed_dict("not a dict", null_to_nan=True)
+
+    # --- assert ------------------------------------------
+    assert result == "not a dict"

--- a/tests/shared/test_compatibility.py
+++ b/tests/shared/test_compatibility.py
@@ -1,3 +1,5 @@
+import pytest
+
 from counted_float._core.compatibility import is_numba_installed, numba
 
 
@@ -13,3 +15,19 @@ def test_is_numba_installed():
 
     # --- assert ------------------------------------------
     assert is_numba_deemed_installed == is_numba_truly_installed
+
+
+@pytest.mark.skipif(is_numba_installed(), reason="the dummy decorator shim exists only when numba is absent")
+def test_numba_dummy_decorator_bare_form_returns_the_function():
+    # without numba, `@njit` used bare (no parentheses) must return the decorated function unchanged
+    # --- arrange -----------------------------------------
+    from counted_float._core.compatibility._numba import dummy_decorator
+
+    def probe():
+        return 1.0
+
+    # --- act ---------------------------------------------
+    decorated = dummy_decorator(probe)
+
+    # --- assert ------------------------------------------
+    assert decorated is probe

--- a/tests/shared/test_version.py
+++ b/tests/shared/test_version.py
@@ -1,0 +1,27 @@
+"""The package __version__ fallback when installed metadata is unavailable (source-tree use)."""
+
+import importlib
+import importlib.metadata
+
+import counted_float
+
+
+def test_version_falls_back_when_package_metadata_is_missing(monkeypatch):
+    # a source tree without installed metadata makes importlib.metadata.version raise; __init__
+    # must fall back to "0.0.0" rather than letting PackageNotFoundError escape at import
+    # --- arrange -----------------------------------------
+    def _raise_not_found(_name):
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(importlib.metadata, "version", _raise_not_found)
+
+    # --- act ---------------------------------------------
+    try:
+        importlib.reload(counted_float)
+        fallback_version = counted_float.__version__
+    finally:
+        monkeypatch.undo()
+        importlib.reload(counted_float)  # restore the real __version__ for later tests
+
+    # --- assert ------------------------------------------
+    assert fallback_version == "0.0.0"

--- a/tests/utils/test_cpu_freq.py
+++ b/tests/utils/test_cpu_freq.py
@@ -1,8 +1,14 @@
+from types import SimpleNamespace
+
+import psutil
+import pytest
+
 from counted_float._core.utils import (
     get_cpu_frequency_mhz_current,
     get_cpu_frequency_mhz_max,
     get_cpu_frequency_mhz_min,
 )
+from counted_float._core.utils._cpu_freq import _get_psutil_cpu_freq_attribute_mhz
 
 
 def test_get_cpu_frequency_mhz_min_max_current():
@@ -18,3 +24,23 @@ def test_get_cpu_frequency_mhz_min_max_current():
 
     if (freq_min is not None) and (freq_max is not None):
         assert freq_min <= freq_max
+
+
+@pytest.mark.parametrize(("raw_reading", "expected_mhz"), [(3.5, 3500.0), (3.5e6, 3500.0)])
+def test_cpu_freq_normalizes_out_of_range_readings(monkeypatch, raw_reading, expected_mhz):
+    # a GHz-valued reading (far below ~63 MHz) is scaled up; a Hz-valued one (far above ~63 GHz)
+    # is scaled down -- both land in the MHz range
+    # --- arrange -----------------------------------------
+    # raising=False: psutil.cpu_freq does not exist on every platform (e.g. macOS), so inject it
+    monkeypatch.setattr(
+        psutil,
+        "cpu_freq",
+        lambda: SimpleNamespace(min=raw_reading, max=raw_reading, current=raw_reading),
+        raising=False,
+    )
+
+    # --- act ---------------------------------------------
+    result = _get_psutil_cpu_freq_attribute_mhz("min")
+
+    # --- assert ------------------------------------------
+    assert result == expected_mhz


### PR DESCRIPTION
Raises the combined-matrix coverage gate to `fail_under = 100`, with an honest test for every line -- no `# pragma: no cover`.

Drops the `except AttributeError: # first counted op on this thread` entry from the coverage exclusion (the fresh-thread test now exercises those ~79 sites) and adds ~25 test cases for the lines that exposed:

- fresh-thread constant-fold cases (the fold paths keep their own lazy-init sites: constant divisor, `* -1.0`, `round(x, 0)`, `// 1.0`, `x.__rsub__(-0.0)`, `x.__rpow__(x)`, two-arg `log` runtime base, `fma` constant product);
- plain-float `math.*` delegation paths for the special functions, the reflected-`NotImplemented` returns, and the version-gated `fma`/`sumprod` stand-ins;
- mock / env tests for the platform-defensive branches: libm `OSError`, cpu-freq unit normalization, absent package metadata (`__version__` fallback), the non-`click` CLI re-raise, and the numba-absent decorator shim (no-numba leg).

One genuinely unreachable branch in `math_prod` (the empty-values / plain-start case, already delegated by the guard above it) is removed rather than excluded -- it could never run.

`fail_under = 100` is a standing ratchet: every later PR must keep the combined matrix fully covered (a mock test for any new defensive branch), which is the intended trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)