### PR TITLE
chore: catch a screenshot whose inputs moved on without it

### DIFF
--- a/scripts/docs_artifacts/__init__.py
+++ b/scripts/docs_artifacts/__init__.py
@@ -9,6 +9,8 @@ Modules
   - `_artifact` — the `DerivedFile` hierarchy: one class per kind of generated file.
   - `_manager` — `DocsArtifactManager`, holding a set of them and offering the only two operations
     there are: check them, or regenerate them.
+  - `_manifest` — the committed record of what the files that cannot be re-derived here were last
+    built from.
   - `_ansi` — helpers for the files whose content is raw terminal output.
 
 The `DerivedFile` hierarchy
@@ -19,7 +21,8 @@ is allowed to ask; each subclass answers in its own terms, so the manager never 
 
     DerivedFile                (abstract: defines the questions)
     ├── MarkedBlockFile        an authored file with generated regions in it
-    └── GeneratedFile          a whole file that is nothing but generator output
+    ├── GeneratedFile          a whole file that is nothing but generator output
+    └── RenderedFile           a whole file built by external tooling, not reproducible here
 
 What the base asks, and what differs between the children:
 
@@ -33,8 +36,19 @@ What the base asks, and what differs between the children:
     rather than reported stale, because the only local answer would be a false mismatch.
   - **`readable(content)`** — how the content should appear in a diff. Only `GeneratedFile`
     overrides it, for the captures whose raw ANSI is unreadable as it stands.
+  - **`fingerprint()`** — a hash of the file's inputs, defaulting to None. Only `RenderedFile`
+    answers it, and it is the *only* question that class can answer: its bytes come from external
+    tooling that no two machines agree on, so there is nothing to re-derive and compare.
 
-Two flat value types sit beside the hierarchy and are deliberately not part of it: `MarkedBlock`
+Each file is therefore checked by the strongest means available to it — re-derived and compared byte
+for byte where that is possible, and against a hash of its inputs only where it is not. The manager
+asks both questions and takes whichever answer it gets.
+
+A second, smaller hierarchy lives in `_manager`: `Stale` with `StaleContent` and `StaleInputs`. It
+exists because the two ways a file goes stale read differently in a report — one can show a diff of
+what changed, the other only knows *that* the inputs moved.
+
+Two flat value types sit beside the hierarchies and are deliberately not part of them: `MarkedBlock`
 (one registered region: its file plus its generator) and `RegenerationOutcome` (what a regeneration
 pass produced). They carry data, answer no questions, and have no subclasses.
 
@@ -48,11 +62,12 @@ from ._artifact import (
     GeneratedFile,
     MarkedBlock,
     MarkedBlockFile,
+    RenderedFile,
     marked_block_files,
     read_lf,
     rewrite_marked_blocks,
 )
