### PR TITLE
fix: survive a benchmark slice the clock cannot resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- a benchmark slice that measures zero elapsed time no longer crashes the calibration; it now ramps up the execution count instead
+
 ### Security
 
 ## 2.0.3 (2026-07-25)

--- a/src/counted_float/_core/benchmarking/micro/_interleaved_runner.py
+++ b/src/counted_float/_core/benchmarking/micro/_interleaved_runner.py
@@ -10,6 +10,7 @@ handled by a low-quantile estimator over the recorded slices.
 
 from __future__ import annotations
 
+import math
 import random
 from typing import TYPE_CHECKING, Generic, TypeVar
 
@@ -87,11 +88,26 @@ class SliceController:
                     self.is_calibrated = True
             else:
                 self._n_consecutive_on_target = 0
-            self._rescale(target / t_nsecs, max_factor=self.MAX_ADJUST_FACTOR_CALIBRATION)
+            self._rescale(self._adjust_factor(t_nsecs, target), max_factor=self.MAX_ADJUST_FACTOR_CALIBRATION)
         elif not (self.DEADBAND_LOW * target <= t_nsecs <= self.DEADBAND_HIGH * target):
-            self._rescale(target / t_nsecs, max_factor=self.MAX_ADJUST_FACTOR_CALIBRATED)
+            self._rescale(self._adjust_factor(t_nsecs, target), max_factor=self.MAX_ADJUST_FACTOR_CALIBRATED)
 
     # --- internals ----------------------------------------
+    @staticmethod
+    def _adjust_factor(t_nsecs: float, target: float) -> float:
+        """By how much to scale n_executions so a slice of t_nsecs would land on target.
+
+        A slice measuring zero is not merely fast: it finished below the clock's resolution, so
+        there is no ratio to take. Asking for an unbounded increase is the honest answer — the
+        caller's clamp turns it into the largest step an adjustment is allowed to make, which is
+        exactly what a slice too short to time calls for. On a coarse-resolution clock this is
+        reachable for a cheap probe at low execution counts, so it is the ramp's starting regime
+        rather than a pathological case.
+        """
+        if t_nsecs <= 0.0:
+            return math.inf
+        return target / t_nsecs
+
     def _rescale(self, factor: float, max_factor: float) -> None:
         factor = max(1 / max_factor, min(max_factor, factor))
         self.n_executions = max(1, min(self.MAX_N_EXECUTIONS, int(self.n_executions * factor)))

--- a/tests/benchmarking/micro/test_interleaved_runner.py
+++ b/tests/benchmarking/micro/test_interleaved_runner.py
@@ -4,7 +4,7 @@ import pytest
 
 from counted_float._core.benchmarking._output import output_quiet
 from counted_float._core.benchmarking.micro import InterleavedBenchmarkRunner, MicroBenchmark, SliceController
-from counted_float._core.models import MicroBenchmarkResult
+from counted_float._core.models import MicroBenchmarkResult, SingleRunResult
 
 
 @pytest.fixture(autouse=True)
@@ -39,6 +39,18 @@ class FakeBenchmark(MicroBenchmark):
 
     def _run_benchmark(self) -> None:
         pass
+
+
+class UntimeableBenchmark(FakeBenchmark):
+    """A benchmark every one of whose slices measures zero elapsed time.
+
+    What a clock too coarse to resolve a cheap probe produces, made deterministic: the real thing
+    depends on machine load, so it surfaces as an occasional crash rather than a reproducible one.
+    """
+
+    def run_slice(self, n_executions: int, round_index: int, cpu_freq_mhz: float | None) -> SingleRunResult:
+        self.prepare_slice(n_executions, round_index)
+        return SingleRunResult(n_executions=n_executions, t_nsecs=0.0, t_cycles=0.0)
 
 
 # =================================================================================================
@@ -104,6 +116,41 @@ def test_controller_execution_count_floor_raises_effective_target():
     assert controller.t_slice_target_nsecs == SliceController.N_MIN_EXECUTIONS * 1e6
 
 
