### PR TITLE
fix: seal CountedFloat against subclassing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - re-entering a `PauseFlopCounting` block that is already active now fails immediately with a clear message, instead of corrupting the pause state and silently leaving counting paused
+- subclassing `CountedFloat` now fails at class definition instead of silently producing wrong flop counts
 
 ### Security
 

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -10,13 +10,16 @@ ensure results of math operations where at least one operand is a
 `CountedFloat` will also be a `CountedFloat`. This way we ensure flop counting
 is a 'closed system'.
 
-That closed system is also why `CountedFloat` is **final** — subclassing it
-raises `TypeError` at class-definition time. Every operator builds its result as
-a `CountedFloat` rather than as the operand's own type, so a subclass would lose
-its identity on its first operation; and for as long as it existed, the operand
-tests that drive constant folding would read it as a plain-float constant and
-price its arithmetic as folded away, undercounting silently. Hold a
-`CountedFloat` inside your own type rather than deriving from it.
+`CountedFloat` deliberately does **not** support subclassing — it is `final`,
+and deriving from it raises `TypeError` at class-definition time. That is a
+performance decision: with no subtype possible, every operator can tell a runtime
+value from a constant with an exact type check (`type(x) is CountedFloat`) rather
+than an `isinstance` test, which costs roughly twice as much on precisely the
+path that runs most — an operand that is a plain float, i.e. a constant to be
+folded. Supporting subclasses would also mean carrying the operand's own type
+through every result construction, on that same hot path.
+
+So hold a `CountedFloat` inside your own type rather than deriving from it.
 
 On top of this, `math` module functions that require counting (`sqrt`, `log2`,
 `pow`, ...) are also instrumented: while a `FlopCountingContext` is active

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -10,6 +10,14 @@ ensure results of math operations where at least one operand is a
 `CountedFloat` will also be a `CountedFloat`. This way we ensure flop counting
 is a 'closed system'.
 
+That closed system is also why `CountedFloat` is **final** — subclassing it
+raises `TypeError` at class-definition time. Every operator builds its result as
+a `CountedFloat` rather than as the operand's own type, so a subclass would lose
+its identity on its first operation; and for as long as it existed, the operand
+tests that drive constant folding would read it as a plain-float constant and
+price its arithmetic as folded away, undercounting silently. Hold a
+`CountedFloat` inside your own type rather than deriving from it.
+
 On top of this, `math` module functions that require counting (`sqrt`, `log2`,
 `pow`, ...) are also instrumented: while a `FlopCountingContext` is active
 (see below), they are temporarily replaced by counting equivalents. Outside

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -138,15 +138,17 @@ class CountedFloat(float):
     # exact errors plain float gives (and instances shed 16 of their 32 bytes over plain float)
     __slots__ = ()
 
-    # sealed at runtime, not only for type checkers: every operator builds its result as a
-    # CountedFloat by name rather than from the operand's type, so a subtype does not survive a
-    # single operation — and while it exists it is read as a plain-float constant by the operand
-    # tests below, which prices its arithmetic as folded-away and silently undercounts
+    # subclassing is consciously unsupported, sealed at runtime and not only for type checkers,
+    # because that is what buys the hot-path optimizations below: with no subtype possible, the
+    # operand tests can ask `type(other) is CountedFloat` instead of isinstance (about twice as
+    # cheap for a plain-float operand, which is the constant-folding path every operator runs),
+    # and every result can be constructed as a CountedFloat by name rather than from the
+    # operand's type
     def __init_subclass__(cls, **kwargs: object) -> None:
-        """Refuse subclass creation, which the operators cannot support."""
+        """Refuse subclass creation, which the hot-path design deliberately rules out."""
         raise TypeError(
-            "CountedFloat cannot be subclassed: its operators return CountedFloat, so a subtype "
-            "would be lost on the first operation and its arithmetic counted as a constant"
+            "CountedFloat does not support subclassing: its operators trade that away for exact-type "
+            "operand tests on the counting hot path.  Hold a CountedFloat in your own type instead."
         )
 
     # numpy counting is an explicit non-goal; refusing numpy's ufunc protocol makes the boundary

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import operator
 from math import copysign as _copysign  # the raw builtin: math.copysign is patched inside contexts
 from math import frexp as _frexp  # the raw builtin: math.frexp may later carry a reporting wrapper