-from ._manager import DocsArtifactManager, RegenerationOutcome, StaleFile
+from ._manager import DocsArtifactManager, RegenerationOutcome, Stale, StaleContent, StaleInputs
 
 __all__ = [
     "DerivedFile",
@@ -61,7 +76,10 @@ __all__ = [
     "MarkedBlock",
     "MarkedBlockFile",
     "RegenerationOutcome",
-    "StaleFile",
+    "RenderedFile",
+    "Stale",
+    "StaleContent",
+    "StaleInputs",
     "capture_env",
     "crop_ansi_line",
     "marked_block_files",

--- a/scripts/docs_artifacts/_artifact.py
+++ b/scripts/docs_artifacts/_artifact.py
@@ -1,14 +1,16 @@
 """The `DerivedFile` hierarchy: one committed file that is generated rather than written.
 
-`DerivedFile` is the abstract base. It defines the three questions the manager asks of every
-committed file, and answers two of them with defaults:
+`DerivedFile` is the abstract base. It defines the four questions the manager asks of every
+committed file, and answers three of them with defaults:
 
   - `intended_content()` — abstract, and the only thing every subclass must implement. It is what
     the file *should* contain right now, re-derived from whatever the file is generated from.
   - `can_produce_here()` — whether this machine can answer the first question at all. Default True.
   - `readable(content)` — that content as it should appear in a diff. Default: unchanged.
+  - `fingerprint()` — a hash of the file's inputs, for kinds that cannot be re-derived here at all.
+    Default None, meaning "compare my content instead".
 
-Two concrete subclasses, differing only in how they answer the first question:
+Three concrete subclasses, differing mainly in how they answer the first question:
 
   - **`MarkedBlockFile`** — an authored file with generated regions in it, between
     `<!-- BEGIN/END generated: name -->` markers. Its intended content is the *committed* file with
@@ -18,20 +20,25 @@ Two concrete subclasses, differing only in how they answer the first question:
     generator's output, so its intended content is simply that output. It also overrides the other
     two defaults, since a whole-file generator may be unavailable on a given platform and its
     output may not be readable as it stands.
+  - **`RenderedFile`** — a file built by external tooling whose bytes no machine reproduces
+    identically. It cannot answer the first question at all, so it answers the fourth instead:
+    `fingerprint()`, a hash of everything its bytes are a function of.
 
-Both are checked the same way by the manager — re-derive, compare — which is the point of the base
-class: the manager asks, the subclass knows.
+The first two are checked the same way — re-derive, compare. The third cannot be, which is why the
+base carries a fingerprint question whose default is None: the manager asks both, and each subclass
+answers whichever one it can.
 """
 
 from __future__ import annotations
 
 import abc
 import dataclasses
+import hashlib
 import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
     from pathlib import Path
 
 _MARKER_RE = re.compile(r"<!-- (BEGIN|END) generated: ([a-z0-9-]+) -->")
@@ -70,8 +77,8 @@ class DerivedFile(abc.ABC):
     def can_produce_here(self) -> bool:
         """Whether this machine can produce the intended content at all.
 
-        A file that cannot be produced here is neither checked nor rewritten, because the only
-        honest answer available locally would be a false mismatch.
+        A file that cannot be produced here is never byte-compared, because the only honest answer
+        available locally would be a false mismatch.
         """
         return True
 
@@ -82,6 +89,14 @@ class DerivedFile(abc.ABC):
         override it, so a reader sees which *output* changed rather than which escape sequences.
         """
         return content
+
+    def fingerprint(self) -> str | None:
+        """A hash of everything this file is a function of, for files that cannot be re-derived here.
+
+        None means the file is checked by re-deriving and comparing its content, which is strictly
+        stronger — so a fingerprint exists only where that is impossible.
+        """
+        return None
 
 
 # ==================================================================================================
@@ -216,3 +231,43 @@ class GeneratedFile(DerivedFile):
     def readable(self, content: str) -> str:
         """The content as it should appear in a diff, per `as_readable`."""
         return content if self.as_readable is None else self.as_readable(content)
+
+
+# ==================================================================================================
+#  RenderedFile
+# ==================================================================================================
+class RenderedFile(DerivedFile):
+    """A file built by external tooling, whose bytes are not reproducible across machines.
+
+    Nothing here can be byte-compared: the renderer is absent in CI, and even where it is present
+    its output differs by tool version and platform. So the file is checked against a hash of its
+    inputs instead, which is platform-stable and needs no renderer to recompute.
+    """
+
+    def __init__(self, path: Path, inputs: Callable[[], Sequence[str]]) -> None:
+        """Bind the file to a description of everything its bytes are a function of.
+
+        Args:
+            path: The committed file.
+            inputs: Returns source content, the resolved render geometry, and the tool parameters,
+                in a canonical, stable order.
+        """
+        super().__init__(path)
+        self.inputs = inputs
+
+    def intended_content(self) -> str:
+        """Never called: a rendered file is checked by fingerprint, never by content."""
+        raise NotImplementedError(f"{self.path.name} is checked by fingerprint, not by content")
+
+    def can_produce_here(self) -> bool:
+        """Always False — that is what makes this a fingerprinted artifact rather than a compared one."""
+        return False
+
+    def fingerprint(self) -> str:
+        """A stable hash over this file's declared inputs."""
+        digest = hashlib.sha256()
+        for part in self.inputs():
+            # length-prefixed so that concatenation can never make two different input lists collide
+            digest.update(f"{len(part)}:".encode())
+            digest.update(part.encode("utf-8"))
+        return f"sha256:{digest.hexdigest()}"

--- a/scripts/docs_artifacts/_manager.py
+++ b/scripts/docs_artifacts/_manager.py
@@ -7,11 +7,13 @@ which is the point: adding a kind is a `DerivedFile` subclass, never a branch in
 
 from __future__ import annotations
 
+import abc
 import dataclasses
 import difflib
 from typing import TYPE_CHECKING
 
 from ._artifact import read_lf
+from ._manifest import Manifest
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -26,12 +28,28 @@ _REMEDY = "run `make regen-docs`"
 # ==================================================================================================
 #  Findings
 # ==================================================================================================
-class StaleFile:
-    """One committed file whose re-derived content no longer matches what is committed."""
+class Stale(abc.ABC):
+    """One committed file that no longer agrees with what it should be.
+
+    Two subclasses, because the two ways a file goes stale are reported differently: one can show a
+    diff of what changed, the other only knows *that* its inputs moved.
+    """
+
+    def __init__(self, artifact: DerivedFile) -> None:
+        """Bind the finding to the artifact it was found on."""
+        self.artifact = artifact
+
+    @abc.abstractmethod
+    def describe(self) -> str:
+        """How this staleness reads in the report."""
+
+
+class StaleContent(Stale):
+    """A file whose re-derived content differs from what is committed."""
 
     def __init__(self, artifact: DerivedFile, committed: str, intended: str) -> None:
         """Record what was found on disk against what the generator now produces."""
-        self.artifact = artifact
+        super().__init__(artifact)
         self.committed = committed
         self.intended = intended
 
@@ -47,6 +65,25 @@ class StaleFile:
                 tofile=f"{self.artifact.path.name} (regenerated)",
             )
         )
