### PR TITLE
chore: gate the release on a healthy mutation run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ regen-machine-code:
 	uv run --all-extras python scripts/generate_machine_code_docs.py
 
 release:
-	@test -n "$(VERSION)" || (echo "Usage: make release VERSION=X.Y.Z" && exit 1)
+	# DRY_RUN=1 stops after the preconditions (mutation measurement included), writing nothing
+	@test -n "$(VERSION)" || (echo "Usage: make release VERSION=X.Y.Z [DRY_RUN=1]" && exit 1)
 	$(MAKE) test
-	uv run python scripts/release.py $(VERSION)
+	uv run python scripts/release.py $(VERSION) $(if $(DRY_RUN),--dry-run,)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,9 +1,13 @@
 """Release driver for counted-float.
 
-Run via ``make release VERSION=X.Y.Z``.  Validates state, finalizes the
-changelog, commits, tags, opens a new Unreleased section, commits, and
-pushes main + tag atomically.  The package version itself is derived from
-the git tag at build time (hatch-vcs), so no version bump is written.
+Run via ``make release VERSION=X.Y.Z``.  Validates state, gathers the badge
+metrics, finalizes the changelog, commits, tags, opens a new Unreleased
+section, commits, and pushes main + tag atomically.  The package version
+itself is derived from the git tag at build time (hatch-vcs), so no version
+bump is written.
+
+Every check that can fail runs before the first write, so an abort always
+leaves the tree as it was.  ``--dry-run`` stops at exactly that boundary.
 """
 
 from __future__ import annotations
@@ -17,8 +21,10 @@ import sys
 import tempfile
 import urllib.error
 import urllib.request
+from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
+from typing import NoReturn
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = REPO_ROOT / "pyproject.toml"
@@ -32,6 +38,10 @@ MUTATION_STATS_FILE = REPO_ROOT / "mutants" / "mutmut-cicd-stats.json"
 PACKAGE_NAME = "counted-float"
 CATEGORIES = ["Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"]
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+# ceiling on the mutation measurement, past which the run is treated as unable to produce a number.
+# A healthy full run finishes in a small fraction of this; the headroom is for a bad run, not for an
+# unknown machine -- the release always runs on the maintainer's.
+MUTATION_TIMEOUT_SEC = 600
 # provenance line above the badge block: rewritten in place each release, never appended to
 BADGE_STAMP_RE = re.compile(r"^<!-- badges below refreshed at release v[^>]*-->$", re.MULTILINE)
 
@@ -59,7 +69,7 @@ def print_step(n: int, msg: str) -> None:
     print(f"  [{n:>2}] {msg}")
 
 
-def fail_with_message(msg: str, code: int = 1) -> None:
+def fail_with_message(msg: str, code: int = 1) -> NoReturn:
     """Print an error and exit."""
     print(f"\nERROR: {msg}", file=sys.stderr)
     sys.exit(code)
@@ -167,51 +177,23 @@ def step_7_check_changelog_has_entries() -> None:
 
 
 # ==================================================================================================
-#  release commit steps (8-10)
+#  badge metrics (step 8)
 # ==================================================================================================
-def step_8_finalize_changelog(version: str) -> None:
-    """Move Unreleased entries to a dated version section."""
-    print_step(8, f"finalize CHANGELOG.md '## Unreleased' -> '## {version} ({date.today().isoformat()})'")
-    text = CHANGELOG.read_text()
-    m = re.search(r"^## Unreleased\s*$(.*?)(?=^## |\Z)", text, re.MULTILINE | re.DOTALL)
-    if not m:
-        fail_with_message("no '## Unreleased' section to finalize")
-    body = m.group(1)
-    new_body_lines: list[str] = []
-    lines = body.splitlines(keepends=True)
-    i = 0
-    while i < len(lines):
-        line = lines[i]
-        cat_match = re.match(r"^### (\w+)\s*$", line)
-        if cat_match and cat_match.group(1) in CATEGORIES:
-            j = i + 1
-            has_entry = False
-            while j < len(lines) and not re.match(r"^### ", lines[j]):
-                if lines[j].lstrip().startswith("- "):
-                    has_entry = True
-                    break
-                j += 1
-            if has_entry:
-                new_body_lines.append(line)
-                i += 1
-                while i < len(lines) and not re.match(r"^### ", lines[i]):
-                    new_body_lines.append(lines[i])
-                    i += 1
-            else:
-                i += 1
-                while i < len(lines) and lines[i].strip() == "":
-                    i += 1
-        else:
-            new_body_lines.append(line)
-            i += 1
-    new_body = "".join(new_body_lines).rstrip() + "\n"
-    new_header = f"## {version} ({date.today().isoformat()})\n"
-    text = text[: m.start()] + new_header + new_body + text[m.end() :]
-    CHANGELOG.write_text(text)
-
+# Gathering these is the last precondition, and the only one that can take minutes: it runs after
+# every cheap check has passed and before the first write, so an abort here costs nothing to
+# recover from.
 
 # warn if the cumulative union exceeds this multiple of the largest single combo
 TEST_COUNT_UNION_RATIO_WARN = 1.5
