### PR TITLE
chore: keep the heavy dependencies off the import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- importing the package no longer pulls in numpy, rich, psutil or py-cpuinfo, cutting import time for counting-only use
+
 ### Deprecated
 
 ### Removed

--- a/src/counted_float/_core/counting/_flop_weights_tree_view.py
+++ b/src/counted_float/_core/counting/_flop_weights_tree_view.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING
 
-from rich.console import Console
-
 from counted_float._core.models import FlopType, FlopWeights
 
 if TYPE_CHECKING:
@@ -75,6 +73,10 @@ class FlopWeightsTreeView:
     #  Visualization
     # -------------------------------------------------------------------------
     def show(self) -> None:
+        # rich is imported here rather than at module level: this module is reachable from the
+        # counting path, while rendering a tree only ever happens on an explicit show()
+        from rich.console import Console
+
         # --- prep ----------------------------------------
         console = Console()
         console_width = console.width

--- a/src/counted_float/_core/models/_flop_weights.py
+++ b/src/counted_float/_core/models/_flop_weights.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING, Literal
 
-import numpy as np
 from pydantic import field_serializer, field_validator
 
 from counted_float._core.utils import geo_mean, impute_missing_data, round_number
@@ -120,11 +119,9 @@ class FlopWeights(JsonReprModel):
         # --- prep ----------------------------------------
         all_flop_weights = list(all_flop_weights)
 
-        # put in numpy array for easier processing
-        w = np.zeros(shape=(len(FlopType), len(all_flop_weights)), dtype=float)
-        for i_row, flop_type in enumerate(FlopType):
-            for i_col, fw in enumerate(all_flop_weights):
-                w[i_row, i_col] = fw.weights[flop_type]
+        # one row per flop type, one column per contributing set of weights
+        flop_types = list(FlopType)
+        w = [[float(fw.weights[flop_type]) for fw in all_flop_weights] for flop_type in flop_types]
 
         # --- fill missing data ---------------------------
         if fill_missing_data and (len(all_flop_weights) > 1) and any(fw.has_missing_data() for fw in all_flop_weights):
@@ -133,10 +130,9 @@ class FlopWeights(JsonReprModel):
         # --- compute geo_mean ----------------------------
         return FlopWeights(
             weights={
-                flop_type: geo_mean(
-                    [float(w_i) for w_i in w[i, :]]
-                )  # take geo_mean of row (will return nan if any value is nan)
-                for i, flop_type in enumerate(FlopType)
+                # take geo_mean of row (will return nan if any value is nan)
+                flop_type: geo_mean(w[i])
+                for i, flop_type in enumerate(flop_types)
             }
         )
 

--- a/src/counted_float/_core/models/_flops_benchmark_meta_data.py
+++ b/src/counted_float/_core/models/_flops_benchmark_meta_data.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import platform
 from importlib.metadata import PackageNotFoundError, version
 
-import cpuinfo
-import psutil
-
 from counted_float._core.utils import get_cpu_frequency_mhz_max, get_cpu_frequency_mhz_min
 
 from ._base import JsonReprModel
@@ -64,6 +61,12 @@ class ProcessorInfo(JsonReprModel):
 
     @classmethod
     def from_system(cls) -> ProcessorInfo:
+        """Describe the running machine's processor, as stamped onto a benchmark result."""
+        # both imported here rather than at module level: this is the only place either is used, and
+        # it runs while benchmarking -- whereas the model itself is loaded to parse the shipped data
+        import cpuinfo
+        import psutil
+
         cpu_info_dict = cpuinfo.get_cpu_info()
         return ProcessorInfo(
             description=cpu_info_dict.get("brand_raw", ""),

--- a/src/counted_float/_core/models/_micro_benchmark_result.py
+++ b/src/counted_float/_core/models/_micro_benchmark_result.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from counted_float._core.utils import quantile
 
 from ._base import JsonReprModel
 
@@ -52,11 +52,11 @@ class MicroBenchmarkResult(JsonReprModel):
 
     def get_nsecs_per_exec_quantile(self, q: float) -> float:
         """Returns a specific quantile of all results in the 'benchmark_runs' category expressed as nsecs/execution."""
-        return float(np.quantile([el.nsecs_per_exec() for el in self.benchmark_runs], q))
+        return quantile([el.nsecs_per_exec() for el in self.benchmark_runs], q)
 
     def get_cycles_per_exec_quantile(self, q: float) -> float:
         """Returns a specific quantile of all results in the 'benchmark_runs' category expressed as cycles/execution."""
-        return float(np.quantile([el.cycles_per_exec() for el in self.benchmark_runs], q))
+        return quantile([el.cycles_per_exec() for el in self.benchmark_runs], q)
 
     def summary_stats_nsecs_per_exec(self) -> Quantiles:
         # summary statistics of nsecs_per_exec

--- a/src/counted_float/_core/utils/__init__.py
+++ b/src/counted_float/_core/utils/__init__.py
@@ -3,5 +3,6 @@ from ._formatting import format_latency, format_time_duration
 from ._geo_mean import geo_mean
 from ._latency import convert_nsecs_to_cycles
 from ._missing_data import impute_missing_data
+from ._quantile import quantile
 from ._rounding import round_number
 from ._timer import Timer

--- a/src/counted_float/_core/utils/_cpu_freq.py
+++ b/src/counted_float/_core/utils/_cpu_freq.py
@@ -1,7 +1,5 @@
 import math
 
-import psutil
-
 
 # =================================================================================================
 #  Get Min, Max, Current CPU frequency in MHz
@@ -28,7 +26,12 @@ def _get_psutil_cpu_freq_attribute_mhz(att_name: str) -> float | None:
     """Get an attribute from psutil.cpu_freq(), returning None for missing or 0 data.
 
     Applies heuristics to distinguish Mhz & GHz.
+
+    psutil is imported here rather than at module level: reading a CPU frequency only ever happens
+    while benchmarking, and the counting path reaches this module for its other helpers.
     """
+    import psutil
+
     try:
         value = getattr(psutil.cpu_freq(), att_name)
     except AttributeError:

--- a/src/counted_float/_core/utils/_missing_data.py
+++ b/src/counted_float/_core/utils/_missing_data.py
@@ -1,75 +1,84 @@
-import numpy as np
+import math
 
 from ._geo_mean import geo_mean
 
+# exponent applied to the correction coefficients; keep < 1.0 for stability
+_E_STEP = 0.75
+# hard cap; the alternating correction contracts, so it converges well before this
+_MAX_ITER = 100
+# converged once the corrections stop moving the factors (see the break below)
+_TOL = 1e-12
 
-def impute_missing_data(data: np.ndarray) -> np.ndarray:
+
+def impute_missing_data(data: list[list[float]]) -> list[list[float]]:
     """Impute missing values in a NON-NEGATIVE matrix using a rank-1 approximation.
 
     This works by...
       - creating a rank-1 approximation of the matrix (ignore missing values)
       - using the approximation to fill in the missing values.
 
+    The work is per-element by nature — a geometric mean of ratios taken row-wise then column-wise —
+    so it is expressed over plain lists. An array library buys nothing here and costs the boxing of
+    every scalar read.
+
     NOTE: this will only be able to impute missing values present where both the column and row
           have at least 1 non-missing value.
 
-    :param data:  (mxn ndarray) input data with missing values as np.nan
-    :return: (mxn ndarray) data with missing values imputed, where possible
+    Args:
+        data: Row-major matrix with missing values marked as `math.nan`. Left unmodified.
+
+    Returns:
+        A new matrix with missing values imputed where possible, the rest still `math.nan`.
     """
     # --- rank-1 approx -----------------------------------
     # we try to approximate data = c_rows.T @ c_cols  with  c_rows > 0 and c_cols > 0
-    n_rows, n_cols = data.shape[0], data.shape[1]
-    c_rows, c_cols = np.ones(n_rows), np.ones(n_cols)
+    n_rows, n_cols = len(data), len(data[0])
+    c_rows, c_cols = [1.0] * n_rows, [1.0] * n_cols
 
-    e_step = 0.75  # exponent to apply to correction coefficients  (keep <1.0 for stability)
-    max_iter = 100  # hard cap; the alternating correction contracts, so it converges well before this
-    tol = 1e-12  # converged once the corrections stop moving the factors (see the break below)
-
-    for _i in range(max_iter):
+    for _i in range(_MAX_ITER):
         # compute correction factors for c_rows
-        c_row_correct = np.zeros(n_rows)
+        c_row_correct = [0.0] * n_rows
         for i_row in range(n_rows):
             # compare actual row to rank-1 approximation of row
             factors: list[float] = [
-                float(data[i_row, i_col] / (c_rows[i_row] * c_cols[i_col]))
+                data[i_row][i_col] / (c_rows[i_row] * c_cols[i_col])
                 for i_col in range(n_cols)
-                if not (np.isnan(data[i_row, i_col]) or np.isnan(c_cols[i_col]) or np.isnan(c_rows[i_row]))
+                if not (math.isnan(data[i_row][i_col]) or math.isnan(c_cols[i_col]) or math.isnan(c_rows[i_row]))
             ]
 
-            # overall exact correction is geo_mean of these factors, which we'll apply with step e_step
-            c_row_correct[i_row] = geo_mean(factors) ** e_step if factors else np.nan
+            # overall exact correction is geo_mean of these factors, which we'll apply with step _E_STEP
+            c_row_correct[i_row] = geo_mean(factors) ** _E_STEP if factors else math.nan
 
         # compute correction factors for c_cols
-        c_col_correct = np.zeros(n_cols)
+        c_col_correct = [0.0] * n_cols
         for i_col in range(n_cols):
             # compare actual col to rank-1 approximation of col
             factors = [
-                float(data[i_row, i_col] / (c_rows[i_row] * c_cols[i_col]))
+                data[i_row][i_col] / (c_rows[i_row] * c_cols[i_col])
                 for i_row in range(n_rows)
-                if not (np.isnan(data[i_row, i_col]) or np.isnan(c_cols[i_col]) or np.isnan(c_rows[i_row]))
+                if not (math.isnan(data[i_row][i_col]) or math.isnan(c_cols[i_col]) or math.isnan(c_rows[i_row]))
             ]
 
-            # overall exact correction is geo_mean of these factors, which we'll apply with step e_step
-            c_col_correct[i_col] = geo_mean(factors) ** e_step if factors else np.nan
+            # overall exact correction is geo_mean of these factors, which we'll apply with step _E_STEP
+            c_col_correct[i_col] = geo_mean(factors) ** _E_STEP if factors else math.nan
 
         # apply corrections
-        c_rows *= c_row_correct
-        c_cols *= c_col_correct
+        c_rows = [c * correction for c, correction in zip(c_rows, c_row_correct, strict=True)]
+        c_cols = [c * correction for c, correction in zip(c_cols, c_col_correct, strict=True)]
 
         # converged once the multiplicative corrections stop moving the factors: at the rank-1
         # fixed point every correction is 1.0. Rows/cols with no data carry a NaN correction by
         # construction and are excluded from the test; an all-NaN pass (degenerate matrix) just
-        # runs to max_iter.
-        corrections = np.concatenate([c_row_correct, c_col_correct])
-        finite = corrections[~np.isnan(corrections)]
-        if finite.size and float(np.max(np.abs(finite - 1.0))) < tol:
+        # runs to _MAX_ITER.
+        finite = [c for c in (c_row_correct + c_col_correct) if not math.isnan(c)]
+        if finite and max(abs(c - 1.0) for c in finite) < _TOL:
             break
 
     # --- fill missing data -------------------------------
-    result = data.copy()
+    result = [row[:] for row in data]
     for i_row in range(n_rows):
         for i_col in range(n_cols):
-            if np.isnan(result[i_row, i_col]) and (not np.isnan(c_rows[i_row])) and (not np.isnan(c_cols[i_col])):
-                result[i_row, i_col] = c_rows[i_row] * c_cols[i_col]
+            if math.isnan(result[i_row][i_col]) and not (math.isnan(c_rows[i_row]) or math.isnan(c_cols[i_col])):
+                result[i_row][i_col] = c_rows[i_row] * c_cols[i_col]
 
     return result

--- a/src/counted_float/_core/utils/_quantile.py
+++ b/src/counted_float/_core/utils/_quantile.py
@@ -1,0 +1,39 @@
+import math
+
+
+def quantile(values: list[float], q: float) -> float:
+    """Linear-interpolated quantile of a sample, matching numpy's default method exactly.
+
+    The sample is ordered and `q` addressed as a virtual index into it, blending the two
+    neighbouring order statistics when that index falls between them.
+
+    Args:
+        values: The sample; left unmodified. A single value is enough — it is its own quantile.
+        q: Quantile to take, in [0, 1].
+
+    Returns:
+        The interpolated value at `q`.
+
+    Raises:
+        ValueError: If `values` is empty, or `q` lies outside [0, 1].
+    """
+    if not values:
+        raise ValueError("quantile of an empty sample is undefined")
+    if not 0.0 <= q <= 1.0:
+        raise ValueError(f"quantile q must lie in [0, 1], got {q}")
+
+    ordered = sorted(values)
+    virtual_index = (len(ordered) - 1) * q
+    below, above = math.floor(virtual_index), math.ceil(virtual_index)
+    if below == above:
+        return ordered[below]
+
+    # Interpolate from whichever endpoint is nearer, which is what numpy does: the single
+    # `low + span * fraction` form loses the upper endpoint exactly at fraction 1.0 for large
+    # spans, so approaching each endpoint from its own side is what keeps the two agreeing.
+    low, high = ordered[below], ordered[above]
+    span = high - low
+    fraction = virtual_index - below
+    if fraction < 0.5:
+        return low + span * fraction
+    return high - span * (1.0 - fraction)

--- a/tests/shared/test_imports.py
+++ b/tests/shared/test_imports.py
@@ -99,3 +99,37 @@ def test_bare_import_stays_free_of_the_benchmarking_stack():
 
     # --- assert ------------------------------------------
     assert loaded == [], f"bare import loaded {loaded}"
+
+
+def test_bare_import_does_not_load_the_deferred_dependencies():
+    """A bare `import counted_float` must not load numpy, rich, psutil or py-cpuinfo.
+
+    None of the four is reachable from the counting path: numpy is used only by the benchmark
+    probes, rich only when something is rendered, and psutil / py-cpuinfo only when a benchmark
+    describes the machine it ran on. They are ordinary dependencies rather than extras -- so
+    nothing fails if one of them creeps back to module level, it just gets slower. Which is
+    exactly why the guard has to be a test.
+
+    Fresh interpreter for the same reason as the sibling test above.
+    """
+    # --- arrange -----------------------------------------
+    discover_loaded = textwrap.dedent(
+        """
+        import json, sys
+        import counted_float
+        watched = ("numpy", "rich", "psutil", "cpuinfo")
+        print(json.dumps([name for name in watched if name in sys.modules]))
+        """
+    )
+
+    # --- act ---------------------------------------------
+    result = subprocess.run(  # noqa: S603 -- fixed args, no user input
+        [sys.executable, "-c", discover_loaded],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    loaded = json.loads(result.stdout)
+
+    # --- assert ------------------------------------------
+    assert loaded == [], f"bare import loaded {loaded}"

--- a/tests/utils/test_missing_data.py
+++ b/tests/utils/test_missing_data.py
@@ -1,119 +1,132 @@
 import math
 
-import numpy as np
 from hypothesis import given
 from hypothesis import strategies as st
 
 from counted_float._core.utils import impute_missing_data
 
+Matrix = list[list[float]]
 
+
+# =================================================================================================
+#  Helpers
+# =================================================================================================
+def _same(actual: Matrix, expected: Matrix, *, rel_tol: float = 1e-10) -> bool:
+    """Whether two matrices agree cell by cell, counting two missing markers as agreeing."""
+    if [len(row) for row in actual] != [len(row) for row in expected]:
+        return False
+    return all(
+        (math.isnan(a) and math.isnan(e)) or math.isclose(a, e, rel_tol=rel_tol, abs_tol=1e-10)
+        for row_a, row_e in zip(actual, expected, strict=True)
+        for a, e in zip(row_a, row_e, strict=True)
+    )
+
+
+def _outer(rows: list[float], cols: list[float]) -> Matrix:
+    """The rank-1 matrix formed by two positive vectors."""
+    return [[r * c for c in cols] for r in rows]
+
+
+# =================================================================================================
+#  Worked cases
+# =================================================================================================
 def test_impute_missing_data_full_matrix():
     # --- arrange -----------------------------------------
-    data = np.array(
-        [
-            [1, 2, 3],
-            [2, 4, 6],
-            [3, 6, 10],
-        ]
-    )
+    data = [
+        [1, 2, 3],
+        [2, 4, 6],
+        [3, 6, 10],
+    ]
 
     # --- act ---------------------------------------------
     filled_data = impute_missing_data(data)
 
     # --- assert ------------------------------------------
-    assert np.array_equal(data, filled_data)
+    assert _same(filled_data, data)
 
 
 def test_impute_missing_data_missing_row():
     # --- arrange -----------------------------------------
-    data = np.array(
-        [
-            [1, 2, 3],
-            [2, 4, 6],
-            [math.nan, math.nan, math.nan],
-        ]
-    )
+    data = [
+        [1, 2, 3],
+        [2, 4, 6],
+        [math.nan, math.nan, math.nan],
+    ]
 
     # --- act ---------------------------------------------
     filled_data = impute_missing_data(data)
 
     # --- assert ------------------------------------------
-    assert np.array_equal(data, filled_data, equal_nan=True)
+    assert _same(filled_data, data)
 
 
 def test_impute_missing_data_missing_col():
     # --- arrange -----------------------------------------
-    data = np.array(
-        [
-            [1, 2, math.nan],
-            [2, 4, math.nan],
-            [3, 6, math.nan],
-        ]
-    )
+    data = [
+        [1, 2, math.nan],
+        [2, 4, math.nan],
+        [3, 6, math.nan],
+    ]
 
     # --- act ---------------------------------------------
     filled_data = impute_missing_data(data)
 
     # --- assert ------------------------------------------
-    assert np.array_equal(data, filled_data, equal_nan=True)
+    assert _same(filled_data, data)
 
 
 def test_impute_missing_data_partial_matrix():
     # --- arrange -----------------------------------------
-    data = np.array(
-        [
-            [math.nan, 2, 3],
-            [2, 4, math.nan],
-            [math.nan, 6, math.nan],
-        ],
-        dtype=float,
-    )
-
-    expected = np.array(
-        [
-            [1, 2, 3],
-            [2, 4, 6],
-            [3, 6, 9],
-        ],
-        dtype=float,
-    )
+    data = [
+        [math.nan, 2, 3],
+        [2, 4, math.nan],
+        [math.nan, 6, math.nan],
+    ]
+    expected = [
+        [1, 2, 3],
+        [2, 4, 6],
+        [3, 6, 9],
+    ]
 
     # --- act ---------------------------------------------
     filled_data = impute_missing_data(data)
 
-    print(filled_data)
-
     # --- assert ------------------------------------------
-    assert np.allclose(filled_data, expected, rtol=1e-10, atol=1e-10)
+    assert _same(filled_data, expected)
 
 
 def test_impute_missing_data_mixed_case():
     # --- arrange -----------------------------------------
-    data = np.array(
-        [
-            [1, 2, math.nan],
-            [2, math.nan, math.nan],
-            [math.nan, math.nan, math.nan],
-        ],
-        dtype=float,
-    )
-
-    expected = np.array(
-        [
-            [1, 2, math.nan],
-            [2, 4, math.nan],
-            [math.nan, math.nan, math.nan],
-        ],
-        dtype=float,
-    )
+    data = [
+        [1, 2, math.nan],
+        [2, math.nan, math.nan],
+        [math.nan, math.nan, math.nan],
+    ]
+    expected = [
+        [1, 2, math.nan],
+        [2, 4, math.nan],
+        [math.nan, math.nan, math.nan],
+    ]
 
     # --- act ---------------------------------------------
     filled_data = impute_missing_data(data)
 
-    print(filled_data)
+    # --- assert ------------------------------------------
+    assert _same(filled_data, expected)
+
+
+def test_the_input_is_not_modified():
+    # --- arrange -----------------------------------------
+    data = [
+        [1.0, 2.0],
+        [math.nan, 4.0],
+    ]
+
+    # --- act ---------------------------------------------
+    impute_missing_data(data)
 
     # --- assert ------------------------------------------
-    assert np.allclose(filled_data, expected, rtol=1e-10, atol=1e-10, equal_nan=True)
+    assert math.isnan(data[1][0])  # the hole is still a hole in the caller's own matrix
 
 
 # =================================================================================================
@@ -129,67 +142,70 @@ def _rank1_matrices(draw):
     """A strictly-positive rank-1 matrix (outer product of two positive vectors)."""
     n_rows = draw(st.integers(min_value=1, max_value=6))
     n_cols = draw(st.integers(min_value=1, max_value=6))
-    rows = np.array(draw(st.lists(_finite, min_size=n_rows, max_size=n_rows)))
-    cols = np.array(draw(st.lists(_finite, min_size=n_cols, max_size=n_cols)))
-    return np.outer(rows, cols)
+    rows = draw(st.lists(_finite, min_size=n_rows, max_size=n_rows))
+    cols = draw(st.lists(_finite, min_size=n_cols, max_size=n_cols))
+    return _outer(rows, cols)
 
 
 @given(matrix=_rank1_matrices(), mask=st.data())
-def test_an_exactly_rank1_matrix_is_recovered(matrix: np.ndarray, mask):
+def test_an_exactly_rank1_matrix_is_recovered(matrix: Matrix, mask):
     """The model is rank-1, so a rank-1 input must be reproduced at its missing cells."""
     # --- arrange -----------------------------------------
-    holed = matrix.copy()
-    n_rows, n_cols = matrix.shape
+    n_rows, n_cols = len(matrix), len(matrix[0])
     # knock out one interior cell, leaving its row and col with evidence so it is fillable
     if n_rows >= 2 and n_cols >= 2:
         i = mask.draw(st.integers(min_value=0, max_value=n_rows - 1))
         j = mask.draw(st.integers(min_value=0, max_value=n_cols - 1))
-        holed[i, j] = np.nan
+        holed = [row[:] for row in matrix]
+        holed[i][j] = math.nan
 
         # --- act -----------------------------------------
         filled = impute_missing_data(holed)
 
         # --- assert --------------------------------------
-        assert math.isclose(filled[i, j], matrix[i, j], rel_tol=1e-6)
+        assert math.isclose(filled[i][j], matrix[i][j], rel_tol=1e-6)
 
 
 @given(matrix=_rank1_matrices())
-def test_present_values_are_left_untouched(matrix: np.ndarray):
+def test_present_values_are_left_untouched(matrix: Matrix):
     # --- arrange -----------------------------------------
-    holed = matrix.copy()
-    if matrix.size >= 2:
-        holed.flat[0] = np.nan
+    holed = [row[:] for row in matrix]
+    if len(matrix) * len(matrix[0]) >= 2:
+        holed[0][0] = math.nan
 
     # --- act ---------------------------------------------
     filled = impute_missing_data(holed)
 
     # --- assert ------------------------------------------
-    present = ~np.isnan(holed)
-    assert np.allclose(filled[present], matrix[present])
+    assert all(
+        filled[i][j] == matrix[i][j]
+        for i in range(len(matrix))
+        for j in range(len(matrix[0]))
+        if not math.isnan(holed[i][j])
+    )
 
 
 @given(matrix=_rank1_matrices())
-def test_fills_are_never_negative(matrix: np.ndarray):
+def test_fills_are_never_negative(matrix: Matrix):
     # --- arrange -----------------------------------------
-    holed = matrix.copy()
-    if matrix.size >= 2:
-        holed.flat[0] = np.nan
+    holed = [row[:] for row in matrix]
+    if len(matrix) * len(matrix[0]) >= 2:
+        holed[0][0] = math.nan
 
     # --- act ---------------------------------------------
     filled = impute_missing_data(holed)
 
     # --- assert ------------------------------------------
-    filled_cells = filled[~np.isnan(filled)]
-    assert np.all(filled_cells >= 0)
+    assert all(value >= 0 for row in filled for value in row if not math.isnan(value))
 
 
 def test_a_cell_with_no_row_or_column_evidence_stays_missing():
     # --- arrange -----------------------------------------
     # the whole first row is missing, so its cells have no row evidence to lean on
-    data = np.array([[np.nan, np.nan], [3.0, 6.0]])
+    data = [[math.nan, math.nan], [3.0, 6.0]]
 
     # --- act ---------------------------------------------
     filled = impute_missing_data(data)
 
     # --- assert ------------------------------------------
-    assert np.all(np.isnan(filled[0, :]))  # unfillable cells are left as-is, not invented
+    assert all(math.isnan(value) for value in filled[0])  # unfillable cells are left as-is, not invented

--- a/tests/utils/test_quantile.py
+++ b/tests/utils/test_quantile.py
@@ -1,0 +1,79 @@
+"""The internal quantile must agree with numpy's default method, exactly.
+
+The benchmark results' summary statistics were taken with `np.quantile` before numpy was removed
+from everything the counting path can reach. Keeping the two bit-identical is what makes that a
+substitution rather than a change: previously collected results summarize to the same numbers, and
+the shipped weights derived from them stay reproducible.
+
+numpy is still available in the test environment, so the equivalence can be pinned against the real
+thing rather than against a table of expected values.
+"""
+
+import math
+
+import numpy as np
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from counted_float._core.utils import quantile
+
+_QUANTILES_USED = [0.10, 0.25, 0.50, 0.75]
+
+_FINITE_SAMPLES = st.lists(
+    st.floats(min_value=-1e12, max_value=1e12, allow_nan=False, allow_infinity=False),
+    min_size=1,
+    max_size=40,
+)
+
+
+# =================================================================================================
+#  Equivalence with numpy
+# =================================================================================================
+@given(values=_FINITE_SAMPLES, q=st.sampled_from(_QUANTILES_USED))
+def test_matches_numpy_on_the_quantiles_the_library_takes(values: list[float], q: float):
+    # --- act ---------------------------------------------
+    ours, theirs = quantile(values, q), float(np.quantile(values, q))
+
+    # --- assert ------------------------------------------
+    assert ours == theirs, f"q={q} over {values}: {ours!r} != {theirs!r}"
+
+
+@given(values=_FINITE_SAMPLES, q=st.floats(min_value=0.0, max_value=1.0))
+def test_matches_numpy_on_any_quantile(values: list[float], q: float):
+    # --- act ---------------------------------------------
+    ours, theirs = quantile(values, q), float(np.quantile(values, q))
+
+    # --- assert ------------------------------------------
+    assert ours == theirs, f"q={q} over {values}: {ours!r} != {theirs!r}"
+
+
+# =================================================================================================
+#  Edge cases and rejections
+# =================================================================================================
+@pytest.mark.parametrize("q", _QUANTILES_USED)
+def test_a_single_value_is_its_own_quantile(q: float):
+    # --- act / assert ------------------------------------
+    assert quantile([42.0], q) == 42.0
+
+
+def test_the_extremes_are_the_order_statistics():
+    # --- arrange -----------------------------------------
+    values = [3.0, 1.0, 2.0]
+
+    # --- act / assert ------------------------------------
+    assert quantile(values, 0.0) == 1.0
+    assert quantile(values, 1.0) == 3.0
+
+
+def test_an_empty_sample_is_rejected():
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match="empty sample"):
+        quantile([], 0.5)
+
+
+@pytest.mark.parametrize("q", [-0.01, 1.01, math.inf, -math.inf])
+def test_a_quantile_outside_the_unit_interval_is_rejected(q: float):
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match=r"must lie in \[0, 1\]"):
+        quantile([1.0, 2.0], q)