+
+
+class StaleInputs(Stale):
+    """A rendered file whose inputs changed since it was last built.
+
+    There is no content diff to show — the committed bytes cannot be regenerated here, which is the
+    whole reason this artifact is fingerprinted — so the report says what is known instead.
+    """
+
+    def __init__(self, artifact: DerivedFile, recorded: str | None) -> None:
+        """Record the fingerprint that was on file, if any, against the artifact's current one."""
+        super().__init__(artifact)
+        self.recorded = recorded
+
+    def describe(self) -> str:
+        """A one-line statement of what is known, since no diff is available."""
+        if self.recorded is None:
+            return f"{self.artifact.path.name}: never recorded -- no fingerprint exists to check it against"
+        return f"{self.artifact.path.name}: source content or render settings changed since it was built"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -73,43 +110,69 @@ class DocsArtifactManager:
     wants, rather than threading the registry through every call.
     """
 
-    def __init__(self, artifacts: Sequence[DerivedFile]) -> None:
-        """Take ownership of the artifact registry, in the order findings should be reported."""
+    def __init__(self, artifacts: Sequence[DerivedFile], root: Path, manifest_path: Path) -> None:
+        """Take ownership of the artifact registry, in the order findings should be reported.
+
+        Args:
+            artifacts: Every committed file to keep in step.
+            root: Repo root, which the manifest's keys are relative to.
+            manifest_path: Where the fingerprint record is committed.
+        """
         self._artifacts = artifacts
+        self._root = root
+        self._manifest_path = manifest_path
 
     # --------------------------------------------------------------------------
     #  Checking
     # --------------------------------------------------------------------------
-    def check(self) -> list[StaleFile]:
-        """Compare every producible artifact against what is committed.
+    def check(self) -> list[Stale]:
+        """Check every artifact by the strongest means available to it.
 
-        An artifact that cannot be produced on this machine is skipped rather than reported: the
-        only answer available locally would be a false mismatch.
+        An artifact that can be produced here is re-derived and byte-compared. One that cannot
+        falls back to comparing its input fingerprint against the manifest. One that is neither
+        producible nor fingerprinted is skipped, having nothing checkable on this machine.
 
         Returns:
             One entry per stale file, in registry order; empty when everything is current.
         """
-        stale: list[StaleFile] = []
+        manifest = Manifest.load(self._manifest_path)
+        stale: list[Stale] = []
         for artifact in self._artifacts:
-            if not artifact.can_produce_here():
-                continue
-            if (finding := self._compare_content(artifact)) is not None:
+            if artifact.can_produce_here():
+                finding = self._compare_content(artifact)
+            else:
+                finding = self._compare_fingerprint(artifact, manifest)
+            if finding is not None:
                 stale.append(finding)
         return stale
 
-    def stale_report(self, stale: Sequence[StaleFile]) -> str:
+    def stale_report(self, stale: Sequence[Stale]) -> str:
         """The full stderr report for a set of findings: one description each, then the remedy."""
         described = "".join(f"{finding.describe()}\n" for finding in stale)
         return f"{described}stale generated docs content -- {_REMEDY}\n"
 
     @staticmethod