+
+
+@dataclass(frozen=True)
+class BadgeMetrics:
+    """The badge numbers for one release, gathered before anything is written."""
+
+    coverage_pct: float
+    test_union: int
+    mutation_pct: int
 
 
 def _latest_main_coverage_run() -> tuple[str, str]:
@@ -277,7 +259,7 @@ def _mutation_color(pct: int) -> str:
     return "yellow" if pct >= 60 else "red"
 
 
-def _measure_mutation_score() -> int | None:
+def _measure_mutation_score() -> int:
     """Run the mutation suite locally and return its score as a whole percentage.
 
     Unlike the coverage and test-count metrics, this one cannot come from CI: mutation testing is
@@ -287,34 +269,111 @@ def _measure_mutation_score() -> int | None:
     Killed over *all* mutants: timeouts count toward the denominator but never the numerator, so a
     mutant that merely ran slowly is never scored as caught.
 
+    Two questions are kept apart. Whether a number could be produced at all gates the release: a
+    crashing suite, a missing or malformed stats file, an empty mutant set or a run past
+    MUTATION_TIMEOUT_SEC all mean the measurement is broken, and swallowing that compounds
+    silently across every later release -- the badge would keep claiming a figure nobody measured.
+    What the number *is* never gates: the score wobbles run to run from timeout nondeterminism, so
+    a threshold would reject releases over measurement noise.
+
     Returns:
-        The rounded percentage, or None if the run or its stats could not be obtained -- in which
-        case the committed badge is left untouched. This never aborts the release: the run is
-        mildly timeout-sensitive and machine-dependent, and a stray survivor must not block a
-        publish.
+        The rounded percentage.
     """
     print("  measuring the mutation score (runs the mutation suite; takes a few minutes)")
     MUTATION_STATS_FILE.unlink(missing_ok=True)
     for target in ("mutation", "mutation-stats"):
