### PR TITLE
chore: pin the math surface against silent counting holes

### DIFF
--- a/docs/math_patching.md
+++ b/docs/math_patching.md
@@ -65,6 +65,7 @@ The full per-operation counting rules are in the
 
 Every commonly used `math` function, and how it participates in counting:
 
+<!-- BEGIN generated: math-coverage-table -->
 | Coverage | Functions |
 |---|---|
 | **Instrumented** (patched, counts its FlopType) | `sqrt`, `cbrt`, `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `pow`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `hypot` (+ `HYPOT_XARG` per coordinate beyond the second), `dist` (+ `DIST_XARG` likewise), `fmod`, `remainder`, `gamma`, `lgamma`, `erf`, `erfc`, `fabs`, `copysign`, `fma` (Python 3.13+), `sumprod` (Python 3.12+; + `SUMPROD_XELEM` per element beyond the second — counted inputs are unboxed so the extended-precision algorithm runs) |
@@ -72,6 +73,7 @@ Every commonly used `math` function, and how it participates in counting:
 | **Counted via dunder** (no patch needed — do not expect these in the patch list) | `math.floor` / `math.ceil` / `math.trunc` → F2I through `__floor__`/`__ceil__`/`__trunc__`; the builtins `abs()` → ABS and `round()` → RND/F2I likewise count through their dunders |
 | **Not instrumented** (returns a plain, uncounted `float`) | exactly the float-representation helpers — `frexp`, `ldexp`, `modf`, `nextafter`, `ulp` |
 | **Predicates** (uncounted, return a `bool`) | `isnan`, `isinf`, `isfinite`, `isclose` — and truthiness (`bool(x)`, `if x:`, `assert x`), which a compiled port would test against zero. It is left uncounted because it appears constantly in ordinary control flow rather than in the arithmetic being measured; an *algorithmic* zero-test can be written `x != 0.0`, which counts `COMP` |
+<!-- END generated: math-coverage-table -->
 
 The not-instrumented set breaks contagion: the plain-`float` result silently
 stops all downstream counting, so convert back with `CountedFloat(...)` if a

--- a/scripts/generate_docs_content.py
+++ b/scripts/generate_docs_content.py
@@ -46,6 +46,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from counted_float import BuiltInData
+from counted_float._core.counting._math_patching import (
+    _MATH_NOT_PATCHED,
+    _NOT_PATCHED_DUNDER,
+    _NOT_PATCHED_PREDICATE,
+    _PATCHES,
+    _UNCOUNTED_MATH,
+)
 from counted_float._core.models import FlopType
 from counted_float.config import (
     get_active_flop_weights,
@@ -307,6 +314,94 @@ def generate_builtin_data_table() -> str:
     return "\n".join(rows)
 
 
+# --------------------------------------------------------------------------
+#  math-coverage table
+# --------------------------------------------------------------------------
+# Membership comes from the patch tables in the library; what follows is only how each function is
+# presented and in what order.  Every currently patched function must appear in one of the two
+# instrumented buckets, so patching something new breaks this generator until its row is decided --
+# which is what keeps the table from drifting behind the code.
+#
+# The two arity-parametric and two version-gated entries carry a note; the rest render bare.
+_MATH_INSTRUMENTED_ORDER = [
+    "sqrt", "cbrt", "exp", "exp2", "expm1", "log", "log2", "log10", "log1p", "pow",
+    "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "sinh", "cosh", "tanh",
+    "asinh", "acosh", "atanh", "hypot", "dist", "fmod", "remainder", "gamma", "lgamma",
+    "erf", "erfc", "fabs", "copysign", "fma", "sumprod",
+]  # fmt: skip
+_MATH_INSTRUMENTED_NOTES = {
+    "hypot": "(+ `HYPOT_XARG` per coordinate beyond the second)",
+    "dist": "(+ `DIST_XARG` likewise)",
+    "fma": "(Python 3.13+)",
+    "sumprod": (
+        "(Python 3.12+; + `SUMPROD_XELEM` per element beyond the second — counted inputs are "
+        "unboxed so the extended-precision algorithm runs)"
+    ),
+}
+# patched, but presented by the decomposition each one counts rather than by a FlopType of its own.
+# 1-argument `hypot` also belongs to this row's prose; `hypot` itself is presented above.
+_MATH_DECOMPOSED = ["degrees", "radians", "prod", "fsum"]
+_MATH_DECOMPOSED_CELL = (
+    "`degrees` / `radians` → MUL; `prod` → one MUL per chained multiply; `fsum` → (n−1) ADD; 1-argument `hypot` → ABS"
+)
+# registered conditionally by the patch table, so they are absent from it on an older interpreter
+# while still belonging in the committed table -- the note on each says from which version
+_MATH_VERSION_GATED = {"fma", "sumprod"}
+# uncounted, but shaped like a predicate, so the docs group it with them rather than with the
+# float-representation helpers -- while saying that it alone performs real arithmetic
+_MATH_UNCOUNTED_SHOWN_WITH_PREDICATES = {"isclose"}
+
+
+def _math_names_by_reason(reason: str) -> list[str]:
+    """The unpatched `math` functions sharing one stated reason, in table order."""
+    return [name for name, entry_reason in _MATH_NOT_PATCHED.items() if entry_reason == reason]
+
+
+def generate_math_coverage_table() -> str:
+    """The `math`-coverage table in the patching docs, derived from the classification tables."""
+    presented_as_instrumented = set(_MATH_INSTRUMENTED_ORDER) | set(_MATH_DECOMPOSED)
+    if unpresented := set(_PATCHES) - presented_as_instrumented:
+        raise ValueError(f"patched but missing from the coverage table: {sorted(unpresented)}")
+    if fictional := presented_as_instrumented - set(_PATCHES) - _MATH_VERSION_GATED:
+        raise ValueError(f"presented as patched but not in the patch table: {sorted(fictional)}")
+
+    instrumented = ", ".join(
+        f"`{name}`" + (f" {note}" if (note := _MATH_INSTRUMENTED_NOTES.get(name)) else "")
+        for name in _MATH_INSTRUMENTED_ORDER
+    )
+    dunder = _math_names_by_reason(_NOT_PATCHED_DUNDER)
+    helpers = [name for name in _UNCOUNTED_MATH if name not in _MATH_UNCOUNTED_SHOWN_WITH_PREDICATES]
+    predicates = _math_names_by_reason(_NOT_PATCHED_PREDICATE) + sorted(_MATH_UNCOUNTED_SHOWN_WITH_PREDICATES)
+
+    rows = [
+        ("**Instrumented** (patched, counts its FlopType)", instrumented),
+        (
+            "**Instrumented, counted as a decomposition** (patched, counts the flops a compiled port would execute)",
+            _MATH_DECOMPOSED_CELL,
+        ),
+        (
+            "**Counted via dunder** (no patch needed — do not expect these in the patch list)",
+            " / ".join(f"`math.{name}`" for name in dunder)
+            + " → F2I through "
+            + "/".join(f"`__{name}__`" for name in dunder)
+            + "; the builtins `abs()` → ABS and `round()` → RND/F2I likewise count through their dunders",
+        ),
+        (
+            "**Not instrumented** (returns a plain, uncounted `float`)",
+            "exactly the float-representation helpers — " + ", ".join(f"`{name}`" for name in helpers),
+        ),
+        (
+            "**Predicates** (uncounted, return a `bool`)",
+            ", ".join(f"`{name}`" for name in predicates)
+            + " — and truthiness (`bool(x)`, `if x:`, `assert x`), which a compiled port would test"
+            " against zero. It is left uncounted because it appears constantly in ordinary control"
+            " flow rather than in the arithmetic being measured; an *algorithmic* zero-test can be"
+            " written `x != 0.0`, which counts `COMP`",
+        ),
+    ]
+    return "\n".join(["| Coverage | Functions |", "|---|---|", *(f"| {left} | {right} |" for left, right in rows)])
+
+
 def _snippet_source(name: str) -> str:
     """The committed snippet's source, as the docs' input code block."""
     return f"```python\n{(SNIPPETS_DIR / name).read_text(encoding='utf-8').rstrip()}\n```"
@@ -337,6 +432,7 @@ TEXT_BLOCKS: dict[str, tuple[Path, Callable[[], str]]] = {
     "flop-weights-arm": (REPO_ROOT / "docs" / "flop_weights.md", generate_flop_weights_arm),
     "cli-show-data-slice": (REPO_ROOT / "docs" / "cli.md", generate_cli_show_data_slice),
     "builtin-data-table": (REPO_ROOT / "docs" / "builtin_data.md", generate_builtin_data_table),
+    "math-coverage-table": (REPO_ROOT / "docs" / "math_patching.md", generate_math_coverage_table),
     "snippet-verbosity-info": (REPO_ROOT / "docs" / "counting_flops.md", generate_snippet_verbosity_info),
     "snippet-verbosity-warning": (REPO_ROOT / "docs" / "counting_flops.md", generate_snippet_verbosity_warning),
     "snippet-verbosity-mixed": (REPO_ROOT / "docs" / "counting_flops.md", generate_snippet_verbosity_mixed),

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -810,6 +810,30 @@ if hasattr(math, "fma"):
 if hasattr(math, "sumprod"):
     # Python 3.12+ only; same conditional-registration reasoning as math.fma above.
     _PATCHES["sumprod"] = math_sumprod
+
+# Why each remaining public `math` callable needs no replacement of either kind.  Between this,
+# _PATCHES and _UNCOUNTED_MATH the whole module surface is accounted for, and a test holds them to
+# that -- so a float function a future CPython adds to `math` fails there rather than becoming a
+# silently uncounted hole.  The reason per entry is a judgment about the function's domain that
+# nothing about the callable itself reveals, which is why they are listed rather than detected.
+_NOT_PATCHED_PREDICATE = "predicate: returns a bool, performs no arithmetic of its own"
+_NOT_PATCHED_DUNDER = "counted already, through the CountedFloat dunder it dispatches to"
+_NOT_PATCHED_INTEGER_DOMAIN = "integer domain: never operates on floats"
+_MATH_NOT_PATCHED: dict[str, str] = {
+    "isnan": _NOT_PATCHED_PREDICATE,
+    "isinf": _NOT_PATCHED_PREDICATE,
+    "isfinite": _NOT_PATCHED_PREDICATE,
+    "floor": _NOT_PATCHED_DUNDER,
+    "ceil": _NOT_PATCHED_DUNDER,
+    "trunc": _NOT_PATCHED_DUNDER,
+    "comb": _NOT_PATCHED_INTEGER_DOMAIN,
+    "factorial": _NOT_PATCHED_INTEGER_DOMAIN,
+    "gcd": _NOT_PATCHED_INTEGER_DOMAIN,
+    "isqrt": _NOT_PATCHED_INTEGER_DOMAIN,
+    "lcm": _NOT_PATCHED_INTEGER_DOMAIN,
+    "perm": _NOT_PATCHED_INTEGER_DOMAIN,
+}
+
 # the math functions saved at patch time, to be restored at unpatch time
 _saved_originals: dict[str, object] = {}
 

--- a/tests/counting/test_math_surface.py
+++ b/tests/counting/test_math_surface.py
@@ -1,0 +1,77 @@
+"""Every public callable of `math` must be accounted for by one of the classification tables.
+
+CPython keeps adding float functions to `math` - `cbrt` and `exp2`, then `sumprod`, then `fma` -
+and each addition that nobody classifies becomes a silently uncounted hole: contagion stops there,
+the total comes out wrong, and nothing anywhere says so.  Pinning the surface turns that from a
+defect someone eventually notices into a test failure at the moment the interpreter changes.
+
+The three tables are exhaustive and disjoint by construction:
+
+* ``_PATCHES``           - replaced while counting, so the call registers its flops;
+* ``_UNCOUNTED_MATH``    - deliberately uninstrumented, and reported at WARNING verbosity;
+* ``_MATH_NOT_PATCHED``  - needs no replacement at all, with the reason per entry.
+
+Version-conditional functions need no handling here: the tables register them conditionally
+themselves, so both directions of the comparison hold on every supported Python.
+"""
+
+import math
+
+from counted_float._core.counting._math_patching import _MATH_NOT_PATCHED, _PATCHES, _UNCOUNTED_MATH
+
+_TABLES = {
+    "_PATCHES (instrument it, and give it a FlopType)": set(_PATCHES),
+    "_UNCOUNTED_MATH (leave it uncounted, and report it at WARNING verbosity)": set(_UNCOUNTED_MATH),
+    "_MATH_NOT_PATCHED (needs no replacement - say why)": set(_MATH_NOT_PATCHED),
+}
+
+
+# =================================================================================================
+#  Helpers
+# =================================================================================================
+def _public_math_callables() -> set[str]:
+    """Every callable `math` exposes under a public name, on the running interpreter."""
+    return {name for name in dir(math) if not name.startswith("_") and callable(getattr(math, name))}
+
+
+# =================================================================================================
+#  Tests
+# =================================================================================================
+def test_every_public_math_callable_is_classified():
+    # --- arrange / act -------------------------
+    unclassified = _public_math_callables() - set().union(*_TABLES.values())
+
+    # --- assert --------------------------------
+    assert not unclassified, (
+        f"unclassified `math` callable(s): {sorted(unclassified)}.\n"
+        "Each one belongs in exactly one of:\n" + "\n".join(f"  - {table}" for table in _TABLES)
+    )
+
+
+def test_no_table_classifies_a_function_math_does_not_have():
+    # --- arrange / act -------------------------
+    surface = _public_math_callables()
+    phantom = {name: table for table, names in _TABLES.items() for name in names - surface}
+
+    # --- assert --------------------------------
+    assert not phantom, f"classified but absent from `math` on this interpreter: {phantom}"
+
+
+def test_the_tables_do_not_overlap():
+    # --- arrange / act -------------------------
+    overlapping = {
+        name: sorted(table for table, names in _TABLES.items() if name in names)
+        for name in set().union(*_TABLES.values())
+        if sum(name in names for names in _TABLES.values()) > 1
+    }
+
+    # --- assert --------------------------------
+    assert not overlapping, f"`math` callable(s) classified more than once: {overlapping}"
+
+
+def test_every_unpatched_entry_carries_a_reason():
+    # --- arrange / act -------------------------
+    reasonless = [name for name, reason in _MATH_NOT_PATCHED.items() if not reason.strip()]
+
+    # --- assert --------------------------------
+    assert not reasonless, f"entries with no stated reason for going unpatched: {reasonless}"


### PR DESCRIPTION
**TL;DR**: Every public `math` callable must now be classified, so a float function a future CPython adds fails a test instead of quietly going uncounted. The docs coverage table is generated from the same tables.

## Description

### Problem addressed

`math` is a **moving target**: CPython added `cbrt` and `exp2`, then `sumprod`, then `fma`, and it will keep going. Each addition that nobody classifies becomes a **silently uncounted hole** — contagion stops at that call, the reported total comes out wrong, and nothing anywhere says so. The failure surfaces whenever somebody eventually notices a suspicious number, which may be long after the interpreter upgrade that caused it.

Until now the classification was **real but unstated**. Every float-valued callable was either patched or a deliberate omission, and that was true only because someone had checked by hand; no test held the module surface to it, and there was no home for the reasoning behind the omissions.

The **docs coverage table had the same problem from the other side** — entirely hand-maintained, so it drifted independently of the code it describes.

## Implementation

The `math` surface is now partitioned by **three tables that are exhaustive and disjoint**: the existing patch table, the existing uninstrumented-and-reported table, and a new one naming every remaining public callable together with the reason it needs no replacement at all. Those reasons fall into three kinds — a predicate that performs no arithmetic, a function already counted through the `CountedFloat` dunder it dispatches to, and a function whose domain is integers. **The reason is stated per entry rather than detected**, because "integer domain" is a judgment about what a function means, not something the callable reveals about itself.

Four tests hold the partition: nothing unclassified, nothing classified that the interpreter does not have, no overlap, and no entry without a reason. **Version-conditional functions need no special handling** — the patch table already registers them conditionally, so both directions hold on every supported Python.

The docs table becomes **generated content**, joining the other data-derived blocks in the docs pipeline. Membership comes from the classification tables; the generator declares only how each function is presented and in what order, and **refuses to produce a table that omits a patched function**. So adding a patch now breaks the generator until its row is decided.

## Attention points

- **The generated table is byte-identical to the committed one.** The coverage described is unchanged; only its provenance moved. That was the acceptance bar for the conversion and it is worth checking in the diff.
- **Presentation annotations moved from markdown into the generator** — the arity notes, the version gates, the decomposition arrows. That is the real cost of generating this particular table: it carries prose, not just names. The alternative was leaving the table hand-written and asserting over the parsed markdown, which keeps a second copy of the classification to maintain by hand.
- **`isclose` is presented with the predicates, not with the uninstrumented helpers.** It is predicate-shaped but performs real arithmetic, and the docs deliberately group it where a reader would look for it while saying that it alone computes something. The generator preserves that placement explicitly rather than following its table membership.
- **The generator now imports private names from the counting package.** Unavoidable if the table is to be derived rather than retyped, and the docs tooling is already coupled to library internals elsewhere.
- **`hypot` appears in two rows** — once for its own FlopType, once in the decomposition prose for the 1-argument case. Deliberate, and the generator's partition check accounts for it.

## Tests / Spikes

- **TEST:** full suite green — 1804 passed, 3 skipped (4 new tests).
- **TEST:** the surface pin confirmed to fail on a *simulated* new `math` callable, with a message naming the function and the three tables it could belong to.
- **TEST:** the generator confirmed to refuse a simulated newly patched function that no row presents.
- **TEST:** the docs drift check passes, and the regenerated table byte-matches the previously committed one.

## Changelog entry

None: no user-facing change. This pins an invariant that already held and moves a docs table from hand-written to generated.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
