### PR TITLE
test: add mutation-killing tests for coverage-blind gaps

### DIFF
--- a/tests/benchmarking/flops/test_array_generator.py
+++ b/tests/benchmarking/flops/test_array_generator.py
@@ -1,3 +1,4 @@
+import random
 from collections.abc import Callable
 
 import numpy as np
@@ -7,6 +8,7 @@ from counted_float._core.benchmarking.flops._array_generator import (
     ArrayGenerator,
     ArrayGeneratorLinear,
     ArrayGeneratorLog,
+    _random_balanced_values,
 )
 
 
@@ -72,3 +74,38 @@ def test_array_generator_log(min_value: float, max_value: float):
     assert min_value < np.mean(arr) < max_value
     assert np.mean(np.log(arr)) == pytest.approx(0.5 * (np.log(min_value) + np.log(max_value)))
     assert max(arr) - min(arr) > 0.9 * (max_value - min_value)
+
+
+def test_new_array_is_reproducible_when_given_a_seeded_rng():
+    """Passing a seeded rng makes new_array deterministic; a different seed changes the draw."""
+    # --- arrange -----------------------------------------
+    generator = ArrayGeneratorLinear(min_value=0.0, max_value=1.0)
+
+    # --- act ---------------------------------------------
+    first = generator.new_array(size=500, rng=random.Random(12345))
+    second = generator.new_array(size=500, rng=random.Random(12345))
+    different_seed = generator.new_array(size=500, rng=random.Random(67890))
+
+    # --- assert ------------------------------------------
+    np.testing.assert_array_equal(first, second)  # same seed -> identical draw (rng is honored)
+    assert not np.array_equal(first, different_seed)  # different seed -> different draw
+
+
+@pytest.mark.parametrize("seed", [0, 7, 12345])
+@pytest.mark.parametrize("size", [2, 10, 1000])
+def test_random_balanced_values_invariants_before_scaling(size: int, seed: int):
+    """Pre-scaling contract: values in [-1,1], every partial sum in [-1,1], exact zero total."""
+    # --- arrange -----------------------------------------
+    tol = 1e-9  # allows only float rounding, not a broken clamp (which drifts by O(size))
+
+    # --- act ---------------------------------------------
+    values = _random_balanced_values(size, rng=random.Random(seed))
+
+    # --- assert ------------------------------------------
+    assert len(values) == size
+    partial = 0.0
+    for v in values:
+        assert -1.0 <= v <= 1.0  # each draw stays in [-1, 1]
+        partial += v
+        assert -1.0 - tol <= partial <= 1.0 + tol  # the clamp keeps every partial sum bounded
+    assert partial == 0.0  # the final element drives the running total exactly to zero

--- a/tests/benchmarking/flops/test_libm_bindings.py
+++ b/tests/benchmarking/flops/test_libm_bindings.py
@@ -1,10 +1,17 @@
 import ctypes
+import math
 import subprocess
 import sys
 
 import pytest
 
 from counted_float._core.benchmarking.flops import _libm_bindings
+
+# The real-result probes below need a locatable C math library; skip on platforms (musl, Android)
+# where find_library cannot resolve one, matching how the getters themselves degrade.
+_needs_libm = pytest.mark.skipif(
+    _libm_bindings._load_libm() is None, reason="no locatable C math library on this platform"
+)
 
 
 def test_importing_the_benchmarking_api_does_not_load_libm():
@@ -62,3 +69,34 @@ def test_load_libm_returns_none_when_the_library_fails_to_load(monkeypatch):
         assert _libm_bindings._load_libm() is None
     finally:
         _libm_bindings._load_libm.cache_clear()  # drop the None so later real calls reload
+
+
+@_needs_libm
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(8.0, 2.0), (27.0, 3.0), (-8.0, -2.0), (1.0, 1.0), (0.0, 0.0)],
+)
+def test_libm_cbrt_computes_real_cube_roots(value: float, expected: float):
+    # a wrong restype/argtypes (ctypes defaults restype to c_int) would corrupt the returned double
+    # --- arrange -----------------------------------------
+    cbrt = _libm_bindings.libm_cbrt()
+
+    # --- act ---------------------------------------------
+    result = cbrt(value)
+
+    # --- assert ------------------------------------------
+    assert result == expected
+
+
+@_needs_libm
+@pytest.mark.parametrize(("x", "y"), [(5.0, 3.0), (7.5, 2.0), (-5.0, 3.0), (10.0, 4.0), (1.0, 3.0)])
+def test_libm_remainder_matches_math_remainder(x: float, y: float):
+    # a wrong restype/argtypes would corrupt the result; math.remainder is the same IEEE operation
+    # --- arrange -----------------------------------------
+    remainder = _libm_bindings.libm_remainder()
+
+    # --- act ---------------------------------------------
+    result = remainder(x, y)
+
+    # --- assert ------------------------------------------
+    assert result == math.remainder(x, y)