-        # not run_command(): that raises, and a mutation hiccup must never fail a release
-        outcome = subprocess.run(["make", target], cwd=REPO_ROOT, capture_output=True, check=False)
-        if outcome.returncode != 0:
-            print(
-                f"\nWARNING: 'make {target}' failed; leaving the committed mutation badge as is. "
-                f"Run it by hand to see why -- its output is captured here to keep the release log readable.\n",
-                file=sys.stderr,
+        # not run_command(): its diagnostics dump captured output, which for a full mutation run
+        # buries the actual message -- the hint to re-run by hand is more useful here
+        try:
+            outcome = subprocess.run(
+                ["make", target],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                check=False,
+                timeout=MUTATION_TIMEOUT_SEC,
             )
-            return None
+        except subprocess.TimeoutExpired:
+            fail_with_message(
+                f"'make {target}' did not finish within {MUTATION_TIMEOUT_SEC}s, so no mutation score "
+                f"could be measured. Run it by hand to see where it hangs."
+            )
+        if outcome.returncode != 0:
+            fail_with_message(
+                f"'make {target}' failed, so no mutation score could be measured. "
+                f"Run it by hand to see why -- its output is captured here to keep the release log readable."
+            )
     try:
         stats = json.loads(MUTATION_STATS_FILE.read_text())
         killed, total = int(stats["killed"]), int(stats["total"])
     except (OSError, ValueError, KeyError) as exc:
-        print(f"\nWARNING: could not read the mutation stats ({exc}); leaving the badge as is.\n", file=sys.stderr)
-        return None
+        fail_with_message(f"could not read the mutation stats ({exc}), so no mutation score could be measured")
     if total <= 0:
-        print("\nWARNING: the mutation run produced no mutants; leaving the badge as is.\n", file=sys.stderr)
-        return None
+        fail_with_message("the mutation run produced no mutants, so no mutation score could be measured")
     return round(100 * killed / total)
+
+
+def step_8_gather_badge_metrics() -> BadgeMetrics:
+    """Resolve every badge number, failing the release if any of them cannot be obtained."""
+    print_step(8, "gather badge metrics (CI metrics for HEAD + local mutation score)")
+    metrics = _fetch_release_metrics()
+    union = int(metrics["test_union"])
+    max_combo = int(metrics["test_max"])
+    if max_combo and union > TEST_COUNT_UNION_RATIO_WARN * max_combo:
+        print(
+            f"\nWARNING: cumulative test count ({union}) exceeds "
+            f"{TEST_COUNT_UNION_RATIO_WARN}x the largest single combo ({max_combo}). "
+            "Node-id mismatches across combos can inflate the union — verify before publishing.\n",
+            file=sys.stderr,
+        )
+    return BadgeMetrics(
+        coverage_pct=float(metrics["coverage_pct"]),
+        test_union=union,
+        mutation_pct=_measure_mutation_score(),
+    )
+
+
+# ==================================================================================================
+#  release commit steps (9-11)
+# ==================================================================================================
+def step_9_finalize_changelog(version: str) -> None:
+    """Move Unreleased entries to a dated version section."""
+    print_step(9, f"finalize CHANGELOG.md '## Unreleased' -> '## {version} ({date.today().isoformat()})'")
+    text = CHANGELOG.read_text()
+    m = re.search(r"^## Unreleased\s*$(.*?)(?=^## |\Z)", text, re.MULTILINE | re.DOTALL)
+    if not m:
+        fail_with_message("no '## Unreleased' section to finalize")
+    body = m.group(1)
+    new_body_lines: list[str] = []
+    lines = body.splitlines(keepends=True)
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        cat_match = re.match(r"^### (\w+)\s*$", line)
+        if cat_match and cat_match.group(1) in CATEGORIES:
+            j = i + 1
+            has_entry = False
+            while j < len(lines) and not re.match(r"^### ", lines[j]):
+                if lines[j].lstrip().startswith("- "):
+                    has_entry = True
+                    break
+                j += 1
+            if has_entry:
+                new_body_lines.append(line)
+                i += 1
+                while i < len(lines) and not re.match(r"^### ", lines[i]):
+                    new_body_lines.append(lines[i])
+                    i += 1
+            else:
+                i += 1
+                while i < len(lines) and lines[i].strip() == "":
+                    i += 1
+        else:
+            new_body_lines.append(line)
+            i += 1
+    new_body = "".join(new_body_lines).rstrip() + "\n"
+    new_header = f"## {version} ({date.today().isoformat()})\n"
+    text = text[: m.start()] + new_header + new_body + text[m.end() :]
+    CHANGELOG.write_text(text)
 
 
 def _stamp_badge_provenance(text: str, version: str) -> str:
@@ -330,37 +389,25 @@ def _stamp_badge_provenance(text: str, version: str) -> str:
     return f"{stamp}\n{text}"
 
 
-def refresh_readme_badges(version: str) -> None:
-    """Stamp the README coverage, test-count and mutation badges, and record the release they describe.
+def refresh_readme_badges(version: str, badges: BadgeMetrics) -> None:
+    """Stamp the README badges from already-gathered numbers, and record the release they describe.
 
-    Coverage and test counts come from CI's cumulative metrics; the mutation score is measured
-    locally (see _measure_mutation_score) and is skipped rather than fatal when unavailable.
+    Purely a write: everything that can fail was resolved during validation, so reaching here means
+    the badge values are known and the provenance stamp cannot end up naming a release whose
+    measurements were never taken.
     """
-    metrics = _fetch_release_metrics()
-    coverage_pct = float(metrics["coverage_pct"])
-    union = int(metrics["test_union"])
-    max_combo = int(metrics["test_max"])
-    if max_combo and union > TEST_COUNT_UNION_RATIO_WARN * max_combo:
-        print(
-            f"\nWARNING: cumulative test count ({union}) exceeds "
-            f"{TEST_COUNT_UNION_RATIO_WARN}x the largest single combo ({max_combo}). "
-            "Node-id mismatches across combos can inflate the union — verify before publishing.\n",
-            file=sys.stderr,
-        )
     text = README.read_text()
     text = re.sub(
         r"badge/coverage-[\d.]+%25-[a-z]+",
-        f"badge/coverage-{coverage_pct:.2f}%25-{_coverage_color(coverage_pct)}",
+        f"badge/coverage-{badges.coverage_pct:.2f}%25-{_coverage_color(badges.coverage_pct)}",
         text,
     )
-    text = re.sub(r"badge/tests-\d+-blue", f"badge/tests-{union}-blue", text)
-    mutation_pct = _measure_mutation_score()
-    if mutation_pct is not None:
-        text = re.sub(
-            r"badge/mutmut-\d+%25-[a-z]+",
-            f"badge/mutmut-{mutation_pct}%25-{_mutation_color(mutation_pct)}",
-            text,
-        )
+    text = re.sub(r"badge/tests-\d+-blue", f"badge/tests-{badges.test_union}-blue", text)
+    text = re.sub(
+        r"badge/mutmut-\d+%25-[a-z]+",
+        f"badge/mutmut-{badges.mutation_pct}%25-{_mutation_color(badges.mutation_pct)}",
+        text,
+    )
     README.write_text(_stamp_badge_provenance(text, version))
 
 
@@ -376,27 +423,27 @@ def stamp_splash(version: str) -> None:
     run_command(["sh", str(SPLASH_SCRIPT), f"v{version}"], cwd=REPO_ROOT)
 
 
-def step_9_commit_release(version: str) -> None:
+def step_10_commit_release(version: str, badges: BadgeMetrics) -> None:
     """Refresh README badges, stamp the splash, then create the release commit."""
-    print_step(9, f"refresh README badges + stamp splash + commit 'release: {version}'")
-    refresh_readme_badges(version)
+    print_step(10, f"refresh README badges + stamp splash + commit 'release: {version}'")
+    refresh_readme_badges(version, badges)
     stamp_splash(version)
     run_command(["git", "add", "CHANGELOG.md", "README.md", str(SPLASH_WEBP)])
     run_command(["git", "commit", "-m", f"release: {version}"])
 
 
-def step_10_tag(version: str) -> None:
+def step_11_tag(version: str) -> None:
     """Create the version tag."""
-    print_step(10, f"create tag v{version}")
+    print_step(11, f"create tag v{version}")
     run_command(["git", "tag", f"v{version}"])
 
 
 # ==================================================================================================
-#  post-release steps (11-13)
+#  post-release steps (12-14)
 # ==================================================================================================
-def step_11_add_unreleased_section() -> None:
+def step_12_add_unreleased_section() -> None:
     """Add a fresh Unreleased section to the changelog."""
-    print_step(11, "add fresh '## Unreleased' section to CHANGELOG.md")
+    print_step(12, "add fresh '## Unreleased' section to CHANGELOG.md")
     text = CHANGELOG.read_text()
     m = re.search(r"^## ", text, re.MULTILINE)
     if not m:
@@ -406,16 +453,16 @@ def step_11_add_unreleased_section() -> None:
     CHANGELOG.write_text(text)
 
 
-def step_12_commit_next_cycle() -> None:
+def step_13_commit_next_cycle() -> None:
     """Commit the fresh Unreleased section."""
-    print_step(12, "commit 'chore: begin next development cycle'")
+    print_step(13, "commit 'chore: begin next development cycle'")
     run_command(["git", "add", "CHANGELOG.md"])
     run_command(["git", "commit", "-m", "chore: begin next development cycle"])
 
 
-def step_13_push(version: str) -> None:
+def step_14_push(version: str) -> None:
     """Push main and the tag atomically."""
-    print_step(13, f"push main + v{version} atomically")
+    print_step(14, f"push main + v{version} atomically")
     run_command(["git", "push", "--atomic", "origin", "main", f"refs/tags/v{version}"])
 
 
@@ -439,6 +486,11 @@ def main() -> None:
     """Entry point."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("version", help="X.Y.Z (no leading v)")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="run every precondition, including the mutation measurement, then stop before the first write",
+    )
     args = parser.parse_args()
     version = args.version
     parse_semver(version)