-    def _compare_content(artifact: DerivedFile) -> StaleFile | None:
+    def _compare_content(artifact: DerivedFile) -> StaleContent | None:
         """Re-derive one artifact's content and compare it against what is committed."""
         intended = artifact.intended_content()
         committed = read_lf(artifact.path) if artifact.path.exists() else ""
         if committed == intended:
             return None
-        return StaleFile(artifact=artifact, committed=committed, intended=intended)
+        return StaleContent(artifact=artifact, committed=committed, intended=intended)
+
+    def _compare_fingerprint(self, artifact: DerivedFile, manifest: Manifest) -> StaleInputs | None:
+        """Compare one unproducible artifact's input fingerprint against the recorded one."""
+        fingerprint = artifact.fingerprint()
+        if fingerprint is None:
+            return None  # unproducible and unfingerprinted: nothing checkable here
+        recorded = manifest.recorded(self._manifest_key(artifact))
+        if recorded == fingerprint:
+            return None
+        return StaleInputs(artifact=artifact, recorded=recorded)
+
+    def _manifest_key(self, artifact: DerivedFile) -> str:
+        """An artifact's manifest key: its repo-relative path with forward slashes."""
+        return artifact.path.relative_to(self._root).as_posix()
 
     # --------------------------------------------------------------------------
     #  Regenerating
@@ -128,3 +191,16 @@ class DocsArtifactManager:
                 artifact.path.write_text(content, encoding="utf-8", newline="\n")
                 written.append(artifact.path)
         return RegenerationOutcome(intended=intended, written=written)
+
+    def record_fingerprints(self) -> None:
+        """Record what every fingerprinted artifact was just built from, and commit the manifest.
+
+        Separate from `regenerate` on purpose: the files this describes are built by external
+        tooling *after* their sources are written, so recording early would vouch for images that
+        a partial run never produced.
+        """
+        manifest = Manifest.load(self._manifest_path)
+        for artifact in self._artifacts:
+            if (fingerprint := artifact.fingerprint()) is not None:
+                manifest.record(self._manifest_key(artifact), fingerprint)
+        manifest.write(self._manifest_path)