--- a/tests/benchmarking/flops/test_libm_bindings.py
+++ b/tests/benchmarking/flops/test_libm_bindings.py
@@ -85,7 +85,9 @@ def test_libm_cbrt_computes_real_cube_roots(value: float, expected: float):
     result = cbrt(value)
 
     # --- assert ------------------------------------------
-    assert result == expected
+    # approx, not exact: cbrt's last bit is platform-dependent (glibc returns 3.0000000000000004 for
+    # 27.0); a corrupted restype/argtypes would be off by orders of magnitude, not one ULP
+    assert result == pytest.approx(expected)
 
 
 @_needs_libm

--- a/tests/benchmarking/flops/test_sumprod_port.py
+++ b/tests/benchmarking/flops/test_sumprod_port.py
@@ -1,0 +1,81 @@
+import math
+from fractions import Fraction
+
+import pytest
+
+from counted_float._core.benchmarking.flops._sumprod_port import _dl_sum, tl_fma, tl_to_d
+from counted_float._core.compatibility import is_numba_installed
+
+# The TripleLength port only reproduces math.sumprod bit-for-bit when it can spell a genuine FMA
+# (numba's llvm.fma intrinsic, or math.fma from Py3.13+) and a reference is available to compare
+# against (math.sumprod, Py3.12+). Without a genuine FMA the fold degrades to the double-rounded
+# x*y+z, which is documented as unusable; skip rather than assert against it.
+_needs_reference_and_fma = pytest.mark.skipif(
+    not (hasattr(math, "sumprod") and (is_numba_installed() or hasattr(math, "fma"))),
+    reason="needs math.sumprod (Py3.12+) as reference and a genuine FMA (numba, or math.fma / Py3.13+)",
+)
+
+
+def _triplelength_sumprod(xs: list[float], ys: list[float]) -> float:
+    """Reproduce math.sumprod(xs, ys) through the ported TripleLength fold and close-out."""
+    hi, lo, tiny = 0.0, 0.0, 0.0
+    for x, y in zip(xs, ys, strict=True):
+        hi, lo, tiny = tl_fma(x, y, hi, lo, tiny)
+    return tl_to_d(hi, lo, tiny)
+
+
+@pytest.mark.parametrize(
+    ("a", "b"),
+    [
+        (0.1, 0.2),  # sum is not exactly representable -> non-zero low term
+        (1.0, 2.0**-53),  # the low bit falls off the top part
+        (1e16, 1.0),  # widely separated magnitudes
+        (-1e300, 1e-300),  # extreme magnitude gap
+        (0.3, -0.7),  # cancellation
+        (1.0, 3.0),  # exact sum -> low term is zero
+        (2.0**53, 1.0),  # boundary of integer exactness
+    ],
+)
+def test_dl_sum_is_an_exact_two_sum(a: float, b: float):
+    """The high part is the rounded sum and (hi + lo) recovers a + b exactly (two-sum invariant)."""
+    # --- act ---------------------------------------------
+    hi, lo = _dl_sum(a, b)
+
+    # --- assert ------------------------------------------
+    assert hi == a + b  # hi is fl(a + b), the rounded sum
+    assert Fraction(hi) + Fraction(lo) == Fraction(a) + Fraction(b)  # exact: lo captures every dropped bit
+
+
+@_needs_reference_and_fma
+@pytest.mark.parametrize(
+    ("xs", "ys"),
+    [
+        ([1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]),  # well-conditioned, exact products
+        ([0.1, 0.2, 0.3], [0.4, 0.5, 0.6]),  # rounded products, non-trivial compensation
+        ([1e16, 1.0, -1e16, 1.0], [1.0, 1.0, 1.0, 1.0]),  # small terms a naive sum would drop
+    ],
+)
+def test_triplelength_port_matches_sumprod(xs: list[float], ys: list[float]):
+    """The fold + close-out reproduce CPython's math.sumprod bit-for-bit."""
+    # --- act ---------------------------------------------
+    result = _triplelength_sumprod(xs, ys)
+
+    # --- assert ------------------------------------------
+    assert result == math.sumprod(xs, ys)
+
+
+@_needs_reference_and_fma
+@pytest.mark.parametrize(
+    ("xs", "ys"),
+    [
+        ([1e17, 1.0, -1e17], [1.0, 1.0, 1.0]),  # true sum 1.0; a naive sum collapses to 0.0
+        ([1.0, 1e100, 1.0, -1e100], [1.0, 1.0, 1.0, 1.0]),  # true sum 2.0 under massive cancellation
+    ],
+)
+def test_triplelength_port_matches_sumprod_under_cancellation(xs: list[float], ys: list[float]):
+    """The low/tiny compensation terms are decisive here, so a sign/paren mutant would diverge."""
+    # --- act ---------------------------------------------
+    result = _triplelength_sumprod(xs, ys)
+
+    # --- assert ------------------------------------------
+    assert result == math.sumprod(xs, ys)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -38,9 +39,30 @@ def test_show_data_key_filter_spellings(flag: str, monkeypatch) -> None:
     assert seen == ["arm"]
 
 