@@ -453,24 +505,32 @@ def main() -> None:
     step_5_check_pypi_doesnt_have(version)
     step_6_check_classifiers_match()
     step_7_check_changelog_has_entries()
+    badges = step_8_gather_badge_metrics()
+
+    if args.dry_run:
+        print(
+            f"\nDry run: every precondition passed and nothing was written.\n"
+            f"  coverage {badges.coverage_pct:.2f}% | tests {badges.test_union} | mutation {badges.mutation_pct}%\n"
+        )
+        return
 
     print("\nRelease commit:")
-    step_8_finalize_changelog(version)
-    step_9_commit_release(version)
-    step_10_tag(version)
+    step_9_finalize_changelog(version)
+    step_10_commit_release(version, badges)
+    step_11_tag(version)
 
     print("\nPost-release:")
     also_next_cycle = False
     try:
-        step_11_add_unreleased_section()
-        step_12_commit_next_cycle()
+        step_12_add_unreleased_section()
+        step_13_commit_next_cycle()
         also_next_cycle = True
-        step_13_push(version)
+        step_14_push(version)
     except subprocess.CalledProcessError:
-        post_tag_recovery_hint(11, version, also_next_cycle)
+        post_tag_recovery_hint(12, version, also_next_cycle)
         sys.exit(1)
     except SystemExit:
-        post_tag_recovery_hint(11, version, also_next_cycle)
+        post_tag_recovery_hint(12, version, also_next_cycle)
         raise
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -70,7 +70,13 @@ def print_step(n: int, msg: str) -> None:
 
 
 def fail_with_message(msg: str, code: int = 1) -> NoReturn:
-    """Print an error and exit."""
+    """Print an error and exit.
+
+    ``NoReturn`` is the rarely-seen annotation for a function that never returns *at all* -- not one
+    that returns ``None``. This one always leaves through ``sys.exit``, and saying so is what makes
+    every guard clause below read correctly: ``if not m: fail_with_message(...)`` followed by
+    ``m.group(1)`` is only sound because control cannot come back here.
+    """
     print(f"\nERROR: {msg}", file=sys.stderr)
     sys.exit(code)
 

--- a/tests/counting/test_lazy_init_parity.py
+++ b/tests/counting/test_lazy_init_parity.py
@@ -17,6 +17,11 @@ testing.
 The helpers below take that example apart: the ``try``/``except AttributeError`` pair itself, the
 ``ADD += 1`` write inside each of its branches, and - for the sites whose branches bind the counter
 to a local rather than incrementing it in place - the name each branch binds.
+
+The test reads the source through the module's own file path, so under a mutation runner - which
+works on its own copy of the package - it would be reading generated mutant variants instead of the
+real source.  Those variants are not what this module guards, so it stands down there (see
+``_is_mutation_sandbox_copy``).
 """
 
 import ast
@@ -29,6 +34,9 @@ from counted_float._core.counting import _counted_float, _math_patching
 
 _LAZY_INIT_MODULES = [_counted_float, _math_patching]
 
+# mutmut copies the package under this directory before mutating it (see [tool.mutmut] source_paths)
+_MUTATION_SANDBOX_DIR = "mutants"
+
 
 # =================================================================================================
 #  Helpers
@@ -36,6 +44,17 @@ _LAZY_INIT_MODULES = [_counted_float, _math_patching]
 def _module_id(module: ModuleType) -> str:
     """Bare module name, for readable parametrize ids."""
     return module.__name__.rsplit(".", 1)[-1]
+
+
+def _is_mutation_sandbox_copy(path: Path) -> bool:
+    """Whether this path is a mutation runner's copy of the source rather than the source itself.
+
+    The runner rewrites every mutated function into a trampoline over generated variants, whose
+    cold-start handlers are not the idiom documented above - so the structural assertions below
+    have nothing meaningful to say about them.  Recognizing the copy keeps this test out of the
+    way instead of teaching it the runner's generated shapes.
+    """
+    return _MUTATION_SANDBOX_DIR in path.parts
 
 
 def _lazy_init_pairs(tree: ast.Module) -> list[tuple[ast.Try, ast.ExceptHandler]]:
@@ -87,8 +106,10 @@ def _bound_names(body: list[ast.stmt]) -> list[str]:
 @pytest.mark.parametrize("module", _LAZY_INIT_MODULES, ids=_module_id)
 def test_lazy_init_handler_matches_its_try_branch(module: ModuleType):
     # --- arrange -----------------------------------------
-    source = Path(module.__file__ or "").read_text(encoding="utf-8")
-    tree = ast.parse(source)
+    path = Path(module.__file__ or "")
+    if _is_mutation_sandbox_copy(path):
+        pytest.skip("reading a mutation runner's copy of the source, not the source itself")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
 
     # --- act ---------------------------------------------
     pairs = _lazy_init_pairs(tree)


### PR DESCRIPTION
**TL;DR**: A release whose mutation measurement fails now aborts, instead of silently keeping a stale badge and stamping it as freshly measured. The measurement also moves ahead of every write.

## Description

### Problem addressed

The mutation score cannot come from CI — mutation testing is deliberately off the pipeline — so the release script **measures it locally and stamps it into a README badge**. Three faults combined to make that measurement silently worthless:

- The **structural parity test resolves its target through the module's own file path**, which under a mutation runner points at the runner's *mutated* copy: trampoline-expanded variants whose cold-start handlers are not the idiom the test recognizes. It therefore failed on every mutant, and **no score could be collected at all**.
- **Any mutation failure was a warning**, leaving the previously committed badge untouched. A completely broken measurement was invisible unless someone read the release log closely.
- The badge's **provenance comment was rewritten to name the new release regardless**, so the stamp claimed a measurement that release never took.

Separately, the check that **CI on `main` is current ran after the changelog had already been rewritten**, so aborting there left a dirty tree to clean up by hand.

### Implementation

The measurement now answers **two separate questions**. Whether a number could be produced *gates the release*: a crashing suite, a missing or malformed stats file, an empty mutant set, or a run past a ten-minute ceiling all abort. What the number *is* still **never gates** — the score wobbles run to run from timeout nondeterminism, so a threshold would reject releases over measurement noise. That refines the existing "mutation testing never blocks a release" stance rather than reversing it: what never blocks is the percentage.

**Everything that can fail now runs before the first write.** Gathering the badge numbers — the CI metrics for `HEAD`, including the freshness check, plus the local mutation score — became the last precondition rather than a side effect of composing the release commit. Applying those numbers to the README is a pure write with nothing left to fail, so the provenance stamp can no longer outrun the measurement. Renumbering the steps around that insertion is most of the diff's line count.

A **`--dry-run` flag** stops at exactly that boundary, which is what makes the preconditions exercisable without releasing anything.

The parity test **stands down when it detects a mutation runner's copy** of the source instead of learning the runner's generated shapes — asserting anything about mutant variants is not its job.

## Attention points

- **`fail_with_message` is now `NoReturn`.** The new abort paths need it to type-check, and it tightens the existing call sites for free.
- **Step numbers shifted** — the badge-metric gather is step 8, so every later step renumbered. Mechanical, but it touches each step function's name and its printed line.
- **The score is still not a gate.** It reads 88% today; a low score remains unable to block a release. Only an unmeasurable one aborts.
- **Sandbox detection keys on the runner's copy directory.** If that ever changes, the test stops skipping and starts failing under the runner again — loud rather than silent, which is the right direction for a guard.
- **Unrelated pre-existing flake:** a micro-benchmark test can fail with `ZeroDivisionError` when a timed run measures zero elapsed time on a loaded machine. Hit once here, passes consistently otherwise, and untouched by this change.

## Tests / Spikes

- **TEST:** full suite green — 1800 passed, 3 skipped.
- **TEST:** `make mutation` + `make mutation-stats` complete and produce a score again (88%: 1685 killed of 1923, 5 timeouts). Previously the parity test failed on every mutant, so no score existed to read.
- **TEST:** the parity test confirmed to skip when run against a runner's copy of the source, and to pass against the real source.
- **TEST:** every way the measurement can fail — target exits nonzero, run exceeds the timeout, stats file missing, stats file malformed, zero mutants — confirmed to abort the release; a healthy run confirmed to still return its score.
- **TEST:** `--dry-run` confirmed to reach the precondition block and write nothing.
- No unit tests added for the release script, which deliberately has none; `--dry-run` is what makes its preconditions checkable by hand instead.

## Changelog entry

None: no user-facing change. This is release tooling plus a guard on a structural test.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
