### PR TITLE
fix: refuse re-entry of an already active PauseFlopCounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- re-entering a `PauseFlopCounting` block that is already active now fails immediately with a clear message, instead of corrupting the pause state and silently leaving counting paused
+
 ### Security
 
 ## 2.0.2 (2026-07-24)

--- a/src/counted_float/_core/counting/_context_managers.py
+++ b/src/counted_float/_core/counting/_context_managers.py
@@ -20,6 +20,10 @@ from counted_float._core.models import FlopCounts
 _CROSS_THREAD_MESSAGE = (
     "FlopCountingContext is confined to the thread that opened it; open a separate context per thread"
 )
+_PAUSE_CROSS_THREAD_MESSAGE = (
+    "PauseFlopCounting is confined to the thread that entered it; pause each thread separately"
+)
+_PAUSE_REENTRY_MESSAGE = "PauseFlopCounting is already active; use a separate instance per 'with' block"
 
 
 # =================================================================================================
@@ -232,18 +236,33 @@ class PauseFlopCounting:
 
     This acts on the calling thread, across all of that thread's active FlopCountingContext
     instances.  On exit the counter's prior state is restored (rather than counting being resumed
-    unconditionally), so these blocks can be nested and can sit inside code that already paused
-    counting.
+    unconditionally), so a block can sit inside code that already paused counting, and blocks of
+    separate instances nest.
+
+    One instance covers one open block: entering an instance whose block is still open raises
+    RuntimeError, since the state to restore has a single slot.  Construct the manager where the
+    block is rather than holding one to reuse, and nesting takes care of itself.  (FlopCountingContext
+    does re-enter on one instance, because it accumulates counts that are read off it afterwards -
+    an identity worth keeping while open, which a pause has no equivalent of.)  Reusing an instance
+    for a later, non-overlapping block is fine.
 
     Like FlopCountingContext, an instance is confined to the thread that entered it: exiting from
     another thread raises RuntimeError (it would silently resume the *caller's* thread counter).
     """
 
     def __init__(self) -> None:
+        # State of the thread counter from before this block paused it, restored on exit
         self.__was_active: bool = False
+
+        # ident of the thread that entered the block; None while no block is open, which is what
+        # also makes it the liveness flag that the re-entry guard reads
         self.__owner_ident: int | None = None
 
     def __enter__(self) -> Self:
+        if self.__owner_ident is not None:
+            # refused before anything is written, so the open block keeps the state it saved:
+            # catching this error still leaves its exit able to restore counting correctly
+            raise RuntimeError(_PAUSE_REENTRY_MESSAGE)
         self.__owner_ident = threading.get_ident()
         self.__was_active = THREAD_COUNTER.is_active()
         THREAD_COUNTER.pause()
@@ -256,9 +275,7 @@ class PauseFlopCounting:
         exc_tb: TracebackType | None,
     ) -> None:
         if threading.get_ident() != self.__owner_ident:
-            raise RuntimeError(
-                "PauseFlopCounting is confined to the thread that entered it; pause each thread separately"
-            )
+            raise RuntimeError(_PAUSE_CROSS_THREAD_MESSAGE)
         self.__owner_ident = None
         if self.__was_active:
             THREAD_COUNTER.resume()

--- a/src/counted_float/_core/counting/_context_managers.py
+++ b/src/counted_float/_core/counting/_context_managers.py
@@ -236,15 +236,29 @@ class PauseFlopCounting:
 
     This acts on the calling thread, across all of that thread's active FlopCountingContext
     instances.  On exit the counter's prior state is restored (rather than counting being resumed
-    unconditionally), so a block can sit inside code that already paused counting, and blocks of
-    separate instances nest.
+    unconditionally), so a block can sit inside code that already paused counting.
 
-    One instance covers one open block: entering an instance whose block is still open raises
-    RuntimeError, since the state to restore has a single slot.  Construct the manager where the
-    block is rather than holding one to reuse, and nesting takes care of itself.  (FlopCountingContext
-    does re-enter on one instance, because it accumulates counts that are read off it afterwards -
-    an identity worth keeping while open, which a pause has no equivalent of.)  Reusing an instance
-    for a later, non-overlapping block is fine.
+    One instance covers one open block, so construct the manager where the block is:
+
+        with PauseFlopCounting():       # nested blocks of separate instances: fine
+            with PauseFlopCounting():
+                ...
+
+        pause = PauseFlopCounting()
+        with pause:
+            with pause:                 # re-entering an open block: RuntimeError
+                ...
+
+        pause = PauseFlopCounting()
+        with pause:
+            ...
+        with pause:                     # entering again once the block closed: fine
+            ...
+
+    The single slot holding the state to restore is what makes re-entry an error.
+    FlopCountingContext does re-enter on one instance: it accumulates counts that are read off it
+    afterwards, so its instance has an identity worth keeping while open - which a pause, holding
+    no result, has no equivalent of.
 
     Like FlopCountingContext, an instance is confined to the thread that entered it: exiting from
     another thread raises RuntimeError (it would silently resume the *caller's* thread counter).
@@ -260,8 +274,9 @@ class PauseFlopCounting:
 
     def __enter__(self) -> Self:
         if self.__owner_ident is not None:
-            # refused before anything is written, so the open block keeps the state it saved:
-            # catching this error still leaves its exit able to restore counting correctly
+            # guards against re-entering an instance whose block is still open, which would
+            # overwrite the single slot holding the state that block has to restore.  Refused
+            # before anything is written, so that state survives even if the error is caught
             raise RuntimeError(_PAUSE_REENTRY_MESSAGE)
         self.__owner_ident = threading.get_ident()
         self.__was_active = THREAD_COUNTER.is_active()

--- a/tests/counting/test_context_managers.py
+++ b/tests/counting/test_context_managers.py
@@ -236,6 +236,52 @@ def test_pause_flop_counting_restores_paused_state():
     assert flop_counts.MUL == 1
 
 
+def test_pause_flop_counting_reentry_of_open_instance_refused():
+    # --- arrange -----------------------------------------
+    cf1 = CountedFloat(1.0)
+    cf2 = CountedFloat(2.0)
+    pause = PauseFlopCounting()
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext() as fcc:
+        with pause:
+            # re-entering the same instance while its own block is still open
+            with pytest.raises(RuntimeError, match="already active"), pause:
+                pass
+            _ = cf1 + cf2  # still inside the open pause: not counted
+
+        # the refusal left the open block's saved state untouched, so its exit resumed counting
+        _ = cf1 * cf2  # should be counted
+
+    # --- assert ------------------------------------------
+    flop_counts = fcc.flop_counts()
+    assert flop_counts.ADD == 0
+    assert flop_counts.MUL == 1
+
+
+def test_pause_flop_counting_sequential_reuse_of_one_instance():
+    # --- arrange -----------------------------------------
+    cf1 = CountedFloat(1.0)
+    cf2 = CountedFloat(2.0)
+    pause = PauseFlopCounting()
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext() as fcc:
+        with pause:
+            _ = cf1 + cf2  # should not be counted
+        _ = cf1 * cf2  # should be counted
+        with pause:  # same instance, previous block closed
+            _ = cf1 - cf2  # should not be counted
+        _ = cf1 / cf2  # should be counted
+
+    # --- assert ------------------------------------------
+    flop_counts = fcc.flop_counts()
+    assert flop_counts.ADD == 0
+    assert flop_counts.SUB == 0
+    assert flop_counts.MUL == 1
+    assert flop_counts.DIV == 1
+
+
 def test_flop_counting_context_reentrant_same_instance():
     # --- arrange -----------------------------------------
     cf1 = CountedFloat(1.0)


### PR DESCRIPTION
**TL;DR**: Re-entering a `PauseFlopCounting` instance whose block is still open corrupted its saved state and silently stopped counting; it now refuses instead.

## Description

### Problem addressed

`PauseFlopCounting` suspends counting for a `with` block and, on exit, **restores the state from before** rather than resuming unconditionally — so a paused block can sit inside already-paused code. It keeps **one slot** for that saved state and one for the owning thread, and re-entering the **same instance** overwrote both:

```python
pause = PauseFlopCounting()
with pause:
    with pause:   # overwrites what the outer block saved
        ...
    # outer exit: RuntimeError, and counting never resumes
```

- the inner exit cleared the owner, so the outer exit failed its own owner-thread check and raised the **cross-thread** error — on one thread, where that message actively misleads;
- catching it is worse than letting it propagate: the counter **stays paused** for the rest of the block, so everything after goes uncounted.

Nesting *distinct* instances always worked, which is what the tests exercised and what the docstring promised without qualification.

### Implementation

The manager now **refuses** re-entry: entering an instance whose block is still open raises `RuntimeError`, and does so **before any state is written**, so the open block keeps what it saved and its own exit still restores counting correctly even if the error is caught.

That is a deliberate choice over the **depth-counter** approach its sibling `FlopCountingContext` uses. Holding one instance to re-enter only ever saved an allocation, and this codebase prices the counting hot path aggressively while leaving the context managers **deliberately cold** — so that allocation does not justify an ownership rule the class would carry forever. Constructing the manager at each block makes nesting work through **separate instances**, which was already correct.

Alongside the fix, both messages this class can raise moved into module constants next to the one its sibling already had, and the docstring states the rule through **worked examples** rather than prose.

## Attention points

- **Sequential reuse of one instance stays legal** — only re-entry while the block is open refuses. That is what keeps this patch-safe: every program that re-enters today is already failing, so nothing that currently works changes behavior. Making an instance single-use would instead have broken the module-level-instance pattern, which is fine today.
- **`FlopCountingContext` stays re-entrant on one instance**, deliberately. It accumulates counts that are read off it afterwards, so its instance has an identity worth keeping while open; a pause holds no result and has no equivalent. The docstring now says so, since the asymmetry is the first question a reader will have.
- **The failure now surfaces at the point of misuse** — the inner `__enter__` — instead of at the outer exit, after the damage.

## Tests / Spikes

- **TEST:** re-entry inside an open block raises, and the enclosing block still resumes counting on exit — the property that makes refusing early worth doing.
- **TEST:** one instance across two consecutive, non-overlapping blocks pauses correctly both times.
- 2 unit tests added. The existing distinct-instance nesting test is untouched and still passes.

## Changelog entry

Slotted under **Fixed**:

```
- re-entering a `PauseFlopCounting` block that is already active now fails immediately with a clear message, instead of corrupting the pause state and silently leaving counting paused
```


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
