### PR TITLE
fix: compute before counting at every count site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- a `CountedFloat` construction or integer conversion that raises — an int too large to become a float, or `int()`/`floor()`/`ceil()`/`trunc()`/`round()` of `inf`/`nan` — no longer leaves a phantom flop counted
+
 ### Security
 
 ## 2.0.1 (2026-07-24)

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -156,12 +156,13 @@ class CountedFloat(float):
         it does not parse them. Strings happen to work (the delegation to ``float(value)``
         accepts them) but that is incidental, not part of the contract -- hence the annotation.
         """
+        instance = super().__new__(cls, float(value))  # compute first: an oversized int raises before counting
         if isinstance(value, int):
             try:
                 _TLS.flop_counts.I2F += 1
             except AttributeError:  # first counted op on this thread
                 _create_thread_state().I2F += 1
-        return super().__new__(cls, float(value))
+        return instance
 
     def __str__(self) -> str:
         return self.__repr__()
@@ -177,19 +178,21 @@ class CountedFloat(float):
     # -------------------------------------------------------------------------
     def __abs__(self) -> CountedFloat:
         """abs(x)."""
+        result = float.__abs__(self)
         try:
             _TLS.flop_counts.ABS += 1
         except AttributeError:  # first counted op on this thread
             _create_thread_state().ABS += 1
-        return float.__new__(CountedFloat, float.__abs__(self))
+        return float.__new__(CountedFloat, result)
 
     def __neg__(self) -> CountedFloat:
         """-x."""
+        result = float.__neg__(self)
         try:
             _TLS.flop_counts.MINUS += 1
         except AttributeError:  # first counted op on this thread
             _create_thread_state().MINUS += 1
-        return float.__new__(CountedFloat, float.__neg__(self))
+        return float.__new__(CountedFloat, result)
 
     def __pos__(self) -> CountedFloat:
         """+x.