-def test_benchmark_counted_float():
-    runner = CliRunner()
-    runner.invoke(benchmark_counted_float)
+def test_benchmark_counted_float_invokes_the_benchmark(monkeypatch):
+    """`benchmark-counted-float` runs the comparison benchmark and shows its result."""
+
+    # --- arrange -----------------------------------------
+    # replace the real (slow) benchmark with a fast fake, and prove the command actually calls it
+    calls: list[bool] = []
+
+    class _FakeResult:
+        def show(self) -> None:
+            click.echo("fake benchmark shown")
+
+    def _fake_benchmark() -> _FakeResult:
+        calls.append(True)
+        return _FakeResult()
+
+    monkeypatch.setattr(_cli, "run_counted_float_benchmark", _fake_benchmark)
+
+    # --- act ---------------------------------------------
+    result = CliRunner().invoke(benchmark_counted_float)
+
+    # --- assert ------------------------------------------
+    assert result.exit_code == 0
+    assert calls == [True]  # the command invoked the (patched) benchmark exactly once
+    assert "fake benchmark shown" in result.output  # and rendered its result via .show()
 
 
 def test_benchmark_output_round_trip(tmp_path: Path, monkeypatch):
@@ -59,3 +81,34 @@ def test_benchmark_output_round_trip(tmp_path: Path, monkeypatch):
     assert result.exit_code == 0
     round_tripped = FlopsBenchmarkResults.model_validate_json(output_path.read_text(encoding="utf-8"))
     assert round_tripped == results
+
+
+def test_benchmark_echoes_the_output_path(tmp_path: Path, monkeypatch):
+    """`benchmark --output` confirms the write with a 'Results written to' line naming the path."""
+
+    # --- arrange -----------------------------------------
+    results = list(BuiltInData.benchmarks().values()).pop()
+    monkeypatch.setattr(_cli, "run_flops_benchmark", lambda: results)
+    output_path = tmp_path / "benchmark_results.json"
+
+    # --- act ---------------------------------------------
+    result = CliRunner().invoke(benchmark, ["--output", str(output_path)])
+
+    # --- assert ------------------------------------------
+    assert result.exit_code == 0
+    assert f"Results written to '{output_path}'." in result.output
+
+
+def test_benchmark_without_output_writes_nothing_and_stays_silent(monkeypatch):
+    """With no --output the command shows results but skips the file write and its confirmation."""
+
+    # --- arrange -----------------------------------------
+    results = list(BuiltInData.benchmarks().values()).pop()
+    monkeypatch.setattr(_cli, "run_flops_benchmark", lambda: results)
+
+    # --- act ---------------------------------------------
+    result = CliRunner().invoke(benchmark)
+
+    # --- assert ------------------------------------------
+    assert result.exit_code == 0
+    assert "Results written to" not in result.output  # no write happened, so no confirmation line

--- a/tests/counting/config/test_defaults.py
+++ b/tests/counting/config/test_defaults.py
@@ -29,6 +29,21 @@ def test_default_flop_weights_rounding(rounding_mode: str):
 
 
 @pytest.mark.parametrize("getter", [get_builtin_flop_weights, get_default_consensus_flop_weights])