--- a/scripts/docs_artifacts/_manifest.py
+++ b/scripts/docs_artifacts/_manifest.py
@@ -1,0 +1,57 @@
+"""The committed record of what each non-reproducible artifact was last built from.
+
+A file whose generator cannot run in CI has nothing to compare against there — so instead of its
+bytes, we record a hash of everything it is a function of, and check *that*. The record is plain
+JSON keyed by repo-relative path: no image library, no metadata reader, nothing to parse but the
+manifest itself.
+
+Storing the hash inside the image was considered and dropped: a WebP needs a binary metadata reader
+in CI and the hash would have to survive `magick`'s `-strip`. A sidecar gives the same guarantee,
+works the same way for any format, and stays readable in a diff.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class Manifest:
+    """Recorded input fingerprints, keyed by the artifact's repo-relative path."""
+
+    def __init__(self, entries: dict[str, str]) -> None:
+        self._entries = entries
+
+    # --------------------------------------------------------------------------
+    #  Construction
+    # --------------------------------------------------------------------------
+    @classmethod
+    def load(cls, path: Path) -> Manifest:
+        """Read a manifest, treating an absent file as an empty one.
+
+        An absent manifest makes every fingerprinted artifact report as stale, which is the right
+        answer: nothing has been recorded, so nothing can be vouched for.
+        """
+        if not path.exists():
+            return cls({})
+        return cls(json.loads(path.read_text(encoding="utf-8")))
+
+    def write(self, path: Path) -> None:
+        """Write the manifest sorted and newline-terminated, so its diffs stay reviewable."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        serialized = json.dumps(dict(sorted(self._entries.items())), indent=2) + "\n"
+        path.write_text(serialized, encoding="utf-8", newline="\n")
+
+    # --------------------------------------------------------------------------
+    #  Access
+    # --------------------------------------------------------------------------
+    def recorded(self, key: str) -> str | None:
+        """The fingerprint recorded for `key`, or None when it has never been recorded."""
+        return self._entries.get(key)
+
+    def record(self, key: str, fingerprint: str) -> None:
+        """Set the fingerprint for `key`, replacing any previous value."""
+        self._entries[key] = fingerprint

--- a/scripts/generate_docs_content.py
+++ b/scripts/generate_docs_content.py
@@ -51,9 +51,11 @@ from docs_artifacts import (
     DocsArtifactManager,
     GeneratedFile,
     MarkedBlock,
+    RenderedFile,
     capture_env,
     crop_ansi_line,
     marked_block_files,
+    read_lf,
     strip_ansi,
 )
 
@@ -81,8 +83,19 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SNIPPETS_DIR = Path(__file__).resolve().parent / "docs_snippets"
 CAPTURES_DIR = Path(__file__).resolve().parent / "docs_captures"
 IMAGES_DIR = REPO_ROOT / "docs" / "images"
+# Build metadata rather than documentation, so it sits with the generator that writes it instead of
+# in docs/, where it would ship into the published site.
+IMAGE_MANIFEST = Path(__file__).resolve().parent / "image_manifest.json"
 
 TERMSHOT_PINNED_VERSION = "0.6.1"
+
+# The two render stages' parameters, named once and used both to build an image and to fingerprint
+# it -- so changing a parameter invalidates every image it affects, with nothing to remember to bump.
+TERMSHOT_FLAGS = ["--no-decoration", "--no-shadow"]
+MAGICK_FLAGS = ["-strip", "-resize", "40%", "-quality", "75", "-define", "webp:method=5"]
+# Bump when the *shape* of the pipeline changes -- a stage added, reordered, or swapped for another
+# tool. Parameter values need no bump: they are hashed above.
+RENDER_RECIPE_VERSION = "1"
 
 # Terminal captures are byte-exact ANSI, which is comparable across POSIX platforms but not against
 # Windows: rich decides its color support there through the Windows console API rather than the
@@ -422,33 +435,12 @@ def render_ansi_to_image(ansi_text: str, columns: int, out_path: Path) -> None:
         raw_png = Path(tmp) / "raw.png"
         ansi_file.write_text(ansi_text, encoding="utf-8")
         subprocess.run(
-            [
-                "termshot",
-                "--raw-read",
-                str(ansi_file),
-                "-C",
-                str(columns),
-                "--no-decoration",
-                "--no-shadow",
-                "-f",
-                str(raw_png),
-            ],
+            ["termshot", "--raw-read", str(ansi_file), "-C", str(columns), *TERMSHOT_FLAGS, "-f", str(raw_png)],
             check=True,
             capture_output=True,
         )
         subprocess.run(
-            [
-                "magick",
-                str(raw_png),
-                "-strip",
-                "-resize",
-                "40%",
-                "-quality",
-                "75",
-                "-define",
-                "webp:method=5",
-                str(out_path),
-            ],
+            ["magick", str(raw_png), *MAGICK_FLAGS, str(out_path)],
             check=True,
             capture_output=True,
         )
@@ -503,6 +495,38 @@ def capture_files() -> list[GeneratedFile]:
     ]
 
 
+def screenshot_images() -> list[RenderedFile]:
+    """Each committed screenshot, as an artifact checked against a hash of what it is built from.
+
+    A WebP cannot be byte-compared: `termshot` and `magick` are absent in CI, and their output
+    differs by tool version anyway. So each one declares its inputs instead — which is every
+    argument `render_ansi_to_image` receives plus the tool parameters it applies.
+    """
+    return [
+        RenderedFile(path=IMAGES_DIR / f"{name}.webp", inputs=partial(_screenshot_render_inputs, name))
+        for name in SCREENSHOTS
+    ]
+
+
+def _screenshot_render_inputs(name: str) -> list[str]:
+    """Everything one screenshot's bytes are a function of, in a fixed order.
+
+    The capture is read from disk rather than re-captured: it is fed to `termshot` verbatim, and it
+    is itself byte-checked as a `GeneratedFile`, so a stale capture is caught as a stale capture
+    rather than showing up here as a stale image. Reading it also keeps this computable on a machine
+    that cannot produce captures at all.
+    """
+    ansi = read_lf(CAPTURES_DIR / f"{name}.ansi")
+    return [
+        ansi,
+        str(SCREENSHOTS[name].render_columns(ansi)),
+        TERMSHOT_PINNED_VERSION,
+        *TERMSHOT_FLAGS,
+        *MAGICK_FLAGS,
+        RENDER_RECIPE_VERSION,
+    ]
+
+
 def render_images(captures: dict[Path, str]) -> list[Path]:
     """Render each capture to its committed screenshot.
 
