### PR TITLE
test: pin the lazy-init branches to the same counter field

### DIFF
--- a/tests/counting/test_lazy_init_parity.py
+++ b/tests/counting/test_lazy_init_parity.py
@@ -1,0 +1,81 @@
+"""Structural parity between the two branches of the inlined lazy-init idiom.
+
+Counting sites increment the calling thread's counter directly and fall back to creating that
+thread's state in an `except AttributeError` handler.  The idiom is written out at every site
+rather than factored into a helper - a call would cost about as much as the increment it guards -
+so only a test can guarantee that a handler touches the same counter field as the `try` body it
+backs.  A mismatch there fires on a thread's very first counted operation and never again, which
+is why it survives both full line coverage and mutation testing.
+"""
+
+import ast
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from counted_float._core.counting import _counted_float, _math_patching
+
+_LAZY_INIT_MODULES = [_counted_float, _math_patching]
+
+
+def _module_id(module: ModuleType) -> str:
+    """Bare module name, for readable parametrize ids."""
+    return module.__name__.rsplit(".", 1)[-1]
+
+
+def _lazy_init_pairs(tree: ast.Module) -> list[tuple[ast.Try, ast.ExceptHandler]]:
+    """Every `try` in the tree paired with its handler that catches AttributeError."""
+    return [
+        (node, handler)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Try)
+        for handler in node.handlers
+        if isinstance(handler.type, ast.Name) and handler.type.id == "AttributeError"
+    ]
+
+
+def _counter_increments(body: list[ast.stmt]) -> list[tuple[str, str]]:
+    """(field, increment source) for every `<expr>.FIELD += <expr>` directly in a branch body.
+
+    The increment is compared as source rather than as a value, so the sites that count a
+    length-derived number of flops are held to the same expression on both branches.
+    """
+    return [
+        (stmt.target.attr, ast.unparse(stmt.value))
+        for stmt in body
+        if isinstance(stmt, ast.AugAssign) and isinstance(stmt.op, ast.Add) and isinstance(stmt.target, ast.Attribute)
+    ]
+
+
+def _bound_names(body: list[ast.stmt]) -> list[str]:
+    """Names bound by an assignment directly in a branch body, in order."""
+    names: list[str] = []
+    for stmt in body:
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            names.append(stmt.target.id)
+        elif isinstance(stmt, ast.Assign):
+            names.extend(target.id for target in stmt.targets if isinstance(target, ast.Name))
+    return names
+
+
+@pytest.mark.parametrize("module", _LAZY_INIT_MODULES, ids=_module_id)
+def test_lazy_init_handler_matches_its_try_branch(module: ModuleType):
+    # --- arrange -----------------------------------------
+    source = Path(module.__file__ or "").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    # --- act ---------------------------------------------
+    pairs = _lazy_init_pairs(tree)
+
+    # --- assert ------------------------------------------
+    # renaming the idiom out of existence must fail here, not pass vacuously over zero matches
+    assert pairs, f"no lazy-init try/except AttributeError pairs found in {module.__name__}"
+
+    for try_node, handler in pairs:
+        where = f"{_module_id(module)}:{try_node.lineno}"
+        increments = _counter_increments(try_node.body)
+        bindings = _bound_names(try_node.body)
+        assert increments or bindings, f"{where}: try branch neither counts nor binds - unknown idiom"
+        assert _counter_increments(handler.body) == increments, f"{where}: handler counts something else"
+        assert _bound_names(handler.body) == bindings, f"{where}: handler binds something else"

--- a/tests/counting/test_lazy_init_parity.py
+++ b/tests/counting/test_lazy_init_parity.py
@@ -1,11 +1,22 @@
 """Structural parity between the two branches of the inlined lazy-init idiom.
 
 Counting sites increment the calling thread's counter directly and fall back to creating that
-thread's state in an `except AttributeError` handler.  The idiom is written out at every site
-rather than factored into a helper - a call would cost about as much as the increment it guards -
-so only a test can guarantee that a handler touches the same counter field as the `try` body it
-backs.  A mismatch there fires on a thread's very first counted operation and never again, which
-is why it survives both full line coverage and mutation testing.
+thread's state in an ``except AttributeError`` handler:
+
+    try:
+        _TLS.flop_counts.ADD += 1
+    except AttributeError:  # first counted op on this thread
+        _create_thread_state().ADD += 1
+
+The idiom is written out at every site rather than factored into a helper - a call would cost
+about as much as the increment it guards - so only a test can guarantee that a handler touches the
+same counter field as the ``try`` body it backs.  A mismatch there fires on a thread's very first
+counted operation and never again, which is why it survives both full line coverage and mutation
+testing.
+
+The helpers below take that example apart: the ``try``/``except AttributeError`` pair itself, the
+``ADD += 1`` write inside each of its branches, and - for the sites whose branches bind the counter
+to a local rather than incrementing it in place - the name each branch binds.
 """
 
 import ast