+def test_default_rounding_mode_is_ten_percent(getter):
+    # the documented public default is "10%"; every other test passes rounding_mode explicitly, so
+    # a changed default would slip through. Pin it: the no-arg result must match the explicit "10%"
+    # result (which also rules out a nearest_int default) and differ from the unrounded (None) one.
+    # --- act ---------------------------------------------
+    default = getter()
+    explicit_ten_percent = getter(rounding_mode="10%")
+    unrounded = getter(rounding_mode=None)
+
+    # --- assert ------------------------------------------
+    assert default.weights == explicit_ten_percent.weights  # default rounds the "10%" way...
+    assert default.weights != unrounded.weights  # ...and is not the unrounded default
+
+
+@pytest.mark.parametrize("getter", [get_builtin_flop_weights, get_default_consensus_flop_weights])
 def test_builtin_flop_weight_getters_return_defensive_copies(getter):
     # --- act ---------------------------------------------
     flop_weights = getter()

--- a/tests/counting/test_built_in_data.py
+++ b/tests/counting/test_built_in_data.py
@@ -7,7 +7,7 @@ from counted_float._core.counting._builtin_data import (
     _flat_to_nested_dict,
     _load_json_files_as_dict,
 )
-from counted_float._core.models import FlopsBenchmarkResults, FlopWeights
+from counted_float._core.models import FlopsBenchmarkResults, FlopType, FlopWeights
 
 
 # =================================================================================================
@@ -32,6 +32,23 @@ def test_builtin_data_get_flop_weights(key_filter: str):
 
     # --- assert ------------------------------------------
     assert isinstance(result, FlopWeights)
+
+
+def test_get_flop_weights_returns_independent_copies_per_call():
+    # "" is a precomputed cache key, so this exercises the cache-hit model_copy(deep=True) path:
+    # each call must hand back a distinct deep copy. A shared reference would let one caller's
+    # mutation corrupt the process-wide cache and every later caller.
+    # --- arrange -----------------------------------------
+    first = BuiltInData.get_flop_weights(key_filter="")
+    second = BuiltInData.get_flop_weights(key_filter="")
+
+    # --- act ---------------------------------------------
+    first.weights[FlopType.ADD] = -999.0  # mutate one copy
+
+    # --- assert ------------------------------------------
+    assert first is not second  # distinct objects...
+    assert second.weights[FlopType.ADD] != -999.0  # ...the sibling copy is untouched...
+    assert BuiltInData.get_flop_weights(key_filter="").weights[FlopType.ADD] != -999.0  # ...and so is the cache
 
 
 def test_builtin_data_get_flop_weights_invalid_key():

--- a/tests/counting/test_counted_float_counting.py
+++ b/tests/counting/test_counted_float_counting.py
@@ -807,7 +807,25 @@ def test_counted_float_pow_runtime_counted_exponent_counts_pow(thread_counter):
     assert thread_counter.POW == 1
 
 
-@pytest.mark.parametrize("method", ["__rfloordiv__", "__rmod__", "__rdivmod__", "__rpow__"])
+def test_counted_float_rpow_runtime_counted_base_counts_pow(thread_counter):
+    # a CountedFloat base reaches __rpow__ as a genuinely runtime value -- a port computes
+    # base ** x with no constant to fold, so a lone POW. Pin the absolute count so a
+    # magnitude/field mutant on this branch is caught (a self-comparison of two runtime paths
+    # would move alike on both sides and hide it)
+    # --- act ---------------------------------------------
+    result = CountedFloat(2.0).__rpow__(CountedFloat(3.0))  # base 3.0 ** exponent 2.0
+
+    # --- assert ------------------------------------------
+    assert float(result) == 9.0
+    assert isinstance(result, CountedFloat)
+    assert thread_counter.POW == 1
+    assert thread_counter.total_count() == 1
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["__radd__", "__rsub__", "__rmul__", "__rtruediv__", "__rfloordiv__", "__rmod__", "__rdivmod__", "__rpow__"],
+)
 def test_reflected_op_returns_notimplemented_for_unsupported_operand(method: str) -> None:
     # a reflected dunder must defer (return NotImplemented) when the underlying float op cannot
     # handle the other operand, so Python can fall through to the operand's own handling / a TypeError