### PR DESCRIPTION
**TL;DR**: `import counted_float` drops from 100 ms to 57 ms and stops loading numpy, rich, psutil and py-cpuinfo. numpy leaves the counting path entirely — and the replacement is about 5x faster.

## Description

### Problem addressed

Importing the package **loaded four third-party packages the counting path never touches**: numpy, rich, psutil and py-cpuinfo. Together that is roughly 19.5 MB of numpy plus the rest, and about half the import cost. A project that only counts flops paid all of it, at every interpreter start.

None of the four was reachable from counting in any meaningful sense:

- **numpy** served three cold call sites — an array allocation in the weight aggregation, the imputation helper it calls, and the quantile taken over benchmark runs;
- **rich** was loaded eagerly by the weight tree view, which only renders on an explicit `show()`;
- **psutil** and **py-cpuinfo** are used solely to describe the machine a benchmark ran on.

They arrived at import time simply because the modules that own those uses are pulled in to parse the shipped weight data.

### Implementation

**numpy is now gone from the counting path rather than deferred.** All three uses were small, cold, and exactly expressible in plain Python, and removing them outright avoids a lazy import that would only have to be unwound later. The weight aggregation builds a nested list, the imputation helper works over lists, and a short internal quantile replaces the array one.

Two things made that safe to do:

- **NaN stays the missing-data marker.** It is not merely an artifact of a float array being unable to hold `None` — the weights model itself holds NaN in memory for a missing weight, maps JSON `null` onto it, and tests for it in every missing-weight predicate. Keeping it makes this a container swap and nothing more, which is why the result came out exact.
- **The quantile mirrors numpy's own two-sided interpolation**, including its choice to approach each endpoint from its own side. A property test pins the two to bit-equality, so previously collected benchmark results summarize to exactly the same numbers.

The **other three are deferred to the functions that use them**, all of which are cold. The pleasant surprise is that the numpy removal is not a cost at all: the imputation loop is scalar work — one element read at a time, a geometric mean over a list — where array indexing boxes every scalar. The plain-Python aggregation runs **about five times faster**.

## Attention points

- **The shipped consensus weights still re-derive bit-identically** — verified by bit pattern, not by `==`, across every key filter that ships precomputed, on 3.11, 3.13 and 3.14. That equivalence is what makes this a substitution rather than a change to the published data.
- **The imputation helper's signature changed** from an array to nested lists. It is internal, and its test moved with it — that test now uses no numpy either, which is incidental proof the helper needs none.
- **numpy remains a hard dependency**, used by the benchmark probes. This changes when it is loaded, not whether it is installed.
- **The deferred imports sit in cold functions only.** Worth keeping that way: none of the affected call sites is on the counting hot path, and a deferred import inside one would be a real cost rather than a saving.
- **Nothing fails if a dependency creeps back to module level** — it just gets slower again. That is exactly why the guard is a test rather than a review habit.

## Tests / Spikes

- **SPIKE:** the plain-Python aggregation was written and measured before this was committed to. It reproduces every shipped weight bit-for-bit on 3.11, 3.13 and 3.14, and runs ~5x faster (about 780 ms to 160 ms over the whole shipped dataset). That outcome is what turned "defer numpy" into "remove it".
- **TEST:** full suite green — 1818 passed, 3 skipped (14 new tests).
- **TEST:** import time measured before and after in matched conditions, each the best of seven cold interpreters, both loaded the same way from source: **100.0 ms → 56.7 ms**.
- **TEST:** a subprocess test asserts none of numpy, rich, psutil or cpuinfo appears in `sys.modules` after a bare import.
- **TEST:** the quantile is property-tested against `np.quantile` for exact equality, both on the four quantiles the library takes and on arbitrary ones.
- **TEST:** type checking confirmed to pass in an environment without the optional extras, not only in the full dev environment.

## Changelog entry

Under **Changed**:

```
- importing the package no longer pulls in numpy, rich, psutil or py-cpuinfo, cutting import time for counting-only use
```


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
