### PR TITLE
refactor: stop writing the patched-function list four times

### DIFF
--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -17,6 +17,30 @@ The `original_math_*` references are (re)captured at patch time, not at import t
 package may have applied its own `math` patches after we were imported, and we want to delegate
 through — and later restore — whatever is current, rather than silently wiping those patches.
 
+**Map of the name-keyed tables.** Only the first two are maintained by hand; every other is derived
+or filled at runtime, so a function is added or reclassified in one place (plus its replacement).
+
+  | table                  | holds                          | written        | read              |
+  |------------------------|--------------------------------|----------------|-------------------|
+  | `_PATCHES`             | name -> counting replacement   | by hand        | capture/apply/restore |
+  | `original_math_*`      | name -> delegation target      | by hand¹       | every delegated call |
+  | `_UNCOUNTED_MATH`      | name -> why it goes uncounted  | by hand        | builds the next one |
+  | `_MATH_NOT_PATCHED`    | name -> why it needs no patch  | by hand        | the surface test, docs |
+  | `_UNCOUNTED_PATCHES`   | name -> reporting replacement  | derived        | apply/restore     |
+  | `_saved_originals`     | name -> function to restore    | at capture     | restore           |
+  | `_uncounted_originals` | name -> function to delegate to| at apply       | reporting replacements |
+
+  ¹ the *names* are declared by hand, because the replacements call them directly and a type
+  checker has to resolve them; their values are always rebound by `_capture_originals`.
+
+  `_PATCHES`, `_UNCOUNTED_MATH` and `_MATH_NOT_PATCHED` partition the public `math` surface between
+  them — exhaustively and without overlap, which a test enforces, so a function CPython adds later
+  cannot slip through unclassified.
+
+**Lifecycle**, in order: import (declare references and tables) -> first context entry (capture the
+current `math`, install `_PATCHES`) -> first reporting thread (install `_UNCOUNTED_PATCHES`) -> last
+reporting thread leaves (restore those) -> last context exit (restore the capture).
+
 The patching contract (mirroring unittest.mock.patch / pytest monkeypatch conventions):
   - at first context entry, we snapshot the current math functions (whatever they are, including
     other packages' patches) and delegate through them while counting;
@@ -68,7 +92,16 @@ def _math_sumprod_unavailable(p: Iterable[float], q: Iterable[float], /) -> floa
 #  original math module functions
 #  (import-time values are only a default; re-captured on every 0->1 patch
 #   application by _capture_originals, see module docstring)
+#
+#  Written out one per line rather than generated, for one reason: the
+#  replacements below call these names directly, and a name conjured at
+#  runtime is a name the type checker cannot resolve. Their *values* are
+#  never maintained here -- _capture_originals rebinds every one of them --
+#  so what these lines really declare is which functions exist to delegate
+#  to, which a test holds against the patch table.
 # -------------------------------------------------------------------------
+_REFERENCE_PREFIX = "original_math_"
+
 original_math_sqrt = math.sqrt
 original_math_cbrt = math.cbrt
 original_math_log = math.log
@@ -837,6 +870,11 @@ _MATH_NOT_PATCHED: dict[str, str] = {
     "perm": _NOT_PATCHED_INTEGER_DOMAIN,
 }
 
+# the module-global holding each patched function's delegation target, resolved once at import so
+# re-capture does no string work of its own. Derived from _PATCHES, hence built after the
+# version-gated entries have been registered above.
+_REFERENCE_NAMES: dict[str, str] = {name: f"{_REFERENCE_PREFIX}{name}" for name in _PATCHES}
+
 # the math functions saved at patch time, to be restored at unpatch time
 _saved_originals: dict[str, object] = {}
 
@@ -854,66 +892,30 @@ _patch_lock = threading.Lock()
 
 
 def _capture_originals() -> None:
-    """Snapshot the current math functions.
+    """Snapshot the current math functions, for delegation and for restoring on unpatch.
 
-    This way the replacements delegate through (and unpatching restores) whatever is current —
-    possibly another package's patches, not the stdlib originals.
+    Two views of the same snapshot, because they are read very differently. `_saved_originals` is a
+    dict, walked once per unpatch. The `original_math_*` module globals are what the replacements
+    themselves call, on every delegated call -- a module-global read, which measures meaningfully
+    cheaper than a dict lookup, and is why those names exist at all.
+
+    Rebinding them through `globals()` is what keeps that list of names from being written out a
+    second and third time here: `globals()` *is* this module's namespace, so an update to it is seen
+    by every already-defined replacement. Only the names in `_PATCHES` are re-captured, which is
+    also what makes the plain `getattr` safe -- a version-gated function absent from this
+    interpreter is absent from `_PATCHES` too, and keeps the stand-in bound at import.
+
+    The snapshot deliberately takes whatever is current rather than the stdlib original: another
+    package may have patched `math` after we were imported, and we delegate through -- and later
+    restore -- its patches rather than silently wiping them.
     """
-    global original_math_sqrt, original_math_cbrt, original_math_log, original_math_log2
-    global original_math_log10, original_math_exp, original_math_exp2, original_math_pow, original_math_fma
-    global original_math_sin, original_math_cos, original_math_tan
-    global original_math_asin, original_math_acos, original_math_atan, original_math_atan2
-    global original_math_hypot, original_math_expm1, original_math_log1p, original_math_fmod, original_math_fabs
-    global original_math_sinh, original_math_cosh, original_math_tanh
-    global original_math_asinh, original_math_acosh, original_math_atanh
-    global original_math_degrees, original_math_radians, original_math_dist
-    global original_math_prod, original_math_fsum, original_math_copysign
-    global original_math_gamma, original_math_lgamma, original_math_erf, original_math_erfc
-    global original_math_remainder, original_math_sumprod
-
-    original_math_sqrt = math.sqrt
-    original_math_cbrt = math.cbrt
-    original_math_log = math.log
-    original_math_log2 = math.log2
-    original_math_log10 = math.log10
-    original_math_exp = math.exp
-    original_math_exp2 = math.exp2
-    original_math_pow = math.pow
-    original_math_fma = getattr(math, "fma", _math_fma_unavailable)
-    original_math_sin = math.sin
-    original_math_cos = math.cos
-    original_math_tan = math.tan
-    original_math_asin = math.asin
-    original_math_acos = math.acos
-    original_math_atan = math.atan
-    original_math_atan2 = math.atan2
-    original_math_hypot = math.hypot
-    original_math_expm1 = math.expm1
-    original_math_log1p = math.log1p
-    original_math_fmod = math.fmod
-    original_math_fabs = math.fabs
-    original_math_sinh = math.sinh
-    original_math_cosh = math.cosh
-    original_math_tanh = math.tanh
-    original_math_asinh = math.asinh
-    original_math_acosh = math.acosh
-    original_math_atanh = math.atanh
-    original_math_degrees = math.degrees
-    original_math_radians = math.radians
-    original_math_dist = math.dist
-    original_math_prod = math.prod
-    original_math_fsum = math.fsum
-    original_math_copysign = math.copysign
-    original_math_gamma = math.gamma
-    original_math_lgamma = math.lgamma
-    original_math_erf = math.erf
-    original_math_erfc = math.erfc
-    original_math_remainder = math.remainder
-    original_math_sumprod = getattr(math, "sumprod", _math_sumprod_unavailable)
-
     _saved_originals.clear()
-    for name in _PATCHES:
-        _saved_originals[name] = getattr(math, name)
+    captured: dict[str, object] = {}
+    for name, reference in _REFERENCE_NAMES.items():
+        current = getattr(math, name)
+        _saved_originals[name] = current
+        captured[reference] = current
+    globals().update(captured)
 
 
 def apply_math_patches() -> None:

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -17,8 +17,11 @@ The `original_math_*` references are (re)captured at patch time, not at import t
 package may have applied its own `math` patches after we were imported, and we want to delegate
 through — and later restore — whatever is current, rather than silently wiping those patches.
 
-**Map of the name-keyed tables.** Only the first two are maintained by hand; every other is derived
-or filled at runtime, so a function is added or reclassified in one place (plus its replacement).
+**Map of the name-keyed tables.** Four are maintained by hand, and they are not four copies of one
+list: `_PATCHES`, `_UNCOUNTED_MATH` and `_MATH_NOT_PATCHED` are the *classification*, and every
+public `math` function belongs to exactly one of them. `original_math_*` is the one place a name is
+genuinely written twice — unavoidably, since the replacements call those names directly and a type
+checker has to be able to resolve them. Everything below those four is derived or filled at runtime.
 
   | table                  | holds                          | written        | read              |
   |------------------------|--------------------------------|----------------|-------------------|
@@ -30,12 +33,11 @@ or filled at runtime, so a function is added or reclassified in one place (plus 
   | `_saved_originals`     | name -> function to restore    | at capture     | restore           |
   | `_uncounted_originals` | name -> function to delegate to| at apply       | reporting replacements |
 
-  ¹ the *names* are declared by hand, because the replacements call them directly and a type
-  checker has to resolve them; their values are always rebound by `_capture_originals`.
+  ¹ only the *names* are; their values are always overwritten by `_capture_originals`.
 
-  `_PATCHES`, `_UNCOUNTED_MATH` and `_MATH_NOT_PATCHED` partition the public `math` surface between
-  them — exhaustively and without overlap, which a test enforces, so a function CPython adds later
-  cannot slip through unclassified.
+  That the three classification tables really do partition the surface — exhaustively and without
+  overlap — is enforced by a test, so a function CPython adds later cannot slip through
+  unclassified.
 
 **Lifecycle**, in order: import (declare references and tables) -> first context entry (capture the
 current `math`, install `_PATCHES`) -> first reporting thread (install `_UNCOUNTED_PATCHES`) -> last

--- a/tests/counting/test_originals_capture_sync.py
+++ b/tests/counting/test_originals_capture_sync.py
@@ -1,24 +1,17 @@
-"""The same list of `math` function names is written in four places; they must agree.
+"""Every patched `math` function must have a delegation reference, and re-capture must rebind it.
 
-The patching module keeps a module-level `original_math_<name>` reference per patched function, and
-re-points every one of them each time patching starts, so the replacements delegate through whatever
-is current -- possibly another package's patch rather than the stdlib original. That arrangement
-spells the same list of names four times: the import-time references, the `global` declarations in
-the re-capture step, the re-capture assignments themselves, and the patch table.
+The patching module keeps a module-level `original_math_<name>` per patched function, because the
+replacements call those names on every delegated call and a module-global read is measurably cheaper
+than a dict lookup. That leaves the list of names written in two places -- the declarations and the
+patch table -- which is one more than anybody would like, and as few as a type checker allows: the
+replacements reference those names directly, so conjuring them at runtime would make them
+unresolvable.
 
-Two ways to get it wrong, both invisible in normal operation:
-
-* a name in the patch table with no reference to delegate through, or one that is never re-captured,
-  leaves a stale reference -- correct until another package patches `math` first;
-* a name assigned in the re-capture step but missing from its `global` declaration is not an error
-  at all. Python simply makes it a function-local, so the assignment writes nothing anybody reads
-  and that function keeps its import-time reference forever.
-
-The second is the reason this test parses the source rather than only comparing the tables: the
-other three lists agree perfectly while it is wrong.
-
-The duplication is deliberate and stays. Reading a module-level name is what keeps delegation off a
-dict lookup on the hot path, so the guard goes on the invariant rather than on collapsing the lists.
+Everything downstream of the declarations is derived. Re-capture rebinds them in a loop over the
+patch table rather than name by name, so there is no third or fourth copy to drift. The two tests
+here cover exactly what remains: that the two lists agree, and that the loop really does move the
+references the replacements read -- the one thing no amount of reading the source can confirm,
+since rebinding through the module namespace is invisible to static analysis.
 """
 
 import ast
@@ -26,87 +19,28 @@ import math
 from pathlib import Path
 
 from counted_float._core.counting import _math_patching
-from counted_float._core.counting._math_patching import _PATCHES
-
-_REFERENCE_PREFIX = "original_math_"
-_CAPTURE_FUNCTION = "_capture_originals"
+from counted_float._core.counting._math_patching import _PATCHES, _REFERENCE_PREFIX
 
 
 # =================================================================================================
 #  Helpers
 # =================================================================================================
-def _module_tree() -> ast.Module:
-    """Parse the patching module's own source."""
-    return ast.parse(Path(_math_patching.__file__ or "").read_text(encoding="utf-8"))
-
-
-def _referenced_names(nodes: list[ast.stmt]) -> set[str]:
-    """The math function names assigned as `original_math_<name>` directly among `nodes`."""
+def _declared_reference_names() -> set[str]:
+    """The math function names declared as module-level `original_math_<name>` references."""
+    tree = ast.parse(Path(_math_patching.__file__ or "").read_text(encoding="utf-8"))
     return {
         target.id.removeprefix(_REFERENCE_PREFIX)
-        for node in nodes
+        for node in tree.body
         if isinstance(node, ast.Assign)
         for target in node.targets
         if isinstance(target, ast.Name) and target.id.startswith(_REFERENCE_PREFIX)
     }
 
 
-def _capture_function(tree: ast.Module) -> ast.FunctionDef:
-    """The re-capture function's node."""
-    for node in tree.body:
-        if isinstance(node, ast.FunctionDef) and node.name == _CAPTURE_FUNCTION:
-            return node
-    raise AssertionError(f"{_CAPTURE_FUNCTION} not found -- was it renamed?")
-
-
-def _declared_global(function: ast.FunctionDef) -> set[str]:
-    """The math function names declared global inside `function`."""
-    return {
-        name.removeprefix(_REFERENCE_PREFIX)
-        for node in ast.walk(function)
-        if isinstance(node, ast.Global)
-        for name in node.names
-        if name.startswith(_REFERENCE_PREFIX)
-    }
-
-
 # =================================================================================================
 #  Tests
 # =================================================================================================
-def test_the_import_time_references_match_the_recaptured_ones():
-    # --- arrange -----------------------------------------
-    tree = _module_tree()
-
-    # --- act ---------------------------------------------
-    at_import = _referenced_names(tree.body)
-    recaptured = _referenced_names(_capture_function(tree).body)
-
-    # --- assert ------------------------------------------
-    assert at_import, "no original_math_* references found -- was the naming changed?"
-    assert at_import == recaptured, (
-        f"never re-captured: {sorted(at_import - recaptured)}; "
-        f"re-captured without an import-time reference: {sorted(recaptured - at_import)}"
-    )
-
-
-def test_every_recaptured_reference_is_declared_global():
-    """Otherwise the assignment silently writes a function-local and re-capture does nothing."""
-    # --- arrange -----------------------------------------
-    capture = _capture_function(_module_tree())
-
-    # --- act ---------------------------------------------
-    recaptured = _referenced_names(capture.body)
-    declared = _declared_global(capture)
-
-    # --- assert ------------------------------------------
-    assert recaptured == declared, (
-        f"assigned but not declared global (the re-capture is a no-op for these): "
-        f"{sorted(recaptured - declared)}; "
-        f"declared global but never assigned: {sorted(declared - recaptured)}"
-    )
-
-
-def test_the_patch_table_matches_the_references():
+def test_the_patch_table_matches_the_declared_references():
     """Every patched function has a reference to delegate through, and vice versa.
 
     Compared over the functions this interpreter actually has: the references are declared
@@ -114,37 +48,40 @@ def test_the_patch_table_matches_the_references():
     the version-gated ones only when they exist.
     """
     # --- arrange -----------------------------------------
-    at_import = _referenced_names(_module_tree().body)
+    declared = _declared_reference_names()
 
     # --- act ---------------------------------------------
-    available = {name for name in at_import if hasattr(math, name)}
+    available = {name for name in declared if hasattr(math, name)}
 
     # --- assert ------------------------------------------
+    assert declared, "no original_math_* references found -- was the naming changed?"
     assert available == set(_PATCHES), (
-        f"referenced but not patched: {sorted(available - set(_PATCHES))}; "
+        f"declared but not patched: {sorted(available - set(_PATCHES))}; "
         f"patched with no reference to delegate through: {sorted(set(_PATCHES) - available)}"
     )
 
 
-def test_the_recapture_actually_rebinds_the_module_level_reference():
-    """The behavioral counterpart: re-capturing must move the reference the replacements read.
+def test_recapture_rebinds_every_delegation_reference():
+    """The loop must move all of them, not merely run.
 
-    The AST tests above cannot see a reference that is rebound somewhere other than where they
-    looked; this one just does it and checks.
+    Rebinding happens through this module's own namespace, which no static check can follow -- so
+    this points every reference at a sentinel, re-captures, and insists none survived.
     """
     # --- arrange -----------------------------------------
-    name = next(iter(_PATCHES))
-    reference = f"{_REFERENCE_PREFIX}{name}"
-    original = getattr(_math_patching, reference)
+    references = {
+        f"{_REFERENCE_PREFIX}{name}": getattr(_math_patching, f"{_REFERENCE_PREFIX}{name}") for name in _PATCHES
+    }
     sentinel = object()
-    setattr(_math_patching, reference, sentinel)
+    for reference in references:
+        setattr(_math_patching, reference, sentinel)
 
     # --- act ---------------------------------------------
     try:
         _math_patching._capture_originals()
-        recaptured = getattr(_math_patching, reference)
+        still_sentinel = [reference for reference in references if getattr(_math_patching, reference) is sentinel]
     finally:
-        setattr(_math_patching, reference, original)
+        for reference, original in references.items():
+            setattr(_math_patching, reference, original)
 
     # --- assert ------------------------------------------
-    assert recaptured is not sentinel, f"{reference} was not rebound by the re-capture"
+    assert not still_sentinel, f"never rebound by the re-capture: {sorted(still_sentinel)}"


### PR DESCRIPTION
**TL;DR**: The list of patched `math` function names was hand-maintained in three places; two of them had no reason to exist and are gone. Net −61 lines, and the module docstring now maps every table.

## Description

### Problem addressed

Review of the surface-pinning change made the real objection plain: **it was becoming impossible to tell which list lives where, what each is for, and which depends on which.** That is a fair charge, and pinning the lists with a test rather than deleting them made it worse.

The same 39 names were written out three times by hand:

- as module-level `original_math_<name>` declarations;
- again as a `global` block inside the capture step;
- again as one assignment per name in that same function.

Only the first has a justification. The other two were pure transcription — and one of them, the `global` block, fails *silently* when it drifts: forget a name there and Python makes the assignment a function-local, so the capture writes something nobody reads and that function keeps its import-time reference forever.

### Implementation

Capture now rebinds every reference in **one pass over the patch table**, through the module namespace. `globals()` *is* this module's namespace, so updating it is seen by every already-defined replacement — which makes the `global` block and the 39 assignments both unnecessary. That function went from 57 lines to 8.

**The declarations stay, and it is worth being precise about why**, since it is the only remaining duplication: the replacements call `original_math_sqrt(x)` directly, so those names must be resolvable statically. Conjure them at runtime and the type checker cannot see them. What the declarations really pin is *which functions exist to delegate to* — their values are always overwritten by capture — and a test holds that list against the patch table.

The reference name per function is resolved **once at import** rather than rebuilt per capture, and the single pass does one `getattr` per name instead of two. Both matter only because the first version of this change measurably slowed context entry; see below.

The module docstring gains a **map of all seven name-keyed tables** — what each holds, who writes it, who reads it, which are derived — plus the lifecycle in order, and a note that three of them partition the `math` surface exhaustively.

## Attention points

- **Per-call delegation is untouched, and measured to confirm it.** The replacements still do a module-global read, exactly as before; only the code that *writes* those globals changed, and it runs once per context entry. A/B alternating runs against the parent branch showed no difference above the ~2% run-to-run noise — and the apparent 4-for-4 difference in the first ordering vanished when the order was reversed, which is why it was worth running both ways rather than reporting the first result.
- **Context entry/exit costs ~0.5 µs more** (19.8 → 20.3 µs, ~3%): a Python loop replacing 39 straight-line stores. Stated rather than smoothed over. It happens once per context, which wraps a whole computation, against removing two copies of a 39-name list.
- **The first version of this change was 12% slower on that path** (+2.3 µs), because it built 39 f-strings per capture and called `getattr` twice per name. Caught by measuring, not by reading.
- **This deletes most of the test added alongside the surface pin.** Three of its four tests policed lists that no longer exist. What is left is the one structural check that still has a subject, plus the behavioral one — which is now stronger: it sentinels *every* reference rather than one, and it is the only way to confirm namespace rebinding, which no static check can follow.
- **Sole remaining duplication is the declarations**, down from three, and it is the one a type checker requires.

## Tests / Spikes

- **SPIKE:** confirmed up front that `globals().update()` rebinds a global an already-defined function reads — the assumption the whole change rests on — and measured a module-global call against a dict lookup at **1.34x**, which is why the references exist rather than a plain dict.
- **TEST:** full suite green — 1823 passed, 3 skipped.
- **TEST:** hot-path delegation measured A/B against the parent branch, in both orderings, 4 rounds each.
- **TEST:** context entry/exit measured A/B across three rounds, before and after the single-pass fix.
- **TEST:** type checking passes with and without the optional extras.

## Changelog entry

None: no user-facing change. Internal structure, with per-call behavior measured unchanged.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