@@ -528,8 +552,8 @@ def render_images(captures: dict[Path, str]) -> list[Path]:
 #  Entry point
 # ==================================================================================================
 def derived_files() -> list[DerivedFile]:
-    """Every committed file this script owns: the docs' marked blocks, then the captures."""
-    return [*marked_block_files(MARKED_BLOCKS), *capture_files()]
+    """Every committed file this script owns: marked blocks, then captures, then screenshots."""
+    return [*marked_block_files(MARKED_BLOCKS), *capture_files(), *screenshot_images()]
 
 
 def main() -> int:
@@ -540,7 +564,7 @@ def main() -> int:
     args = parser.parse_args()
 
     capture_paths = {artifact.path for artifact in capture_files()}
-    manager = DocsArtifactManager(derived_files())
+    manager = DocsArtifactManager(derived_files(), root=REPO_ROOT, manifest_path=IMAGE_MANIFEST)
 
     if args.check:
         if stale := manager.check():
@@ -554,14 +578,20 @@ def main() -> int:
 
     if not CAPTURES_ARE_COMPARABLE:
         print("captures and screenshots skipped on this platform -- see CAPTURES_ARE_COMPARABLE")
-    elif args.text_only:
+        return 0
+    if args.text_only:
         if any(file_path in capture_paths for file_path in regenerated.written):
             # the images are rendered from the captures, so stale-vs-capture is now possible
             print("captures changed -- re-run without --text-only to refresh the screenshots")
-    else:
-        captures = {path: content for path, content in regenerated.intended.items() if path in capture_paths}
-        for image in render_images(captures):
-            print(f"rendered {image.relative_to(REPO_ROOT)}")
+        return 0
+
+    captures = {path: content for path, content in regenerated.intended.items() if path in capture_paths}
+    for image in render_images(captures):
+        print(f"rendered {image.relative_to(REPO_ROOT)}")
+
+    # recorded last, so the manifest describes the images that were just written
+    manager.record_fingerprints()
+    print(f"recorded {IMAGE_MANIFEST.relative_to(REPO_ROOT)}")
     return 0
 
 

--- a/scripts/image_manifest.json
+++ b/scripts/image_manifest.json
@@ -1,0 +1,6 @@
+{
+  "docs/images/show_data.webp": "sha256:6d16cf3d4ca137f57bc0f8b412ce36348935e4db2285e670960a98629edbb1de",
+  "docs/images/verbosity_info.webp": "sha256:d98ab788083a1298507f511a49f21dfe0b84102a226d69cedd8a34e88ad6ceef",
+  "docs/images/verbosity_mixed.webp": "sha256:177a60d0fc72eea4522e315d9bd412cc84e20dd8c7b4c88ff7229dcf46a332df",
+  "docs/images/verbosity_warning.webp": "sha256:d1183fcea2eeb588ae56dac3dd4218ecc0e626d84e0ae74b6bfc17841869bf29"
+}