-from typing import TYPE_CHECKING, SupportsIndex
+from typing import TYPE_CHECKING, SupportsIndex, final
 
 from ._thread_counter import _TLS, _create_thread_state
 
@@ -131,11 +131,23 @@ def count_pow_with_constant_base(base: float) -> None:
         cnt.POW += 1
 
 
+@final
 class CountedFloat(float):
     # a drop-in float, enforced: empty slots suppress the per-instance __dict__ a slotless
     # subclass would carry, so attribute assignment and weak references are refused with the
     # exact errors plain float gives (and instances shed 16 of their 32 bytes over plain float)
     __slots__ = ()
+
+    # sealed at runtime, not only for type checkers: every operator builds its result as a
+    # CountedFloat by name rather than from the operand's type, so a subtype does not survive a
+    # single operation — and while it exists it is read as a plain-float constant by the operand
+    # tests below, which prices its arithmetic as folded-away and silently undercounts
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        """Refuse subclass creation, which the operators cannot support."""
+        raise TypeError(
+            "CountedFloat cannot be subclassed: its operators return CountedFloat, so a subtype "
+            "would be lost on the first operation and its arithmetic counted as a constant"
+        )
 
     # numpy counting is an explicit non-goal; refusing numpy's ufunc protocol makes the boundary
     # loud instead of silently uncounted. With the protocol refused, numpy's scalar operators
@@ -425,7 +437,10 @@ class CountedFloat(float):
         result = float.__mul__(self, other)
         if result is NotImplemented:
             return NotImplemented
-        if type(other) is not CountedFloat and (other == 1.0 or other == -1.0):  # two compares: no set on the hot path
+        # two compares: no set on the hot path.  The type test short-circuits ahead of them, and the
+        # class is sealed, so the compares only ever see a plain float - never a counted __eq__,
+        # which would register a COMP the user never wrote
+        if type(other) is not CountedFloat and (other == 1.0 or other == -1.0):
             count_mul_with_identity_multiplier(other)
             return float.__new__(CountedFloat, result)
         try:
@@ -458,7 +473,7 @@ class CountedFloat(float):
         result = float.__truediv__(self, other)
         if result is NotImplemented:
             return NotImplemented
-        if isinstance(other, CountedFloat):
+        if type(other) is CountedFloat:
             try:
                 _TLS.flop_counts.DIV += 1  # genuinely runtime divisor
             except AttributeError:  # first counted op on this thread
@@ -489,7 +504,7 @@ class CountedFloat(float):
         result = float.__floordiv__(self, other)
         if result is NotImplemented:
             return NotImplemented
-        if isinstance(other, CountedFloat):
+        if type(other) is CountedFloat:
             try:
                 cnt: CountsTarget = _TLS.flop_counts
             except AttributeError:  # first counted op on this thread
@@ -533,7 +548,7 @@ class CountedFloat(float):
             cnt: CountsTarget = _TLS.flop_counts
         except AttributeError:  # first counted op on this thread
             cnt: CountsTarget = _create_thread_state()
-        if isinstance(other, CountedFloat):
+        if type(other) is CountedFloat:
             cnt.DIV += 1
         else:
             count_div_with_constant_divisor(other)
@@ -572,7 +587,7 @@ class CountedFloat(float):
             cnt: CountsTarget = _TLS.flop_counts
         except AttributeError:  # first counted op on this thread
             cnt: CountsTarget = _create_thread_state()
-        if isinstance(other, CountedFloat):
+        if type(other) is CountedFloat:
             cnt.DIV += 1
         else:
             count_div_with_constant_divisor(other)
@@ -615,7 +630,7 @@ class CountedFloat(float):
             return NotImplemented
         if not isinstance(result, float):
             return result
-        if isinstance(other, CountedFloat):
+        if type(other) is CountedFloat:
             try:
                 _TLS.flop_counts.POW += 1  # genuinely runtime exponent
             except AttributeError:  # first counted op on this thread
@@ -641,7 +656,7 @@ class CountedFloat(float):
             return NotImplemented
         if not isinstance(result, float):
             return result
-        if isinstance(other, CountedFloat):
+        if type(other) is CountedFloat:
             try:
                 _TLS.flop_counts.POW += 1  # genuinely runtime base
             except AttributeError:  # first counted op on this thread

--- a/tests/counting/test_counted_float.py
+++ b/tests/counting/test_counted_float.py
@@ -82,6 +82,14 @@ def test_counted_float_refuses_weak_references_like_plain_float():
         weakref.ref(cf)
 
 
