### PR TITLE
chore: return every CodeQL trigger to one workflow file

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,19 +3,24 @@ name: CodeQL
 # Static analysis (SAST) for the Python package. Complements zizmor/actionlint
 # (which lint the workflows, not the package code).
 #
-# On pull requests this runs as a job of the PR pipeline rather than off its own
-# `pull_request` trigger, so it inherits the pipeline's lack of a base-branch
-# filter: a PR based on another feature branch is scanned while it is being
-# reviewed. The `CI gate` aggregation waits for it, so a merge can no longer
-# outrun its own scan — but the gate is not what acts on findings. This step
-# always exits 0; the check run that reports alerts introduced by a PR is
-# code scanning's own, which branch protection requires separately.
+# Every trigger lives here, and that is load-bearing rather than tidy. Code
+# scanning identifies a configuration by analysis key — `<workflow file>:<job>` —
+# and compares a pull request against the configurations recorded on its base
+# branch. Scanning pull requests from one workflow file and `main` from another
+# therefore produces two keys that never match, and every PR reports that the
+# alerts it introduced could not be determined. One file, one key, one comparison.
 #
-# The `main`-push and weekly triggers below stay standalone: they cover the
-# merged tip and new query packs, neither of which is review-time.
+# The `pull_request` trigger deliberately carries no base-branch filter, matching
+# the PR pipeline's own stance: a PR based on another feature branch is scanned
+# while it is being reviewed, which is the window that matters.
+#
+# This step exits 0 whether or not it finds anything, so it gates nothing by
+# itself. What acts on findings is code scanning's own check run, which branch
+# protection requires — and requiring it is also what makes a merge wait for the
+# scan, since a required check has to report before the merge button unlocks.
 
 on:
-  workflow_call:
+  pull_request:
   push:
     branches: [main]
   schedule:
@@ -25,11 +30,7 @@ permissions:
   contents: read
 
 concurrency:
-  # `github.workflow` resolves to the *caller's* name when this runs as a called
-  # workflow, so the literal prefix is what keeps the group distinct from the
-  # caller's own — sharing one would have this run cancel the pipeline waiting
-  # on it.
-  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -51,11 +52,8 @@ jobs:
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
-          # Code scanning matches a pull request's analysis against the base
-          # branch's by category, which otherwise defaults to the analysis key
-          # `<workflow file>:<job>`. A called workflow runs under the *caller's*
-          # file, so leaving it implicit gives the same scan two identities and
-          # code scanning reports that it cannot determine which alerts the PR
-          # introduced. Pinning it to a literal makes the identity independent
-          # of how the scan was invoked.
+          # A label, not a mechanism: it names the configuration in the code
+          # scanning UI instead of leaving it as a workflow path. Explicitly not
+          # what makes a pull request comparable to its base branch — the
+          # analysis key does that, and no category overrides it (see the header).
           category: python

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -91,17 +91,6 @@ jobs:
     needs: [preflight]
     uses: ./.github/workflows/_package_check.yml
 
-  # Static-analysis gate. Permissions are declared here because a called
-  # workflow cannot grant itself more than its caller has, and this file's
-  # default is `contents: read`.
-  codeql:
-    needs: [preflight]
-    permissions:
-      security-events: write  # upload analysis results to code scanning
-      contents: read          # checkout
-      actions: read           # read workflow run metadata (CodeQL requirement)
-    uses: ./.github/workflows/codeql.yml
-
   # Synchronous dependency-CVE gate: audits the locked runtime dependencies
   # against the advisory DB at PR time — the blocking complement to the async,
   # repo-level Dependabot alerts. Hard-fails on any advisory; accepted ones go
@@ -136,7 +125,7 @@ jobs:
     # `always()` is load-bearing — without it the gate is skipped when an
     # upstream job fails, and GitHub treats a skipped required check as passing.
     if: always()
-    needs: [preflight, pre-commit, test, package, codeql, pip-audit]
+    needs: [preflight, pre-commit, test, package, pip-audit]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job did not succeed


### PR DESCRIPTION
**TL;DR**: Scanning `main` and pull requests from two different workflow files gave code scanning two identities for one scan, so no PR could report which alerts it introduced. One file fixes it.

## Description

### Problem addressed

Code scanning identifies a configuration by **analysis key** — workflow file path plus job name — and compares a pull request against the configurations recorded on its base branch. Since #278, `main` was scanned by `codeql.yml` while pull requests were scanned through the PR pipeline, producing `codeql.yml:analyze` on one side and `pull_request.yml:analyze` on the other.

Those never match. Every `main`-based PR therefore reported **"cannot determine the alerts introduced by this pull request"** and returned a neutral check — strictly less review-time signal than before #278, which is the opposite of what it set out to do.

### Implementation

The `pull_request` trigger comes back to `codeql.yml`, and the `workflow_call` plumbing plus the pipeline job go away. One file owns push, schedule and pull requests, so there is one analysis key and the comparison works.

**Removing the base-branch filter was always the part that fixed stacked PRs** — that survives here. The pipeline-job machinery around it contributed nothing to that fix, so reverting it costs no coverage.

**The `category` pin stays, demoted to a label.** It names the configuration in the UI instead of a workflow path. It does *not* make a PR comparable to its base, and its comment now says so — that misreading is what cost a round trip.

**Blocking moves to branch protection.** Requiring code scanning's own check is what turns a finding red, and it is also what makes a merge wait for the scan, since a required check has to report first. The aggregate gate could do neither: the analyze step exits 0 regardless of findings.

## Attention points

- **Merges can outrun the scan until the required check is added.** That is the one interval where this is weaker than what it replaces, and it closes as soon as branch protection is updated.
- **The branch-protection change is deliberately not in this PR.** It should follow a `main`-based PR observed reporting a real comparison, since requiring a check that cannot report gates nothing.
- **A stacked PR is not evidence this works.** Its base branch has no recorded configuration, so nothing can be reported missing and it passes vacuously. Only a `main`-based PR proves it.
- **This is a partial revert of #278**, keeping the unfiltered trigger and dropping the rest. Worth reading as one change with that PR rather than on its own.

## Tests / Spikes

- **SPIKE:** compared analysis keys and categories across `main` and an open PR through the code-scanning API. Categories matched (`python` both sides) while keys differed, which isolated the key as the identity that governs the comparison.
- **TEST:** deleting the retired configuration's recorded analyses on `main` changed nothing, ruling out stale records as the cause before this fix was chosen.
- **TEST:** `make lint` passes, including `actionlint`, `zizmor`, and the workflow schema validator.
- No unit tests added — CI configuration only. Its real verification is this PR's own code-scanning check reporting a comparison rather than a neutral result.

## Changelog entry

None: CI-only change with no user-facing effect.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
