### PR TITLE
chore: make CodeQL a job of the PR pipeline

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,10 +4,13 @@ name: CodeQL
 # (which lint the workflows, not the package code).
 #
 # On pull requests this runs as a job of the PR pipeline rather than off its own
-# `pull_request` trigger, and the `CI gate` aggregation waits for it — so a
-# finding blocks the merge until it is fixed or dismissed. Being a job of that
-# pipeline also means it inherits the pipeline's lack of a base-branch filter,
-# so a PR based on another feature branch is scanned while it is being reviewed.
+# `pull_request` trigger, so it inherits the pipeline's lack of a base-branch
+# filter: a PR based on another feature branch is scanned while it is being
+# reviewed. The `CI gate` aggregation waits for it, so a merge can no longer
+# outrun its own scan — but the gate is not what acts on findings. This step
+# always exits 0; the check run that reports alerts introduced by a PR is
+# code scanning's own, which branch protection requires separately.
+#
 # The `main`-push and weekly triggers below stay standalone: they cover the
 # merged tip and new query packs, neither of which is review-time.
 
@@ -47,3 +50,12 @@ jobs:
           languages: python  # pure-Python package: no build step, CodeQL analyzes sources directly
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          # Code scanning matches a pull request's analysis against the base
+          # branch's by category, which otherwise defaults to the analysis key
+          # `<workflow file>:<job>`. A called workflow runs under the *caller's*
+          # file, so leaving it implicit gives the same scan two identities and
+          # code scanning reports that it cannot determine which alerts the PR
+          # introduced. Pinning it to a literal makes the identity independent
+          # of how the scan was invoked.
+          category: python

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,18 @@
 name: CodeQL
 
-# Static analysis (SAST) for the Python package. Advisory, not blocking:
-# this is an independent security scanner, deliberately NOT part of the
-# `CI gate` aggregation — a code-scanning alert should surface without
-# failing an unrelated PR. Complements zizmor/actionlint (which lint the
-# workflows, not the package code).
+# Static analysis (SAST) for the Python package. Complements zizmor/actionlint
+# (which lint the workflows, not the package code).
+#
+# On pull requests this runs as a job of the PR pipeline rather than off its own
+# `pull_request` trigger, and the `CI gate` aggregation waits for it — so a
+# finding blocks the merge until it is fixed or dismissed. Being a job of that
+# pipeline also means it inherits the pipeline's lack of a base-branch filter,
+# so a PR based on another feature branch is scanned while it is being reviewed.
+# The `main`-push and weekly triggers below stay standalone: they cover the
+# merged tip and new query packs, neither of which is review-time.
 
 on:
-  pull_request:
-    branches: [main]
+  workflow_call:
   push:
     branches: [main]
   schedule:
@@ -18,7 +22,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # `github.workflow` resolves to the *caller's* name when this runs as a called
+  # workflow, so the literal prefix is what keeps the group distinct from the
+  # caller's own — sharing one would have this run cancel the pipeline waiting
+  # on it.
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -91,6 +91,17 @@ jobs:
     needs: [preflight]
     uses: ./.github/workflows/_package_check.yml
 
+  # Static-analysis gate. Permissions are declared here because a called
+  # workflow cannot grant itself more than its caller has, and this file's
+  # default is `contents: read`.
+  codeql:
+    needs: [preflight]
+    permissions:
+      security-events: write  # upload analysis results to code scanning
+      contents: read          # checkout
+      actions: read           # read workflow run metadata (CodeQL requirement)
+    uses: ./.github/workflows/codeql.yml
+
   # Synchronous dependency-CVE gate: audits the locked runtime dependencies
   # against the advisory DB at PR time — the blocking complement to the async,
   # repo-level Dependabot alerts. Hard-fails on any advisory; accepted ones go
@@ -125,7 +136,7 @@ jobs:
     # `always()` is load-bearing — without it the gate is skipped when an
     # upstream job fails, and GitHub treats a skipped required check as passing.
     if: always()