--- a/tests/counting/test_math_patching_counting.py
+++ b/tests/counting/test_math_patching_counting.py
@@ -412,6 +412,20 @@ def test_dist_accepts_iterator_inputs_and_mismatched_lengths_raise(thread_counte
     assert thread_counter.DIST == 1  # only the successful call above counted anything
 
 
+def test_dist_counts_when_only_q_holds_a_counted_float(thread_counter):
+    # the contagion scan must cover BOTH point tuples: a CountedFloat present solely in q (with p
+    # all plain floats) is still a runtime input and still counts DIST -- a scan that only inspects
+    # p would miss it and hand back an uncounted plain float
+    # --- act ---------------------------------------------
+    result = math.dist([1.0, 2.0], [CountedFloat(4.0), CountedFloat(6.0)])
+
+    # --- assert ------------------------------------------
+    assert float(result) == 5.0
+    assert isinstance(result, CountedFloat)
+    assert thread_counter.DIST == 1
+    assert thread_counter.total_count() == 1
+
+
 @pytest.mark.parametrize("n_values", [1, 2, 4])
 def test_prod_counts_the_multiply_chain(thread_counter, n_values):
     # --- arrange -----------------------------------------
@@ -435,6 +449,20 @@ def test_prod_with_an_explicit_start_counts_its_multiply(thread_counter):
     assert float(result) == 30.0
     assert isinstance(result, CountedFloat)
     assert thread_counter.MUL == 2  # start*v1, then *v2
+
+
+def test_prod_with_a_plain_nonidentity_start_is_not_folded_away(thread_counter):
+    # a plain start of 2.0 is NOT the multiplicative identity: it opens the chain and its multiply
+    # is counted, exactly as writing the chain out would. Only an identity start (plain 1) folds
+    # away -- folding a non-identity start would drop a MUL and change the product itself
+    # --- act ---------------------------------------------
+    result = math.prod([CountedFloat(3.0), CountedFloat(4.0)], start=2.0)
+
+    # --- assert ------------------------------------------
+    assert float(result) == 24.0  # 2.0 * 3.0 * 4.0, not the folded-start 3.0 * 4.0 == 12.0
+    assert isinstance(result, CountedFloat)
+    assert thread_counter.MUL == 2  # 2.0*v1, then *v2
+    assert thread_counter.total_count() == 2
 
 
 def test_prod_without_counted_values_keeps_stdlib_behavior(thread_counter):

--- a/tests/counting/verbosity/test_callsite.py
+++ b/tests/counting/verbosity/test_callsite.py
@@ -38,6 +38,26 @@ def test_locate_call_skips_frames_inside_the_package():
     )
 
 
+def test_locate_call_skips_the_top_level_package_frame():
+    # --- arrange -----------------------------------------
+    # a frame whose module name is exactly the package, as ``counted_float/__init__.py`` reports --
+    # it lacks the trailing dot the submodule check keys on, so only the exact-name clause skips it.
+    package_frame = compile(
+        "from counted_float._core.counting.verbosity._callsite import locate_call\nlocation = locate_call()\n",
+        "<fabricated counted_float top-level frame>",
+        "exec",
+    )
+    namespace = {"__name__": "counted_float"}
+
+    # --- act ---------------------------------------------
+    exec(package_frame, namespace)  # noqa: S102 -- fabricating the top-level package frame is the point
+
+    # --- assert ------------------------------------------
+    assert Path(namespace["location"][0]).name == "test_callsite.py", (
+        "The top-level package frame should have been walked past, down to this test's frame."
+    )
+
+
 def test_locate_call_without_any_user_frame(monkeypatch):
     # --- arrange -----------------------------------------
     # the walk only gives up when no frame outside the package is left, which a caller of the

--- a/tests/counting/verbosity/test_flop_counts_with_logging.py
+++ b/tests/counting/verbosity/test_flop_counts_with_logging.py
@@ -69,6 +69,18 @@ def test_a_bulk_increment_logs_one_line_carrying_its_size(target, logged_lines):
     assert "+4" in line
 
 
+def test_a_further_increment_logs_its_delta_not_the_new_total(target, logged_lines):
+    # --- act ---------------------------------------------
+    target.ADD += 4
+    target.ADD += 3
+
+    # --- assert ------------------------------------------
+    first, second = logged_lines()
+    assert "+4" in first
+    assert "+3" in second, "The logged amount is this statement's increment, not the field's running total."
+    assert "+7" not in second
+
+
 def test_the_logged_line_reports_the_incrementing_location(target, logged_lines):
     # --- act ---------------------------------------------
     target.ADD += 1

--- a/tests/counting/verbosity/test_output.py
+++ b/tests/counting/verbosity/test_output.py
@@ -1,6 +1,35 @@
 import pytest
 