+def test_counted_float_refuses_subclassing():
+    """Sealed for type checkers and at runtime: no operator can carry a subtype through."""
+    # --- act / assert ------------------------------------
+    with pytest.raises(TypeError, match="cannot be subclassed"):
+        type("Tagged", (CountedFloat,), {"__slots__": ()})
+    assert CountedFloat.__final__ is True  # the marker @final leaves for type checkers
+
+
 # =================================================================================================
 #  CountedFloat - Correct math operations
 # =================================================================================================

--- a/tests/counting/test_counted_float.py
+++ b/tests/counting/test_counted_float.py
@@ -85,7 +85,7 @@ def test_counted_float_refuses_weak_references_like_plain_float():
 def test_counted_float_refuses_subclassing():
     """Sealed for type checkers and at runtime: no operator can carry a subtype through."""
     # --- act / assert ------------------------------------
-    with pytest.raises(TypeError, match="cannot be subclassed"):
+    with pytest.raises(TypeError, match="does not support subclassing"):
         type("Tagged", (CountedFloat,), {"__slots__": ()})
     assert CountedFloat.__final__ is True  # the marker @final leaves for type checkers
 


### PR DESCRIPTION
**TL;DR**: `CountedFloat` is now sealed — subclassing raises at class definition. That removes a silent-miscount path and lets every operand test use the cheaper exact-type check.

## Description

### Problem addressed

Every operator has to decide whether its other operand is a **runtime value** (counted) or a **compile-time constant** (folded away, free). Three things were wrong with how that decision was made:

- **Two spellings.** The additive and multiplicative operators asked with an exact type check, the division family with an instance check — so a `CountedFloat` subclass was a constant to one half of the library and a runtime value to the other.
- **Leaked comparisons.** A counted operand passing the exact-type check reached the identity-fold guard, whose own `== 1.0` then dispatched into the **counted** equality:

  ```
  x * Tagged(5.0)        ->  {'COMP': 2, 'MUL': 1}   # two flops nobody wrote
  x * CountedFloat(5.0)  ->  {'MUL': 1}
  ```

- **Subclassing never worked anyway.** Every operator constructs its result as a `CountedFloat` **by name** rather than from the operand's type, so a subtype is lost on its first operation.

### Implementation

The extension point is **closed rather than repaired**: the class is marked final for type checkers *and* refuses subclass creation at runtime, so the misuse fails **where it is written** instead of as a wrong number later.

Sealing beat both ways of supporting subclasses. Supporting it **properly** means threading the operand's own type through every result construction on the hot path, replacing a compile-time constant with an attribute lookup. Supporting it **partially** — fixing only the operand tests — leaves a subclass that counts correctly and still evaporates on first use, which is the worst of the three outcomes.

With no subtype reachable, the exact-type check is correct everywhere, so all twelve operand tests unify on it. The split resolves toward the **cheaper** spelling rather than the more expensive one, and the leaked comparisons become **unreachable** rather than merely fixed. The counting docs now carry the stance and its motive, which they previously left to inference.

## Attention points

- **Patch-safe despite removing a capability.** Anyone subclassing today already gets wrong counts, so no program that currently works changes behavior.
- **Enforced at runtime, not only statically.** The final marker alone is advisory — a type checker sees it, a runtime subclass is still created and still miscounts — so the refusal fires at class-creation time, where it costs nothing measurable.
- **Composition is the documented alternative**: hold a `CountedFloat` inside your own type rather than deriving from it. Both the error message and the docs say so.

## Tests / Spikes

- **SPIKE:** micro-benchmarked the two operand-test spellings (2M reps × 7, best-of). They tie when the operand is counted — 7.22 ns for the instance check against 7.51 ns for the exact-type one, both taking CPython's identity fast path. When the operand is a plain float the instance check falls through to a real subclass check and costs **14.84 ns against 7.21 ns**. That slower case is the constant-folding path every operator runs, which is what makes unifying on exact-type worth doing.
- **TEST:** bisection benchmark end to end, back-to-back on one machine: 269.67 µs/exec before this change, 267.71 µs/exec after — small, and in the expected direction since the change removes operand checks rather than adding any.
- 1 unit test added, pinning both halves of the seal: the runtime refusal and the marker type checkers read.

## Changelog entry

Slotted under **Fixed**:

```
- subclassing `CountedFloat` now fails at class definition instead of silently producing wrong flop counts
```


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