--- a/tests/docs/test_artifact_freshness.py
+++ b/tests/docs/test_artifact_freshness.py
@@ -1,0 +1,163 @@
+"""The freshness driver must pick the right check per artifact, and catch what each one can catch.
+
+Covers the two halves that have no other guard: the fingerprint's sensitivity to every input it
+declares, and the driver's dispatch between byte-comparison and the manifest fallback.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/ is not on the path for a test run, and the machinery lives in a package under it
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
+from docs_artifacts import (
+    DocsArtifactManager,
+    GeneratedFile,
+    RenderedFile,
+    StaleContent,
+    StaleInputs,
+)
+
+
+def _manager(artifacts, tmp_path):
+    """A manager over `artifacts`, rooted at `tmp_path` with its manifest alongside."""
+    return DocsArtifactManager(artifacts, root=tmp_path, manifest_path=tmp_path / "image_manifest.json")
+
+
+# ==================================================================================================
+#  Fingerprints
+# ==================================================================================================
+def test_fingerprint_is_stable_across_calls():
+    # --- arrange ----------------------------
+    artifact = RenderedFile(path=Path("/repo/out.webp"), inputs=lambda: ["capture", "190", "0.6.1"])
+
+    # --- act --------------------------------
+    first, second = artifact.fingerprint(), artifact.fingerprint()
+
+    # --- assert -----------------------------
+    assert first == second
+    assert first.startswith("sha256:")
+
+
+@pytest.mark.parametrize(
+    ("changed", "reason"),
+    [
+        (["CAPTURE", "190", "0.6.1"], "source content"),
+        (["capture", "191", "0.6.1"], "render geometry"),
+        (["capture", "190", "0.6.2"], "tool version"),
+        (["capture", "190"], "a dropped input"),
+    ],
+)
+def test_fingerprint_changes_when_any_declared_input_changes(changed, reason):
+    # --- arrange ----------------------------
+    baseline = RenderedFile(path=Path("/repo/out.webp"), inputs=lambda: ["capture", "190", "0.6.1"])
+    variant = RenderedFile(path=Path("/repo/out.webp"), inputs=lambda: changed)
+
+    # --- act & assert -----------------------
+    assert baseline.fingerprint() != variant.fingerprint(), f"{reason} did not change the fingerprint"
+
+
+def test_fingerprint_does_not_collide_on_regrouped_inputs():
+    """Length-prefixing is what stops `["ab", "c"]` and `["a", "bc"]` hashing alike."""
+    # --- arrange ----------------------------
+    left = RenderedFile(path=Path("/repo/out.webp"), inputs=lambda: ["ab", "c"])
+    right = RenderedFile(path=Path("/repo/out.webp"), inputs=lambda: ["a", "bc"])
+
+    # --- act & assert -----------------------
+    assert left.fingerprint() != right.fingerprint()
+
+
+# ==================================================================================================
+#  Manifest
+# ==================================================================================================
+def test_recorded_manifest_is_sorted_and_keyed_by_relative_path(tmp_path):
+    # --- arrange ----------------------------
+    artifacts = [
+        RenderedFile(path=tmp_path / "images" / "b.webp", inputs=lambda: ["b"]),
+        RenderedFile(path=tmp_path / "images" / "a.webp", inputs=lambda: ["a"]),
+    ]
+
+    # --- act --------------------------------
+    _manager(artifacts, tmp_path).record_fingerprints()
+    written = (tmp_path / "image_manifest.json").read_text(encoding="utf-8")
+
+    # --- assert -----------------------------
+    assert '"images/a.webp"' in written
+    # sorted on write, so a re-record never reshuffles the committed file
+    assert written.index('"images/a.webp"') < written.index('"images/b.webp"')
+
+
+def test_recorded_fingerprints_survive_a_reload(tmp_path):
+    # --- arrange ----------------------------
+    artifacts = [RenderedFile(path=tmp_path / "out.webp", inputs=lambda: ["inputs"])]
+    _manager(artifacts, tmp_path).record_fingerprints()
+
+    # --- act & assert -----------------------
+    assert _manager(artifacts, tmp_path).check() == []
+
+
+# ==================================================================================================
+#  Driver dispatch
+# ==================================================================================================
+def test_producible_artifact_is_byte_compared(tmp_path):
+    # --- arrange ----------------------------
+    target = tmp_path / "block.md"
+    target.write_text("stale", encoding="utf-8")
+    artifact = GeneratedFile(path=target, produce=lambda: "fresh")
+
+    # --- act --------------------------------
+    stale = _manager([artifact], tmp_path).check()
+
+    # --- assert -----------------------------
+    assert len(stale) == 1
+    assert isinstance(stale[0], StaleContent)
+    assert "fresh" in stale[0].describe()
+
+
+def test_unproducible_artifact_without_fingerprint_is_skipped(tmp_path):
+    """A capture on a platform that cannot produce it has nothing honest to report."""
+    # --- arrange ----------------------------
+    target = tmp_path / "capture.ansi"
+    target.write_text("whatever", encoding="utf-8")
+    artifact = GeneratedFile(path=target, produce=lambda: "different", producible_here=False)
+
+    # --- act & assert -----------------------
+    assert _manager([artifact], tmp_path).check() == []
+
+
+def test_rendered_artifact_is_checked_against_the_manifest(tmp_path):
+    # --- arrange ----------------------------
+    artifact = RenderedFile(path=tmp_path / "out.webp", inputs=lambda: ["inputs"])
+    _manager([artifact], tmp_path).record_fingerprints()
+
+    # --- act --------------------------------
+    current = _manager([artifact], tmp_path).check()
+    drifted = _manager([RenderedFile(path=tmp_path / "out.webp", inputs=lambda: ["other"])], tmp_path).check()
+
+    # --- assert -----------------------------
+    assert current == []
+    assert len(drifted) == 1
+    assert isinstance(drifted[0], StaleInputs)
+
+
+def test_unrecorded_rendered_artifact_reports_as_never_recorded(tmp_path):
+    # --- arrange ----------------------------
+    artifact = RenderedFile(path=tmp_path / "out.webp", inputs=lambda: ["inputs"])
+
+    # --- act --------------------------------
+    stale = _manager([artifact], tmp_path).check()
+
+    # --- assert -----------------------------
+    assert len(stale) == 1
+    assert "never recorded" in stale[0].describe()
+
+
+def test_rendered_artifact_never_asks_for_content(tmp_path):
+    """Its bytes are unreproducible here, so requesting them is a bug rather than a fallback."""
+    # --- arrange ----------------------------
+    artifact = RenderedFile(path=tmp_path / "out.webp", inputs=lambda: ["inputs"])
+
+    # --- act & assert -----------------------
+    with pytest.raises(NotImplementedError, match="fingerprint"):
+        artifact.intended_content()


### PR DESCRIPTION
**TL;DR**: Committed screenshots gain the freshness check they never had — a hash of everything they are built from, recorded in a sidecar manifest and verified in CI without any render tooling.

## Description

### Problem addressed

**A committed screenshot could go stale silently, and once did.** A footer added to the `show-data` output landed in the drift-tested capture, while the WebP rendered from that capture kept the old text. Nothing caught it.

The images are excluded from the byte-for-byte drift test for a real reason: **WebP encoding is not reproducible** across platforms and tool versions, and the render tools are absent in CI by design. So there is nothing to compare rendered bytes against — which left the images as the one category of committed generated content with no check at all.

### Implementation

Each screenshot declares **what its bytes are a function of**, and a hash of that is recorded in a committed manifest. CI recomputes the hash from the sources and compares; a mismatch means the image was built from something other than what is committed now. This reads plain JSON and needs no image library, no metadata reader, and no renderer.

The declared inputs are the capture, the resolved render width, and both tools' parameters. Those parameters were literals inside the render function and are now **named constants used both to build an image and to hash it** — so changing a quality setting or a flag invalidates every image it affects, with nothing to remember to bump. Only a change to the pipeline's *shape* needs the explicit recipe version.

The capture is read from the committed file rather than re-captured. It is fed to the renderer verbatim, and it is byte-checked in its own right, so **a stale capture is reported as a stale capture** instead of surfacing here as a mysteriously stale image.

## Attention points

- **CI now goes red when an image's inputs change without a regenerate**, which is the intended loud failure. The cost is real: a capture-affecting or parameter-affecting change must be followed by `make regen-docs` on a machine with the render tools before CI passes.
- **The manifest lives beside the generator, not beside the images.** It is build metadata; putting it under `docs/` would ship it into the published site. This departs from the "next to what it describes" instinct, so it is worth an explicit look.
- **Hashing inputs is strictly weaker than comparing bytes**, and is used only where bytes cannot be compared. It cannot see a change to the render function's structure — hence the recipe version, the one value still bumped by hand, and the only manual step in the mechanism.
- **The fingerprint is length-prefixed per input.** Without it, regrouping the same characters across inputs would hash identically; there is a test pinning exactly that.

## Tests / Spikes

- **SPIKE:** confirmed the committed capture is fed to `termshot` verbatim — the crop happens while producing the capture, not between the file and the renderer — so hashing the committed file hashes the true render input, with no transform unaccounted for.
- **TEST:** changed a render parameter with every capture untouched; all four screenshots correctly reported as stale, and the exit code flipped to 1.
- **TEST:** removed one manifest entry; that image alone reported as never recorded.
- **TEST:** a full regenerate reproduced all four images byte-identically, so nothing committed changes here beyond the new manifest.
- 13 unit tests added, covering fingerprint stability and sensitivity to each declared input, the manifest round-trip, and the driver's dispatch between byte-comparison and the manifest fallback.

## Changelog entry

None: CI and tooling change with no user-facing effect.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