-from counted_float._core.counting.verbosity._output import _location_spans
+from counted_float._core.counting.verbosity._output import (
+    _COUNT_WIDTH,
+    _LEVEL_WIDTH,
+    _OPERATION_WIDTH,
+    VerbosityWriter,
+    _location_spans,
+)
+
+
+# ==================================================================================================
+#  Uncounted lines
+# ==================================================================================================
+def test_write_uncounted_renders_the_consequence(logged_lines):
+    # --- act ---------------------------------------------
+    VerbosityWriter.shared().write_uncounted("erf", "returns a plain float", "my_algo.py:42")
+
+    # --- assert ------------------------------------------
+    (line,) = logged_lines()
+    assert "returns a plain float" in line, "The consequence is what a WARN line exists to say."
+
+
+def test_write_uncounted_leaves_the_count_column_blank(logged_lines):
+    # --- act ---------------------------------------------
+    VerbosityWriter.shared().write_uncounted("erf", "returns a plain float", "my_algo.py:42")
+
+    # --- assert ------------------------------------------
+    (line,) = logged_lines()
+    count_column_start = _LEVEL_WIDTH + len("  ") + _OPERATION_WIDTH + len("  ")
+    count_column = line[count_column_start : count_column_start + _COUNT_WIDTH]
+    assert count_column.strip() == "", "Nothing was counted, so the count column stays empty."
 
 
 # ==================================================================================================

--- a/tests/counting/verbosity/test_uncounted_warnings.py
+++ b/tests/counting/verbosity/test_uncounted_warnings.py
@@ -181,6 +181,21 @@ def test_each_call_site_is_reported_separately(logged_lines):
     assert first != second, "Two distinct call sites are two distinct findings."
 
 
+def test_two_operations_from_one_call_site_are_both_reported(logged_lines):
+    # --- arrange -----------------------------------------
+    x = CountedFloat(2.5)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext(verbosity=Verbosity.WARNING):
+        _ = math.ulp(x), math.frexp(x)  # two operations, one source line -> one shared location
+
+    # --- assert ------------------------------------------
+    operations = {line.split()[1] for line in logged_lines()}
+    assert operations == {"ulp", "frexp"}, (
+        "The operation is half the dedup key, so two operations from one line are two findings."
+    )
+
+
 def test_a_call_site_is_reported_once_per_process(logged_lines):
     # --- arrange -----------------------------------------
     x = CountedFloat(2.5)

--- a/tests/models/test_flop_weights.py
+++ b/tests/models/test_flop_weights.py
@@ -140,6 +140,56 @@ def test_flop_weights_show_smoke(sample_flop_weights_dict_by_str):
     flop_weights.show()
 
 
+@pytest.mark.parametrize(("weight", "expected"), [(0.3, 1), (2.4, 2)])
+def test_round_nearest_int_floors_at_one_and_returns_int(weight: float, expected: int):
+    # 0.3 would round to 0, but the max(1, ...) floor lifts it to 1; 2.4 is a normal round above
+    # the floor. Both must come back as a genuine int, not a 1.0 float (the "10%"/round_number path
+    # returns floats, so the type is what tells the two apart).
+    # --- arrange -----------------------------------------
+    flop_weights = FlopWeights(weights={FlopType.ADD: weight})
+
+    # --- act ---------------------------------------------
+    rounded = flop_weights.round("nearest_int").weights[FlopType.ADD]
+
+    # --- assert ------------------------------------------
+    assert rounded == expected
+    assert isinstance(rounded, int) and not isinstance(rounded, float)  # int, never a float
+
+
+def test_round_nearest_int_leaves_missing_weights_missing():
+    # a NaN weight marks "unknown"; rounding must skip it, not turn it into a number (and note that
+    # round(nan) would itself raise, so a dropped NaN guard blows up here rather than degrading)
+    # --- arrange -----------------------------------------
+    flop_weights = FlopWeights(weights={FlopType.ADD: 2.0, FlopType.MUL: math.nan})
+
+    # --- act ---------------------------------------------
+    rounded = flop_weights.round("nearest_int")
+
+    # --- assert ------------------------------------------
+    assert rounded.weights[FlopType.ADD] == 2
+    assert math.isnan(rounded.weights[FlopType.MUL])  # missing stays missing
+
+
+def test_as_geo_mean_fill_missing_data_imputes_only_when_true(sample_flop_weights_dict_by_enum):
+    # one genuinely missing entry makes the two branches diverge: fill=True imputes it to a finite
+    # value (so the row's geo-mean is finite), fill=False leaves it NaN (so the geo-mean propagates
+    # NaN). Present entries must be untouched either way.
+    # --- arrange -----------------------------------------
+    weights1 = FlopWeights(weights=dict(sample_flop_weights_dict_by_enum))
+    weights2_dict = {k: v + 1 for k, v in sample_flop_weights_dict_by_enum.items()}
+    weights2_dict[FlopType.MUL] = math.nan  # the only missing entry
+    weights2 = FlopWeights(weights=weights2_dict)
+
+    # --- act ---------------------------------------------
+    filled = FlopWeights.as_geo_mean([weights1, weights2], fill_missing_data=True)
+    unfilled = FlopWeights.as_geo_mean([weights1, weights2], fill_missing_data=False)
+
+    # --- assert ------------------------------------------
+    assert not math.isnan(filled.weights[FlopType.MUL])  # imputed -> finite
+    assert math.isnan(unfilled.weights[FlopType.MUL])  # left missing -> NaN propagates
+    assert filled.weights[FlopType.ADD] == unfilled.weights[FlopType.ADD]  # present data untouched by fill
+
+
 @pytest.mark.parametrize("fill_missing_data", [True, False])
 def test_flop_weights_as_geo_mean(sample_flop_weights_dict_by_enum, fill_missing_data: bool):
     # --- arrange -----------------------------------------