@@ -19,13 +30,19 @@ from counted_float._core.counting import _counted_float, _math_patching
 _LAZY_INIT_MODULES = [_counted_float, _math_patching]
 
 
+# =================================================================================================
+#  Helpers
+# =================================================================================================
 def _module_id(module: ModuleType) -> str:
     """Bare module name, for readable parametrize ids."""
     return module.__name__.rsplit(".", 1)[-1]
 
 
 def _lazy_init_pairs(tree: ast.Module) -> list[tuple[ast.Try, ast.ExceptHandler]]:
-    """Every `try` in the tree paired with its handler that catches AttributeError."""
+    """Every `try` in the tree paired with its handler that catches AttributeError.
+
+    The outer shape of the example in the module docstring.
+    """
     return [
         (node, handler)
         for node in ast.walk(tree)
@@ -38,8 +55,9 @@ def _lazy_init_pairs(tree: ast.Module) -> list[tuple[ast.Try, ast.ExceptHandler]
 def _counter_increments(body: list[ast.stmt]) -> list[tuple[str, str]]:
     """(field, increment source) for every `<expr>.FIELD += <expr>` directly in a branch body.
 
-    The increment is compared as source rather than as a value, so the sites that count a
-    length-derived number of flops are held to the same expression on both branches.
+    The `ADD += 1` of the example in the module docstring, taken from one branch.  The increment
+    is compared as source rather than as a value, so the sites that count a length-derived number
+    of flops are held to the same expression on both branches.
     """
     return [
         (stmt.target.attr, ast.unparse(stmt.value))
@@ -49,7 +67,11 @@ def _counter_increments(body: list[ast.stmt]) -> list[tuple[str, str]]:
 
 
 def _bound_names(body: list[ast.stmt]) -> list[str]:
-    """Names bound by an assignment directly in a branch body, in order."""
+    """Names bound by an assignment directly in a branch body, in order.
+
+    The variant of the example where a branch binds the counter to a local (`cnt = ...`) and the
+    increments follow after the try/except, instead of incrementing in place.
+    """
     names: list[str] = []
     for stmt in body:
         if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
@@ -59,6 +81,9 @@ def _bound_names(body: list[ast.stmt]) -> list[str]:
     return names
 
 
+# =================================================================================================
+#  Tests
+# =================================================================================================
 @pytest.mark.parametrize("module", _LAZY_INIT_MODULES, ids=_module_id)
 def test_lazy_init_handler_matches_its_try_branch(module: ModuleType):
     # --- arrange -----------------------------------------


### PR DESCRIPTION
**TL;DR**: Adds a test that parses both counting modules and asserts every cold-start handler increments the same counter field, with the same expression, as the `try` body it backs.

## Description

### Problem addressed

Every counting site increments the calling thread's counter inline, falling back to creating that thread's state when it does not exist yet:

```python
try:
    _TLS.flop_counts.ADD += 1
except AttributeError:            # first counted op on this thread
    _create_thread_state().ADD += 1   # nothing checks this is the same field
```

The idiom is **written out at each site** rather than factored into a helper — a call would cost about as much as the increment it guards — so every handler is a **hand-copied twin** of its `try` body, and a handler naming the wrong field is an unusually well-hidden slip:

- it fires on a thread's **very first** counted operation and never again, so one flop stays misattributed per thread indefinitely;
- **line coverage** cannot see it, because both branches execute;
- **mutation testing** cannot either, because the mutant needed is a field swap between two valid branches.

### Implementation

The test parses each module and walks every `try` whose handler catches the cold-start error, comparing **what the two branches write**.

- **Two shapes are covered**: the sites that increment a field in place, and the sites that bind the counter to a local in both branches and increment after the block. A pair matching neither fails as an **unrecognized idiom** rather than passing silently.
- **The increment is compared as source text**, not as a value, so the sites counting a length-derived number of flops are held to the same expression on both branches — not merely to the same field.
- **Pairs must be found at all**, so renaming the idiom out of existence fails loudly instead of passing over zero matches.

Scope is the two counting modules. The thread-counter module's single handler of the same exception is a **different construct** — a bare attribute probe inside the get-or-create facade, with no counter write — so it is deliberately out of scope.

## Attention points

- **No source changes.** This adds a test file and nothing else.
- **The idiom is pinned, not refactored.** Collapsing the copies via code generation would break coverage line attribution and mutation-testing mutant addressing, and the reasoning for inlining is already documented where the thread counter lives. This closes the risk without paying either cost.

## Tests / Spikes

- **TEST:** verified the test is not vacuous by deliberately swapping one handler's counter field to a different one — it fails and names the exact module and line. Reverted immediately.
- 1 parametrized test added, covering both counting modules.

## Changelog entry

```
None: test-only, no user-facing change — no category, no entry.
```


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