@@ -280,14 +283,15 @@ class CountedFloat(float):
                     CPython itself runs (David Gay's algorithm), which has no fixed
                     instruction cost to price.
         """
+        result = float.__round__(self, n)  # compute first: round(inf/nan) with n=None raises (F2I) before counting
         if n is None:
             try:
-                _TLS.flop_counts.F2I += 1  # will round and return int
+                _TLS.flop_counts.F2I += 1  # rounded and returned int
             except AttributeError:  # first counted op on this thread
                 _create_thread_state().F2I += 1
         elif operator.index(n) == 0:
             try:
-                _TLS.flop_counts.RND += 1  # will round and return float
+                _TLS.flop_counts.RND += 1  # rounded and returned float
             except AttributeError:  # first counted op on this thread
                 _create_thread_state().RND += 1
         else:
@@ -300,39 +304,43 @@ class CountedFloat(float):
             cnt.RND += 1
             cnt.DIV += 1
 
-        return float.__round__(self, n)
+        return result
 
     def __floor__(self) -> int:
         """math.floor(x)."""
+        result = float.__floor__(self)  # compute first: floor(inf/nan) raises before counting
         try:
             _TLS.flop_counts.F2I += 1
         except AttributeError:  # first counted op on this thread
             _create_thread_state().F2I += 1
-        return float.__floor__(self)
+        return result
 
     def __ceil__(self) -> int:
         """math.ceil(x)."""
+        result = float.__ceil__(self)  # compute first: ceil(inf/nan) raises before counting
         try:
             _TLS.flop_counts.F2I += 1
         except AttributeError:  # first counted op on this thread
             _create_thread_state().F2I += 1
-        return float.__ceil__(self)
+        return result
 
     def __int__(self) -> int:
         """int(x)."""
+        result = float.__int__(self)  # compute first: int(inf/nan) raises before counting
         try:
             _TLS.flop_counts.F2I += 1
         except AttributeError:  # first counted op on this thread
             _create_thread_state().F2I += 1
-        return float.__int__(self)
+        return result
 
     def __trunc__(self) -> int:
         """int(x)."""
+        result = float.__trunc__(self)  # compute first: trunc(inf/nan) raises before counting
         try:
             _TLS.flop_counts.F2I += 1
         except AttributeError:  # first counted op on this thread
             _create_thread_state().F2I += 1
-        return float.__trunc__(self)
+        return result
 
     def __add__(self, other: float) -> CountedFloat:
         """x+other.

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -130,11 +130,12 @@ def math_sqrt(x: float) -> float | CountedFloat:
 
 def math_cbrt(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_cbrt(x)
         try:
             _TLS.flop_counts.CBRT += 1
         except AttributeError:  # first counted op on this thread
             _create_thread_state().CBRT += 1
-        return float.__new__(CountedFloat, original_math_cbrt(x))
+        return float.__new__(CountedFloat, result)
     return original_math_cbrt(x)
 
 
@@ -353,21 +354,23 @@ def math_acos(x: float) -> float | CountedFloat:
 
 def math_atan(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_atan(x)
         try:
             _TLS.flop_counts.ATAN += 1
         except AttributeError:  # first counted op on this thread
             _create_thread_state().ATAN += 1
-        return float.__new__(CountedFloat, original_math_atan(x))
+        return float.__new__(CountedFloat, result)
     return original_math_atan(x)
 
 
 def math_atan2(y: float, x: float) -> float | CountedFloat:
     if isinstance(y, CountedFloat) or isinstance(x, CountedFloat):
+        result = original_math_atan2(y, x)
         try:
             _TLS.flop_counts.ATAN2 += 1
         except AttributeError:  # first counted op on this thread
             _create_thread_state().ATAN2 += 1
-        return float.__new__(CountedFloat, original_math_atan2(y, x))
+        return float.__new__(CountedFloat, result)
     return original_math_atan2(y, x)
 
 
@@ -444,11 +447,12 @@ def math_remainder(x: float, y: float) -> float | CountedFloat:
 
 def math_fabs(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_fabs(x)
         try:
             _TLS.flop_counts.ABS += 1  # same FABS/ANDPD instruction as abs(); reuses FlopType.ABS
         except AttributeError:  # first counted op on this thread
             _create_thread_state().ABS += 1
-        return float.__new__(CountedFloat, original_math_fabs(x))
+        return float.__new__(CountedFloat, result)
     return original_math_fabs(x)
 
 
@@ -476,21 +480,23 @@ def math_cosh(x: float) -> float | CountedFloat:
 
 def math_tanh(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_tanh(x)
         try:
             _TLS.flop_counts.TANH += 1
         except AttributeError:  # first counted op on this thread
             _create_thread_state().TANH += 1
-        return float.__new__(CountedFloat, original_math_tanh(x))
+        return float.__new__(CountedFloat, result)
     return original_math_tanh(x)
 
 
 def math_asinh(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_asinh(x)
         try:
             _TLS.flop_counts.ASINH += 1
         except AttributeError:  # first counted op on this thread
             _create_thread_state().ASINH += 1
-        return float.__new__(CountedFloat, original_math_asinh(x))
+        return float.__new__(CountedFloat, result)
     return original_math_asinh(x)
 
 
@@ -564,21 +570,23 @@ def math_erfc(x: float) -> float | CountedFloat:
 
 def math_degrees(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_degrees(x)
         try:
             _TLS.flop_counts.MUL += 1  # x * (180/pi), the constant folded at compile time
         except AttributeError:  # first counted op on this thread
             _create_thread_state().MUL += 1
-        return float.__new__(CountedFloat, original_math_degrees(x))
+        return float.__new__(CountedFloat, result)
     return original_math_degrees(x)
 
 
 def math_radians(x: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat):
+        result = original_math_radians(x)
         try:
             _TLS.flop_counts.MUL += 1  # x * (pi/180), the constant folded at compile time
         except AttributeError:  # first counted op on this thread
             _create_thread_state().MUL += 1
-        return float.__new__(CountedFloat, original_math_radians(x))
+        return float.__new__(CountedFloat, result)
     return original_math_radians(x)
 
 
@@ -686,11 +694,12 @@ def math_sumprod(p: Iterable[float], q: Iterable[float], /) -> object:
 
 def math_copysign(x: float, y: float) -> float | CountedFloat:
     if isinstance(x, CountedFloat) or isinstance(y, CountedFloat):
+        result = original_math_copysign(x, y)
         try:
             _TLS.flop_counts.COPYSIGN += 1
         except AttributeError:  # first counted op on this thread
             _create_thread_state().COPYSIGN += 1
-        return float.__new__(CountedFloat, original_math_copysign(x, y))
+        return float.__new__(CountedFloat, result)
     return original_math_copysign(x, y)
 
 

--- a/tests/counting/test_counted_float_counting.py
+++ b/tests/counting/test_counted_float_counting.py
@@ -816,3 +816,39 @@ def test_reflected_op_returns_notimplemented_for_unsupported_operand(method: str
 
     # --- assert ------------------------------------------
     assert result is NotImplemented
+
+
+# =================================================================================================
+#  CountedFloat - error-before-count invariant (a raising op counts nothing)
+# =================================================================================================
+def test_counted_float_construction_from_overflowing_int_counts_nothing(thread_counter):
+    """An int too large to become a float raises before the I2F is counted -- no phantom flop."""
+    # --- act / assert ------------------------------------
+    with pytest.raises(OverflowError):
+        CountedFloat(10**400)  # float(10**400) overflows; the I2F must not survive the raise
+
+    assert thread_counter.total_count() == 0
+
+
+@pytest.mark.parametrize(
+    ("non_finite", "expected_exc"),
+    [(float("inf"), OverflowError), (float("nan"), ValueError)],
+    ids=["inf", "nan"],
+)
+@pytest.mark.parametrize(
+    "convert",
+    [int, math.floor, math.ceil, math.trunc, round],
+    ids=["int", "floor", "ceil", "trunc", "round"],
+)
+def test_counted_float_non_finite_to_int_conversion_counts_nothing(
+    thread_counter, convert: Callable, non_finite: float, expected_exc: type[Exception]
+):
+    """int/floor/ceil/trunc/round(x) of inf or nan raises before the F2I is counted -- no phantom flop."""
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(non_finite)  # construction from a float counts nothing
+
+    # --- act / assert ------------------------------------
+    with pytest.raises(expected_exc):
+        convert(cf)
+
+    assert thread_counter.total_count() == 0


### PR DESCRIPTION
The count-vs-compute step was split across the counting core: most patched functions and dunders compute the result before counting, but a minority counted first. Two of those count-first sites can raise — constructing a `CountedFloat` from an int too large to become a float, and `int()`/`floor()`/`ceil()`/`trunc()`/`round()` of `inf`/`nan` — and left a phantom flop counted when the underlying call raised.

This standardizes on compute-first everywhere: the two raising paths no longer leak, and the remaining raise-safe sites are reordered to the same uniform rule (behavior-identical). Counts are unchanged for every non-raising input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)