-    needs: [preflight, pre-commit, test, package, pip-audit]
+    needs: [preflight, pre-commit, test, package, codeql, pip-audit]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job did not succeed


### PR DESCRIPTION
**TL;DR**: CodeQL becomes a called job of the PR pipeline, so every pull request is scanned while it is being reviewed and no merge can outrun its own scan.

## Description

### Problem addressed

CodeQL watched pull requests off its own `pull_request` trigger, **filtered to a `main` base**. A PR based on another feature branch therefore got no scan for as long as it was stacked — exactly the window a reviewer reads it in. Such a PR was first scanned at merge time, when the retarget and force-push finally matched the filter, and **the merge did not wait for that run**: one merged three seconds after its scan started and two and a half minutes before it finished.

### Implementation

CodeQL gains a `workflow_call` trigger and the PR pipeline calls it the way it already calls the unit-test and package-check workflows. The aggregate `CI gate` adds it to the set it waits on. Its own `pull_request` trigger goes away in the same move — otherwise every PR would scan twice — while the `main`-push and weekly-schedule triggers stay untouched, since those cover the merged tip and new query packs rather than review.

**The stacked-PR hole closes as a side effect rather than as a special case**: the PR pipeline deliberately carries no base-branch filter, so a job of it runs wherever the PR points.

Three mechanics of reusable workflows shaped the diff:

- **The analysis category is pinned to a literal.** Code scanning identifies a configuration by workflow file path plus job name unless told otherwise, and a called workflow runs under the *caller's* file — so the same scan acquires one identity on `main` and another on a pull request, and code scanning then reports that it cannot determine which alerts the PR introduced. An explicit `category` decouples identity from invocation path.
- **Permissions are declared on the calling job.** A called workflow cannot grant itself more than its caller has, and the pipeline's default is `contents: read`, so `security-events: write` has to be granted at the call site.
- **The concurrency group needed a literal prefix.** `github.workflow` resolves to the caller's name inside a called workflow, so the previous expression would have put the scan in the pipeline's own group — and with `cancel-in-progress`, the scan would have cancelled the run waiting on it.

## Attention points

- **This does not make findings block merges, and the gate cannot make them.** The analyze step exits 0 whether or not it finds anything. What the gate adds is that the scan **completes** before a merge is possible; acting on findings is the job of code scanning's own check run, which is a separate app's check and is not currently a required context. Making it one is a branch-protection change that deliberately does not ride in this PR — see below.
- **Expect one transitional PR with a neutral code-scanning check.** The comparison is against configurations recorded on `main`, which still carries the pre-pin category until a push to `main` re-registers it. So this PR reports "configuration not found"; the next one after merge is where the pin can be confirmed working.
- **The branch-protection change must follow, not accompany, this merge.** Requiring the code-scanning check while `main` still holds the old configuration would gate merges on a check that cannot yet report properly.
- **No new coverage claim.** The tip of `main` was always scanned, so nothing unscanned was shipping; what was missing is the signal at review time.
- **Wall-clock cost is negligible but worth watching once.** The scan ran in 56s against a pipeline that spends minutes in runner queueing, and total runner demand is unchanged since the scan moves rather than being added. The residual risk is that under contention it lands in a later wave and stretches the tail.

## Tests / Spikes

- **TEST:** the pipeline run on this PR shows `codeql / Analyze (python)` as a job under `CI gate`, passing in 56s — the mechanism working end to end.
- **TEST:** the code-scanning API confirmed the diagnosis behind the category pin, reporting this PR's analysis under `.github/workflows/pull_request.yml:analyze` against `.github/workflows/codeql.yml:analyze` on `main`.
- **TEST:** `make lint` passes, including `actionlint`, `zizmor`, and the GitHub-workflow schema validator — the last of which checks the reusable-workflow call site is well-formed.
- **TEST:** `make test` passes (1823 passed, 3 skipped); no package code is touched.
- No unit tests added — the change is entirely CI configuration.

## Changelog entry

None: CI-only change with no user-facing effect.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