+def test_controller_treats_an_unmeasurably_fast_slice_as_far_below_target():
+    """A slice measuring zero has no ratio to take, so it must ramp by the full allowed step.
+
+    Reachable whenever a cheap probe at a low execution count finishes below the clock's
+    resolution -- the ramp's own starting regime on a coarse-resolution clock, not an exotic case.
+    """
+    # --- arrange -----------------------------------------
+    controller = SliceController(t_slice_target_nsecs=1e6)
+    controller.n_executions = 4
+
+    # --- act ---------------------------------------------
+    controller.record_slice(t_nsecs=0.0)
+
+    # --- assert ------------------------------------------
+    assert controller.n_executions == int(4 * SliceController.MAX_ADJUST_FACTOR_CALIBRATION)
+    assert not controller.is_calibrated  # a zero slice is not on target
+
+
+def test_controller_survives_a_zero_slice_once_calibrated():
+    """The calibrated deadband path divides by the same measurement, so it needs the same guard."""
+    # --- arrange -----------------------------------------
+    controller = SliceController(t_slice_target_nsecs=1e6)
+    controller.n_executions = 1000  # keeps the per-execution floor below the common target
+    controller.record_slice(t_nsecs=1e6)
+    controller.record_slice(t_nsecs=1e6)
+    assert controller.is_calibrated
+    n_before = controller.n_executions
+
+    # --- act ---------------------------------------------
+    controller.record_slice(t_nsecs=0.0)
+
+    # --- assert ------------------------------------------
+    assert controller.n_executions == int(n_before * SliceController.MAX_ADJUST_FACTOR_CALIBRATED)
+
+
 def test_controller_never_exceeds_absolute_execution_cap():
     # --- arrange -----------------------------------------
     controller = SliceController(t_slice_target_nsecs=1e6)
@@ -139,6 +186,25 @@ def test_runner_returns_requested_number_of_recorded_slices(fake_benchmarks):
         assert isinstance(result, MicroBenchmarkResult)
         assert len(result.warmup_runs) == 2
         assert len(result.benchmark_runs) == 7
+
+
+def test_runner_completes_when_every_slice_measures_zero():
+    """A full run must survive a probe the clock cannot resolve, rather than dividing by its time."""
+    # --- arrange -----------------------------------------
+    benchmarks = {name: UntimeableBenchmark(name) for name in ["alpha", "beta"]}
+    runner = InterleavedBenchmarkRunner(
+        benchmarks, t_slice_target_ms=0.001, n_rounds_measure=3, n_rounds_warmup=1, seed=3
+    )
+
+    # --- act ---------------------------------------------
+    results = runner.run()
+
+    # --- assert ------------------------------------------
+    assert set(results.keys()) == set(benchmarks.keys())
+    for result in results.values():
+        assert len(result.benchmark_runs) == 3
+        # the reported quantiles stay well-defined even though every measurement was zero
+        assert result.summary_stats_nsecs_per_exec().q50 == 0.0
 
 
 def test_runner_prepares_each_suite_exactly_once(fake_benchmarks):


### PR DESCRIPTION
**Problem**: The slice controller sized its next execution count as `target / measured_time`, so a slice finishing below the clock's resolution crashed the whole benchmark run with `ZeroDivisionError`. Load-dependent, hence intermittent.

**Solution**: A zero measurement now asks for an unbounded increase rather than computing a ratio, and the controller's existing clamp turns that into the largest step an adjustment is allowed to make — which is exactly the right response to a slice too short to time. Both the calibrating and the calibrated path divided by that measurement; the guard sits in one helper both use.

- **Attention:** this is not an exotic case. A cheap probe at a low execution count on a coarse-resolution clock is the ramp's own *starting* regime, so the crash was always reachable — it just needed the timing to land on exactly zero rather than 1.
- **Attention:** the second call site (the calibrated deadband path) was not the one that crashed in the wild, but divides by the same measurement and is fixed and covered too.
- **Attention:** it produced a *plausible* failure mode. The run dies inside calibration, so a user sees a benchmark crash rather than a wrong number — no risk that bad data was ever reported.
- **TEST:** all three new tests were confirmed to fail with the fix reverted and pass with it applied, rather than assumed to cover it.
- **TEST:** one of them drives a full run end to end through a probe whose every slice reports zero, which makes the intermittent failure deterministic; the reported quantiles stay well-defined.
- **TEST:** full suite green — 1825 passed, 3 skipped.

**Changelog** (Fixed): 

```
- a benchmark slice that measures zero elapsed time no longer crashes the calibration; it now ramps up the execution count instead
```


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
