### PR TITLE
docs: document reduction-patch input materialization and note show-data weights are model-relative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- the `show-data` CLI output now closes with a note that its weights are model-relative estimates, linking the cost-model docs
+
 ### Deprecated
 
 ### Removed

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -84,6 +84,16 @@ counted region.
   (those comparisons really execute) but can surprise when a dict is used as
   bookkeeping rather than algorithm — pause counting or use plain-float keys
   for bookkeeping structures
+- while a `FlopCountingContext` is open, the patched `math.fsum`, `math.prod`,
+  `math.sumprod` and `math.dist` materialize their iterable inputs (they call
+  `list(...)` on them) even when no `CountedFloat` is involved, so the argument
+  can be inspected after the value is computed. The stdlib versions consume some
+  of these lazily, so passing a very large one-shot iterator to one of these
+  functions inside a context holds the whole sequence in memory — O(n) space
+  where the unpatched call would stream. The computed value is unchanged; only
+  peak memory differs, and only while a context is active. (`math.hypot` takes
+  its coordinates as separate positional arguments, already materialized as a
+  tuple by the interpreter, so it does not diverge.)
 - flop weights should be taken with a grain of salt and should only provide
   relative ballpark estimates w.r.t. computational complexity. Production
   implementations in a compiled language could have vastly differing

--- a/docs/math_patching.md
+++ b/docs/math_patching.md
@@ -77,6 +77,11 @@ The not-instrumented set breaks contagion: the plain-`float` result silently
 stops all downstream counting, so convert back with `CountedFloat(...)` if a
 result of these feeds counted computation.
 
+While a context is open, the reduction patches (`fsum`, `prod`, `sumprod`,
+`dist`) materialize their iterable inputs to inspect the operands after
+computing the result — a space-behavior divergence from the streaming stdlib
+versions; see [Known limitations](known_limitations.md).
+
 The predicates return a `bool` rather than a number, so contagion does not apply
 to them — but they are uncounted all the same. `math.isclose` is the one where
 that matters: it performs real arithmetic (a difference, absolute values, and a

--- a/scripts/docs_captures/show_data.ansi
+++ b/scripts/docs_captures/show_data.ansi
@@ -89,3 +89,5 @@
           │  └─intel_xeon_6975p_granite_rapids_ec2_m8i_xlarge            0.12      0.99      2.54      1.00      1.00      1.05      1.50      2.00      5.07        /         /        3.19  [0m[2m …[0m
           └─[1;3mother                                                        0.50      0.50      1.50      1.00      1.00        /       2.00      2.00      4.00      3.50      2.50         /   [0m[0m[2m …[0m
              └─specs_intel                                               0.50      0.50      1.50      1.00      1.00        /       2.00      2.00      4.00      3.50      2.50         /   [0m[2m …[0m
+
+Weights are model-relative estimates (relative to ADD); see the cost model for the pricing rules and their caveats: https://counted-float.readthedocs.io/en/latest/cost_model/

--- a/src/counted_float/_core/_cli.py
+++ b/src/counted_float/_core/_cli.py
@@ -39,6 +39,12 @@ def benchmark(output: Path | None) -> None:
 )
 def show_data(key_filter: str) -> None:
     BuiltInData.show(key_filter=key_filter)
+    # a first-time reader can mistake these weights for absolute truth; the one-line footer names
+    # them as model-relative and points at the cost model rather than restating its caveats here
+    click.echo(
+        "Weights are model-relative estimates (relative to ADD); see the cost model for the "
+        "pricing rules and their caveats: https://counted-float.readthedocs.io/en/latest/cost_model/"
+    )
 
 
 @cli.command(short_help="run benchmark of float vs CountedFloat performance")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -14,6 +14,14 @@ def test_show_data():
     runner.invoke(show_data)
 
 
+def test_show_data_prints_model_relative_footer():
+    """`show-data` closes with a caveat naming the weights as model-relative and linking the docs."""
+    result = CliRunner().invoke(show_data)
+    assert result.exit_code == 0
+    assert "model-relative" in result.output
+    assert "counted-float.readthedocs.io/en/latest/cost_model/" in result.output
+
+
 @pytest.mark.parametrize("flag", ["--key-filter", "--key_filter"])
 def test_show_data_key_filter_spellings(flag: str, monkeypatch) -> None:
     """Both the kebab-case flag and its underscore alias forward the same filter value."""


### PR DESCRIPTION
Documents a known behavioral divergence and adds a point-of-use caveat.

- **Reduction-patch input materialization** — while a `FlopCountingContext` is open, the patched `math.fsum` / `math.prod` / `math.sumprod` / `math.dist` call `list(...)` on their iterable inputs even when no `CountedFloat` is present, so a very large one-shot iterator uses O(n) space where the streaming stdlib would not. Now documented in the known-limitations and math-patching pages; the computed value is unaffected.
- **Model-relative weights** — the `show-data` CLI output now ends with a one-line footer marking its weights as model-relative estimates and linking the cost-model docs, so a first-time user is less likely to over-trust them.

The `show-data` docs screenshot needs a later refresh on the image-render machine to include the footer; its drift-tested text capture is already updated, and images are not CI-gated.