--- a/tests/models/test_flop_weights.py
+++ b/tests/models/test_flop_weights.py
@@ -153,7 +153,8 @@ def test_round_nearest_int_floors_at_one_and_returns_int(weight: float, expected
 
     # --- assert ------------------------------------------
     assert rounded == expected
-    assert isinstance(rounded, int) and not isinstance(rounded, float)  # int, never a float
+    assert isinstance(rounded, int)  # a genuine int...
+    assert not isinstance(rounded, float)  # ...never a float (the "10%"/round_number path returns floats)
 
 
 def test_round_nearest_int_leaves_missing_weights_missing():

--- a/tests/shared/test_compatibility.py
+++ b/tests/shared/test_compatibility.py
@@ -31,3 +31,41 @@ def test_numba_dummy_decorator_bare_form_returns_the_function():
 
     # --- assert ------------------------------------------
     assert decorated is probe
+
+
+@pytest.mark.skipif(is_numba_installed(), reason="the dummy decorator shim exists only when numba is absent")
+def test_numba_dummy_decorator_parametrized_form_calls_through():
+    # without numba, `@njit(cache=True)` (the parametrized inner-decorator path, distinct from the
+    # bare form) must return a decorator that yields a function which still calls through unchanged
+    # --- arrange -----------------------------------------
+    from counted_float._core.compatibility._numba import dummy_decorator
+
+    def probe(x):
+        return x + 1.0
+
+    # --- act ---------------------------------------------
+    decorated = dummy_decorator(cache=True)(probe)
+
+    # --- assert ------------------------------------------
+    assert decorated is probe
+    assert decorated(2.0) == 3.0
+
+
+@pytest.mark.skipif(is_numba_installed(), reason="the dummy decorator shim exists only when numba is absent")
+def test_numba_dummy_decorator_signature_string_form_returns_a_working_decorator():
+    # without numba, `njit('float64(float64)')` -- a single non-callable positional arg -- must take
+    # the `isinstance(args[0], Callable)` false branch and return a decorator, not the string itself
+    # --- arrange -----------------------------------------
+    from counted_float._core.compatibility._numba import dummy_decorator
+
+    def probe(x):
+        return x * 2.0
+
+    # --- act ---------------------------------------------
+    decorator = dummy_decorator("float64(float64)")
+
+    # --- assert ------------------------------------------
+    assert callable(decorator)
+    decorated = decorator(probe)
+    assert decorated is probe
+    assert decorated(3.0) == 6.0

--- a/tests/utils/test_cpu_freq.py
+++ b/tests/utils/test_cpu_freq.py
@@ -44,3 +44,57 @@ def test_cpu_freq_normalizes_out_of_range_readings(monkeypatch, raw_reading, exp
 
     # --- assert ------------------------------------------
     assert result == expected_mhz
+
+
+@pytest.mark.parametrize("raw_reading", [None, 0.0, -1.0])
+def test_cpu_freq_none_zero_or_negative_reading_returns_none(monkeypatch, raw_reading):
+    # a None, zero, or negative reading must deterministically yield None (the `value <= 0.0` guard);
+    # this pins all three cases so a `<=`→`<`, `or`→`and`, or dropped `is None` mutant is caught
+    # --- arrange -----------------------------------------
+    monkeypatch.setattr(
+        psutil,
+        "cpu_freq",
+        lambda: SimpleNamespace(min=raw_reading, max=raw_reading, current=raw_reading),
+        raising=False,
+    )
+
+    # --- act ---------------------------------------------
+    result = _get_psutil_cpu_freq_attribute_mhz("min")
+
+    # --- assert ------------------------------------------
+    assert result is None
+
+
+def test_cpu_freq_missing_attribute_returns_none(monkeypatch):
+    # if psutil.cpu_freq() lacks the requested attribute, the AttributeError branch sets value=0.0 → None
+    # --- arrange -----------------------------------------
+    monkeypatch.setattr(psutil, "cpu_freq", lambda: SimpleNamespace(), raising=False)
+
+    # --- act ---------------------------------------------
+    result = _get_psutil_cpu_freq_attribute_mhz("current")
+
+    # --- assert ------------------------------------------
+    assert result is None
+
+
+def test_cpu_freq_wrappers_read_distinct_attributes(monkeypatch):
+    # each public wrapper must read its own attribute literal; distinct in-range values make a
+    # swapped "min"/"current"/"max" literal break both the exact reads and min ≤ current ≤ max
+    # --- arrange -----------------------------------------
+    monkeypatch.setattr(
+        psutil,
+        "cpu_freq",
+        lambda: SimpleNamespace(min=1000.0, current=2000.0, max=3000.0),
+        raising=False,
+    )
+
+    # --- act ---------------------------------------------
+    freq_min = get_cpu_frequency_mhz_min()
+    freq_current = get_cpu_frequency_mhz_current()
+    freq_max = get_cpu_frequency_mhz_max()
+
+    # --- assert ------------------------------------------
+    assert freq_min == 1000.0
+    assert freq_current == 2000.0
+    assert freq_max == 3000.0
+    assert freq_min <= freq_current <= freq_max

--- a/tests/utils/test_cpu_freq.py
+++ b/tests/utils/test_cpu_freq.py
@@ -68,7 +68,7 @@ def test_cpu_freq_none_zero_or_negative_reading_returns_none(monkeypatch, raw_re
 def test_cpu_freq_missing_attribute_returns_none(monkeypatch):
     # if psutil.cpu_freq() lacks the requested attribute, the AttributeError branch sets value=0.0 → None
     # --- arrange -----------------------------------------
-    monkeypatch.setattr(psutil, "cpu_freq", lambda: SimpleNamespace(), raising=False)
+    monkeypatch.setattr(psutil, "cpu_freq", SimpleNamespace, raising=False)  # called with no args -> empty namespace
 
     # --- act ---------------------------------------------
     result = _get_psutil_cpu_freq_attribute_mhz("current")

--- a/tests/utils/test_latency.py
+++ b/tests/utils/test_latency.py
@@ -24,3 +24,13 @@ def test_convert_nsecs_to_cycles(nsec, cpu_freq_mhz: float | None, fallback_freq
 
     # --- assert ------------------------------------------
     assert result == pytest.approx(expected_result)
+
+
+def test_convert_nsecs_to_cycles_uses_default_fallback_freq_mhz():
+    # with cpu_freq_mhz None and no explicit fallback, the default fallback_freq_mhz=1000 must apply;
+    # a mutated default (e.g. 2000) would double the result and fail this pin
+    # --- act ---------------------------------------------
+    result = convert_nsecs_to_cycles(nsec=3.0, cpu_freq_mhz=None)
+
+    # --- assert ------------------------------------------
+    assert result == pytest.approx(3.0)


### PR DESCRIPTION
With line and branch coverage already at 100%, these tests target assertions that would otherwise fail to catch a behavior change — the gaps coverage alone cannot see. They span FlopWeights value semantics, the no-numba compatibility shim, cpu-frequency and latency guards, the pure-Python benchmark ports (two-sum / TripleLength / libm bindings), the fold and contagion matrix, verbosity output fidelity, built-in-data and config defaults, and CLI behavior.

Pure test additions — no source change. Two benchmark-port tests carry version/interpreter guards (they need `math.sumprod` and a genuine FMA) and skip cleanly where unavailable.

Stacked on #263 — review/merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)