### PR TITLE
docs: give the flop-cost model a picture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- the README and docs now show a bar chart of the built-in flop weights, comparing arm64 and x86 against the all-architecture consensus
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Flop weights are computed using a highly curated dataset spanning a wide range o
 <!-- END generated: source-counts -->
 - covering x86 (Intel, AMD) and ARM (Apple, AWS, Azure) architectures
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="images/flop_weights_dark.svg">
+  <img alt="Built-in flop weights, relative to ADD, per architecture" src="images/flop_weights_light.svg">
+</picture>
+
 **Full documentation: [counted-float.readthedocs.io](https://counted-float.readthedocs.io/)**
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ This Python package provides functionality for...
 - **counting floating point operations** (FLOPs) of numerical algorithms implemented in plain Python, optionally weighted by their relative cost of execution
 - **running benchmarks** to estimate the relative cost of executing various floating-point operations (requires `numba` optional dependency for achieving accurate results)
 
-The target application area is evaluation of research prototypes of numerical algorithms where (weighted) flop counting can be
-useful for estimating total computational cost, in cases where benchmarking a compiled version (C, Rust, ...) is not
-feasible or desirable.
-
 Flop weights are computed using a highly curated dataset spanning a wide range of modern CPUs:
 
 <!-- BEGIN generated: source-counts -->
@@ -30,10 +26,16 @@ Flop weights are computed using a highly curated dataset spanning a wide range o
 <!-- END generated: source-counts -->
 - covering x86 (Intel, AMD) and ARM (Apple, AWS, Azure) architectures
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="docs/images/flop_weights_dark.svg">
-  <img alt="Built-in flop weights, relative to ADD, per architecture" src="docs/images/flop_weights_light.svg">
-</picture>
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/images/flop_weights_dark.svg">
+    <img alt="Built-in flop weights, relative to ADD, per architecture" src="docs/images/flop_weights_light.svg">
+  </picture>
+</div>
+
+The target application area is evaluation of research prototypes of numerical algorithms where (weighted) flop counting can be
+useful for estimating total computational cost, in cases where benchmarking a compiled version (C, Rust, ...) is not
+feasible or desirable.
 
 **Full documentation: [counted-float.readthedocs.io](https://counted-float.readthedocs.io/)**
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Flop weights are computed using a highly curated dataset spanning a wide range o
 - covering x86 (Intel, AMD) and ARM (Apple, AWS, Azure) architectures
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="images/flop_weights_dark.svg">
-  <img alt="Built-in flop weights, relative to ADD, per architecture" src="images/flop_weights_light.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="docs/images/flop_weights_dark.svg">
+  <img alt="Built-in flop weights, relative to ADD, per architecture" src="docs/images/flop_weights_light.svg">
 </picture>
 
 **Full documentation: [counted-float.readthedocs.io](https://counted-float.readthedocs.io/)**

--- a/docs/flop_weights.md
+++ b/docs/flop_weights.md
@@ -10,6 +10,13 @@ See [Methodology](analysis_methodology.md) for the rationale behind the choice
 of data sources and methodology, and
 [CPU architecture scope](cpu_architectures_scope.md) for the CPUs covered.
 
+The cheapest and priciest operations, with the two architectures shown against
+the all-architecture consensus. Note the log scale: the range spans more than
+two decades, and the two ISAs disagree most at the cheap end.
+
+![Built-in flop weights, relative to ADD, per architecture](images/flop_weights_light.svg#only-light)
+![Built-in flop weights, relative to ADD, per architecture](images/flop_weights_dark_docs.svg#only-dark)
+
 <!-- BEGIN generated: flop-weights-active -->
 ```python
 >>> from counted_float.config import get_active_flop_weights

--- a/docs/images/flop_weights_dark.svg
+++ b/docs/images/flop_weights_dark.svg
@@ -1,129 +1,130 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840.000 476" width="840.000" height="476" font-family="system-ui, -apple-system, sans-serif">
-<rect x="0" y="0" width="840.000" height="476" fill="#0D1117"/>
-<text x="46" y="26" font-size="15" font-weight="600" fill="#E6EDF3">Built-in flop weights</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840.000 470" width="840.000" height="470" font-family="system-ui, -apple-system, sans-serif">
+<rect x="0" y="0" width="840.000" height="470" fill="#0D1117"/>
+<text x="46" y="26" font-size="15" font-weight="600" fill="#E6EDF3">Built-in flop weights<tspan font-size="9" font-weight="400" dx="2" dy="-6" fill="#8B949E">(1)</tspan></text>
 <text x="46" y="44" font-size="11" fill="#B1BAC4">relative to ADD = 1, log scale</text>
-<line x1="46" y1="352.622" x2="830.000" y2="352.622" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="355.622" font-size="8" fill="#8B949E" text-anchor="end">0.2</text>
-<line x1="46" y1="333.766" x2="830.000" y2="333.766" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="320.388" x2="830.000" y2="320.388" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="310.011" x2="830.000" y2="310.011" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="313.011" font-size="8" fill="#8B949E" text-anchor="end">0.5</text>
-<line x1="46" y1="301.533" x2="830.000" y2="301.533" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="294.364" x2="830.000" y2="294.364" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="288.155" x2="830.000" y2="288.155" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="282.678" x2="830.000" y2="282.678" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="245.544" x2="830.000" y2="245.544" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="248.544" font-size="8" fill="#8B949E" text-anchor="end">2</text>
-<line x1="46" y1="226.689" x2="830.000" y2="226.689" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="213.311" x2="830.000" y2="213.311" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="202.934" x2="830.000" y2="202.934" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="205.934" font-size="8" fill="#8B949E" text-anchor="end">5</text>
-<line x1="46" y1="194.456" x2="830.000" y2="194.456" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="187.287" x2="830.000" y2="187.287" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="181.077" x2="830.000" y2="181.077" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="175.600" x2="830.000" y2="175.600" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="138.467" x2="830.000" y2="138.467" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="141.467" font-size="8" fill="#8B949E" text-anchor="end">20</text>
-<line x1="46" y1="119.612" x2="830.000" y2="119.612" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="106.234" x2="830.000" y2="106.234" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="95.857" x2="830.000" y2="95.857" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="98.857" font-size="8" fill="#8B949E" text-anchor="end">50</text>
-<line x1="46" y1="87.378" x2="830.000" y2="87.378" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="80.210" x2="830.000" y2="80.210" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="74.000" x2="830.000" y2="74.000" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="277.778" x2="830.000" y2="277.778" stroke="#636C76" stroke-width="1"/>
-<text x="38" y="281.278" font-size="10" fill="#B1BAC4" text-anchor="end">1</text>
-<line x1="46" y1="170.701" x2="830.000" y2="170.701" stroke="#636C76" stroke-width="1"/>
-<text x="38" y="174.201" font-size="10" fill="#B1BAC4" text-anchor="end">10</text>
+<line x1="46" y1="352.164" x2="830.000" y2="352.164" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="355.164" font-size="8" fill="#8B949E" text-anchor="end">0.2</text>
+<line x1="46" y1="332.663" x2="830.000" y2="332.663" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="318.826" x2="830.000" y2="318.826" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="308.094" x2="830.000" y2="308.094" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="311.094" font-size="8" fill="#8B949E" text-anchor="end">0.5</text>
+<line x1="46" y1="299.325" x2="830.000" y2="299.325" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="291.911" x2="830.000" y2="291.911" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="285.489" x2="830.000" y2="285.489" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="279.824" x2="830.000" y2="279.824" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="241.419" x2="830.000" y2="241.419" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="244.419" font-size="8" fill="#8B949E" text-anchor="end">2</text>
+<line x1="46" y1="221.918" x2="830.000" y2="221.918" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="208.082" x2="830.000" y2="208.082" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="197.350" x2="830.000" y2="197.350" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="200.350" font-size="8" fill="#8B949E" text-anchor="end">5</text>
+<line x1="46" y1="188.581" x2="830.000" y2="188.581" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="181.167" x2="830.000" y2="181.167" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="174.744" x2="830.000" y2="174.744" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="169.080" x2="830.000" y2="169.080" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="130.675" x2="830.000" y2="130.675" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="133.675" font-size="8" fill="#8B949E" text-anchor="end">20</text>
+<line x1="46" y1="111.174" x2="830.000" y2="111.174" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="97.337" x2="830.000" y2="97.337" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="86.605" x2="830.000" y2="86.605" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="89.605" font-size="8" fill="#8B949E" text-anchor="end">50</text>
+<line x1="46" y1="77.836" x2="830.000" y2="77.836" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="70.422" x2="830.000" y2="70.422" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="64.000" x2="830.000" y2="64.000" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="274.757" x2="830.000" y2="274.757" stroke="#636C76" stroke-width="1"/>
+<text x="38" y="278.257" font-size="10" fill="#B1BAC4" text-anchor="end">1</text>
+<line x1="46" y1="164.012" x2="830.000" y2="164.012" stroke="#636C76" stroke-width="1"/>
+<text x="38" y="167.512" font-size="10" fill="#B1BAC4" text-anchor="end">10</text>
 <line x1="46.000" y1="366" x2="666.000" y2="366" stroke="#6E7681" stroke-width="1"/>
 <line x1="714.000" y1="366" x2="830.000" y2="366" stroke="#6E7681" stroke-width="1"/>
 <line x1="666.000" y1="366" x2="714.000" y2="366" stroke="#6E7681" stroke-width="1" stroke-dasharray="4 4"/>
 <text x="690.000" y="382" font-size="8.5" fill="#8B949E" text-anchor="middle">28 more</text>
-<rect x="50.500" y="316.191" width="9" height="49.809" fill="#707070"/>
-<rect x="59.500" y="287.329" width="9" height="78.671" fill="#FBB85C"/>
-<rect x="68.500" y="345.053" width="9" height="20.947" fill="#6BA1F2"/>
+<rect x="50.500" y="314.485" width="9" height="51.515" fill="#707070"/>
+<rect x="59.500" y="284.635" width="9" height="81.365" fill="#FBB85C"/>
+<rect x="68.500" y="344.336" width="9" height="21.664" fill="#6BA1F2"/>
 <text x="64.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 64.000 379)">MINUS</text>
-<rect x="86.500" y="294.287" width="9" height="71.713" fill="#707070"/>
-<rect x="95.500" y="276.987" width="9" height="89.013" fill="#FBB85C"/>
-<rect x="104.500" y="311.587" width="9" height="54.413" fill="#6BA1F2"/>
+<rect x="86.500" y="291.831" width="9" height="74.169" fill="#707070"/>
+<rect x="95.500" y="273.939" width="9" height="92.061" fill="#FBB85C"/>
+<rect x="104.500" y="309.723" width="9" height="56.277" fill="#6BA1F2"/>
 <text x="100.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 100.000 379)">ABS</text>
-<rect x="122.500" y="278.860" width="9" height="87.140" fill="#707070"/>
-<rect x="131.500" y="299.578" width="9" height="66.422" fill="#FBB85C"/>
-<rect x="140.500" y="258.142" width="9" height="107.858" fill="#6BA1F2"/>
+<rect x="122.500" y="275.876" width="9" height="90.124" fill="#707070"/>
+<rect x="131.500" y="297.303" width="9" height="68.697" fill="#FBB85C"/>
+<rect x="140.500" y="254.449" width="9" height="111.551" fill="#6BA1F2"/>
 <text x="136.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 136.000 379)">COMP</text>
-<rect x="158.500" y="277.778" width="9" height="88.222" fill="#707070"/>
-<rect x="167.500" y="277.778" width="9" height="88.222" fill="#FBB85C"/>
-<rect x="176.500" y="277.778" width="9" height="88.222" fill="#6BA1F2"/>
+<rect x="158.500" y="274.757" width="9" height="91.243" fill="#707070"/>
+<rect x="167.500" y="274.757" width="9" height="91.243" fill="#FBB85C"/>
+<rect x="176.500" y="274.757" width="9" height="91.243" fill="#6BA1F2"/>
 <text x="172.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 172.000 379)">ADD</text>
-<rect x="194.500" y="277.743" width="9" height="88.257" fill="#707070"/>
-<rect x="203.500" y="277.695" width="9" height="88.305" fill="#FBB85C"/>
-<rect x="212.500" y="277.791" width="9" height="88.209" fill="#6BA1F2"/>
+<rect x="194.500" y="274.721" width="9" height="91.279" fill="#707070"/>
+<rect x="203.500" y="274.671" width="9" height="91.329" fill="#FBB85C"/>
+<rect x="212.500" y="274.770" width="9" height="91.230" fill="#6BA1F2"/>
 <text x="208.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 208.000 379)">SUB</text>
-<rect x="230.500" y="270.875" width="9" height="95.125" fill="#707070"/>
-<rect x="239.500" y="253.821" width="9" height="112.179" fill="#FBB85C"/>
-<rect x="248.500" y="287.928" width="9" height="78.072" fill="#6BA1F2"/>
+<rect x="230.500" y="267.617" width="9" height="98.383" fill="#707070"/>
+<rect x="239.500" y="249.980" width="9" height="116.020" fill="#FBB85C"/>
+<rect x="248.500" y="285.255" width="9" height="80.745" fill="#6BA1F2"/>
 <text x="244.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 244.000 379)">COPYSIGN</text>
-<rect x="266.500" y="262.099" width="9" height="103.901" fill="#707070"/>
-<rect x="275.500" y="259.244" width="9" height="106.756" fill="#FBB85C"/>
-<rect x="284.500" y="264.953" width="9" height="101.047" fill="#6BA1F2"/>
+<rect x="266.500" y="258.541" width="9" height="107.459" fill="#707070"/>
+<rect x="275.500" y="255.588" width="9" height="110.412" fill="#FBB85C"/>
+<rect x="284.500" y="261.493" width="9" height="104.507" fill="#6BA1F2"/>
 <text x="280.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 280.000 379)">MUL</text>
-<rect x="302.500" y="253.095" width="9" height="112.905" fill="#707070"/>
-<rect x="311.500" y="248.375" width="9" height="117.625" fill="#FBB85C"/>
-<rect x="320.500" y="257.815" width="9" height="108.185" fill="#6BA1F2"/>
+<rect x="302.500" y="249.228" width="9" height="116.772" fill="#707070"/>
+<rect x="311.500" y="244.347" width="9" height="121.653" fill="#FBB85C"/>
+<rect x="320.500" y="254.110" width="9" height="111.890" fill="#6BA1F2"/>
 <text x="316.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 316.000 379)">FMA</text>
-<rect x="338.500" y="250.489" width="9" height="115.511" fill="#707070"/>
-<rect x="347.500" y="255.454" width="9" height="110.546" fill="#FBB85C"/>
-<rect x="356.500" y="245.523" width="9" height="120.477" fill="#6BA1F2"/>
+<rect x="338.500" y="246.533" width="9" height="119.467" fill="#707070"/>
+<rect x="347.500" y="251.668" width="9" height="114.332" fill="#FBB85C"/>
+<rect x="356.500" y="241.397" width="9" height="124.603" fill="#6BA1F2"/>
 <text x="352.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 352.000 379)">RND</text>
-<rect x="374.500" y="247.463" width="9" height="118.537" fill="#707070"/>
-<rect x="383.500" y="260.269" width="9" height="105.731" fill="#FBB85C"/>
-<rect x="392.500" y="234.658" width="9" height="131.342" fill="#6BA1F2"/>
+<rect x="374.500" y="243.404" width="9" height="122.596" fill="#707070"/>
+<rect x="383.500" y="256.648" width="9" height="109.352" fill="#FBB85C"/>
+<rect x="392.500" y="230.160" width="9" height="135.840" fill="#6BA1F2"/>
 <text x="388.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 388.000 379)">F2I</text>
-<rect x="410.500" y="247.290" width="9" height="118.710" fill="#707070"/>
-<rect x="419.500" y="257.126" width="9" height="108.874" fill="#FBB85C"/>
-<rect x="428.500" y="237.454" width="9" height="128.546" fill="#6BA1F2"/>
+<rect x="410.500" y="243.225" width="9" height="122.775" fill="#707070"/>
+<rect x="419.500" y="253.398" width="9" height="112.602" fill="#FBB85C"/>
+<rect x="428.500" y="233.052" width="9" height="132.948" fill="#6BA1F2"/>
 <text x="424.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 424.000 379)">I2F</text>
-<rect x="446.500" y="234.411" width="9" height="131.589" fill="#707070"/>
-<rect x="455.500" y="225.305" width="9" height="140.695" fill="#FBB85C"/>
-<rect x="464.500" y="243.516" width="9" height="122.484" fill="#6BA1F2"/>
+<rect x="446.500" y="229.904" width="9" height="136.096" fill="#707070"/>
+<rect x="455.500" y="220.487" width="9" height="145.513" fill="#FBB85C"/>
+<rect x="464.500" y="239.321" width="9" height="126.679" fill="#6BA1F2"/>
 <text x="460.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 460.000 379)">HYPOT_XARG</text>
-<rect x="482.500" y="234.365" width="9" height="131.635" fill="#707070"/>
-<rect x="491.500" y="226.404" width="9" height="139.596" fill="#FBB85C"/>
-<rect x="500.500" y="242.325" width="9" height="123.675" fill="#6BA1F2"/>
+<rect x="482.500" y="229.857" width="9" height="136.143" fill="#707070"/>
+<rect x="491.500" y="221.623" width="9" height="144.377" fill="#FBB85C"/>
+<rect x="500.500" y="238.090" width="9" height="127.910" fill="#6BA1F2"/>
 <text x="496.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 496.000 379)">DIST_XARG</text>
-<rect x="518.500" y="208.951" width="9" height="157.049" fill="#707070"/>
-<rect x="527.500" y="210.778" width="9" height="155.222" fill="#FBB85C"/>
-<rect x="536.500" y="207.123" width="9" height="158.877" fill="#6BA1F2"/>
+<rect x="518.500" y="203.572" width="9" height="162.428" fill="#707070"/>
+<rect x="527.500" y="205.462" width="9" height="160.538" fill="#FBB85C"/>
+<rect x="536.500" y="201.682" width="9" height="164.318" fill="#6BA1F2"/>
 <text x="532.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 532.000 379)">SUMPROD_XELEM</text>
-<rect x="554.500" y="198.037" width="9" height="167.963" fill="#707070"/>
-<rect x="563.500" y="193.180" width="9" height="172.820" fill="#FBB85C"/>
-<rect x="572.500" y="202.895" width="9" height="163.105" fill="#6BA1F2"/>
+<rect x="554.500" y="192.285" width="9" height="173.715" fill="#707070"/>
+<rect x="563.500" y="187.261" width="9" height="178.739" fill="#FBB85C"/>
+<rect x="572.500" y="197.309" width="9" height="168.691" fill="#6BA1F2"/>
 <text x="568.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 568.000 379)">DIV</text>
-<rect x="590.500" y="193.852" width="9" height="172.148" fill="#707070"/>
-<rect x="599.500" y="182.706" width="9" height="183.294" fill="#FBB85C"/>
-<rect x="608.500" y="204.998" width="9" height="161.002" fill="#6BA1F2"/>
+<rect x="590.500" y="187.956" width="9" height="178.044" fill="#707070"/>
+<rect x="599.500" y="176.429" width="9" height="189.571" fill="#FBB85C"/>
+<rect x="608.500" y="199.484" width="9" height="166.516" fill="#6BA1F2"/>
 <text x="604.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 604.000 379)">FMOD</text>
-<rect x="626.500" y="186.624" width="9" height="179.376" fill="#707070"/>
-<rect x="635.500" y="185.463" width="9" height="180.537" fill="#FBB85C"/>
-<rect x="644.500" y="187.785" width="9" height="178.215" fill="#6BA1F2"/>
+<rect x="626.500" y="180.481" width="9" height="185.519" fill="#707070"/>
+<rect x="635.500" y="179.280" width="9" height="186.720" fill="#FBB85C"/>
+<rect x="644.500" y="181.682" width="9" height="184.318" fill="#6BA1F2"/>
 <text x="640.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 640.000 379)">SQRT</text>
-<rect x="726.500" y="98.259" width="9" height="267.741" fill="#707070"/>
-<rect x="735.500" y="100.744" width="9" height="265.256" fill="#FBB85C"/>
-<rect x="744.500" y="95.775" width="9" height="270.225" fill="#6BA1F2"/>
+<rect x="726.500" y="89.090" width="9" height="276.910" fill="#707070"/>
+<rect x="735.500" y="91.660" width="9" height="274.340" fill="#FBB85C"/>
+<rect x="744.500" y="86.520" width="9" height="279.480" fill="#6BA1F2"/>
 <text x="740.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 740.000 379)">SINH</text>
-<rect x="762.500" y="97.867" width="9" height="268.133" fill="#707070"/>
-<rect x="771.500" y="98.221" width="9" height="267.779" fill="#FBB85C"/>
-<rect x="780.500" y="97.513" width="9" height="268.487" fill="#6BA1F2"/>
+<rect x="762.500" y="88.684" width="9" height="277.316" fill="#707070"/>
+<rect x="771.500" y="89.050" width="9" height="276.950" fill="#FBB85C"/>
+<rect x="780.500" y="88.318" width="9" height="277.682" fill="#6BA1F2"/>
 <text x="776.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 776.000 379)">TANH</text>
-<rect x="798.500" y="92.184" width="9" height="273.816" fill="#707070"/>
-<rect x="807.500" y="91.503" width="9" height="274.497" fill="#FBB85C"/>
-<rect x="816.500" y="92.864" width="9" height="273.136" fill="#6BA1F2"/>
+<rect x="798.500" y="82.807" width="9" height="283.193" fill="#707070"/>
+<rect x="807.500" y="82.103" width="9" height="283.897" fill="#FBB85C"/>
+<rect x="816.500" y="83.510" width="9" height="282.490" fill="#6BA1F2"/>
 <text x="812.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 812.000 379)">GAMMA</text>
-<rect x="52.000" y="76.000" width="118.950" height="54.000" rx="4" fill="#242C37" fill-opacity="0.8"/>
-<rect x="58" y="82.000" width="10" height="10" rx="1" fill="#707070"/>
-<text x="74.000" y="90.000" font-size="11" fill="#B1BAC4">all architectures</text>
-<rect x="58" y="98.000" width="10" height="10" rx="1" fill="#FBB85C"/>
-<text x="74.000" y="106.000" font-size="11" fill="#B1BAC4">arm64</text>
-<rect x="58" y="114.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
-<text x="74.000" y="122.000" font-size="11" fill="#B1BAC4">x86</text>
+<rect x="52.000" y="66.000" width="118.950" height="54.000" rx="4" fill="#242C37" fill-opacity="0.8"/>
+<rect x="58" y="72.000" width="10" height="10" rx="1" fill="#707070"/>
+<text x="74.000" y="80.000" font-size="11" fill="#B1BAC4">all architectures</text>
+<rect x="58" y="88.000" width="10" height="10" rx="1" fill="#FBB85C"/>
+<text x="74.000" y="96.000" font-size="11" fill="#B1BAC4">arm64</text>
+<rect x="58" y="104.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
+<text x="74.000" y="112.000" font-size="11" fill="#B1BAC4">x86</text>
+<text x="12" y="458" font-size="9" fill="#8B949E"><tspan font-size="7.5" font-weight="600" dy="-3" fill="#B1BAC4">(1)</tspan><tspan dx="3" dy="3">based on 21 benchmarks, 16 spec sheets, 12 third party measurements</tspan></text>
 </svg>

--- a/docs/images/flop_weights_dark.svg
+++ b/docs/images/flop_weights_dark.svg
@@ -126,5 +126,5 @@
 <text x="74.000" y="96.000" font-size="11" fill="#B1BAC4">arm64</text>
 <rect x="58" y="104.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
 <text x="74.000" y="112.000" font-size="11" fill="#B1BAC4">x86</text>
-<text x="12" y="458" font-size="9" fill="#8B949E"><tspan font-size="7.5" font-weight="600" dy="-3" fill="#B1BAC4">(1)</tspan><tspan dx="3" dy="3">based on 21 benchmarks, 16 spec sheets, 12 third party measurements</tspan></text>
+<text x="12" y="458" font-size="9" fill="#8B949E"><tspan font-size="7.5" font-weight="600" dy="-3" fill="#B1BAC4">(1)</tspan><tspan dx="3" dy="3">based on 21 benchmarks, 16 spec sheets, 12 third party measurements (Agner Fog, uops.info)</tspan></text>
 </svg>

--- a/docs/images/flop_weights_dark.svg
+++ b/docs/images/flop_weights_dark.svg
@@ -40,89 +40,89 @@
 <line x1="666.000" y1="366" x2="714.000" y2="366" stroke="#6E7681" stroke-width="1" stroke-dasharray="4 4"/>
 <text x="690.000" y="382" font-size="8.5" fill="#8B949E" text-anchor="middle">28 more</text>
 <rect x="50.500" y="314.485" width="9" height="51.515" fill="#707070"/>
-<rect x="59.500" y="284.635" width="9" height="81.365" fill="#FBB85C"/>
+<rect x="59.500" y="284.635" width="9" height="81.365" fill="#E8837A"/>
 <rect x="68.500" y="344.336" width="9" height="21.664" fill="#6BA1F2"/>
 <text x="64.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 64.000 379)">MINUS</text>
 <rect x="86.500" y="291.831" width="9" height="74.169" fill="#707070"/>
-<rect x="95.500" y="273.939" width="9" height="92.061" fill="#FBB85C"/>
+<rect x="95.500" y="273.939" width="9" height="92.061" fill="#E8837A"/>
 <rect x="104.500" y="309.723" width="9" height="56.277" fill="#6BA1F2"/>
 <text x="100.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 100.000 379)">ABS</text>
 <rect x="122.500" y="275.876" width="9" height="90.124" fill="#707070"/>
-<rect x="131.500" y="297.303" width="9" height="68.697" fill="#FBB85C"/>
+<rect x="131.500" y="297.303" width="9" height="68.697" fill="#E8837A"/>
 <rect x="140.500" y="254.449" width="9" height="111.551" fill="#6BA1F2"/>
 <text x="136.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 136.000 379)">COMP</text>
 <rect x="158.500" y="274.757" width="9" height="91.243" fill="#707070"/>
-<rect x="167.500" y="274.757" width="9" height="91.243" fill="#FBB85C"/>
+<rect x="167.500" y="274.757" width="9" height="91.243" fill="#E8837A"/>
 <rect x="176.500" y="274.757" width="9" height="91.243" fill="#6BA1F2"/>
 <text x="172.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 172.000 379)">ADD</text>
 <rect x="194.500" y="274.721" width="9" height="91.279" fill="#707070"/>
-<rect x="203.500" y="274.671" width="9" height="91.329" fill="#FBB85C"/>
+<rect x="203.500" y="274.671" width="9" height="91.329" fill="#E8837A"/>
 <rect x="212.500" y="274.770" width="9" height="91.230" fill="#6BA1F2"/>
 <text x="208.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 208.000 379)">SUB</text>
 <rect x="230.500" y="267.617" width="9" height="98.383" fill="#707070"/>
-<rect x="239.500" y="249.980" width="9" height="116.020" fill="#FBB85C"/>
+<rect x="239.500" y="249.980" width="9" height="116.020" fill="#E8837A"/>
 <rect x="248.500" y="285.255" width="9" height="80.745" fill="#6BA1F2"/>
 <text x="244.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 244.000 379)">COPYSIGN</text>
 <rect x="266.500" y="258.541" width="9" height="107.459" fill="#707070"/>
-<rect x="275.500" y="255.588" width="9" height="110.412" fill="#FBB85C"/>
+<rect x="275.500" y="255.588" width="9" height="110.412" fill="#E8837A"/>
 <rect x="284.500" y="261.493" width="9" height="104.507" fill="#6BA1F2"/>
 <text x="280.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 280.000 379)">MUL</text>
 <rect x="302.500" y="249.228" width="9" height="116.772" fill="#707070"/>
-<rect x="311.500" y="244.347" width="9" height="121.653" fill="#FBB85C"/>
+<rect x="311.500" y="244.347" width="9" height="121.653" fill="#E8837A"/>
 <rect x="320.500" y="254.110" width="9" height="111.890" fill="#6BA1F2"/>
 <text x="316.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 316.000 379)">FMA</text>
 <rect x="338.500" y="246.533" width="9" height="119.467" fill="#707070"/>
-<rect x="347.500" y="251.668" width="9" height="114.332" fill="#FBB85C"/>
+<rect x="347.500" y="251.668" width="9" height="114.332" fill="#E8837A"/>
 <rect x="356.500" y="241.397" width="9" height="124.603" fill="#6BA1F2"/>
 <text x="352.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 352.000 379)">RND</text>
 <rect x="374.500" y="243.404" width="9" height="122.596" fill="#707070"/>
-<rect x="383.500" y="256.648" width="9" height="109.352" fill="#FBB85C"/>
+<rect x="383.500" y="256.648" width="9" height="109.352" fill="#E8837A"/>
 <rect x="392.500" y="230.160" width="9" height="135.840" fill="#6BA1F2"/>
 <text x="388.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 388.000 379)">F2I</text>
 <rect x="410.500" y="243.225" width="9" height="122.775" fill="#707070"/>
-<rect x="419.500" y="253.398" width="9" height="112.602" fill="#FBB85C"/>
+<rect x="419.500" y="253.398" width="9" height="112.602" fill="#E8837A"/>
 <rect x="428.500" y="233.052" width="9" height="132.948" fill="#6BA1F2"/>
 <text x="424.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 424.000 379)">I2F</text>
 <rect x="446.500" y="229.904" width="9" height="136.096" fill="#707070"/>
-<rect x="455.500" y="220.487" width="9" height="145.513" fill="#FBB85C"/>
+<rect x="455.500" y="220.487" width="9" height="145.513" fill="#E8837A"/>
 <rect x="464.500" y="239.321" width="9" height="126.679" fill="#6BA1F2"/>
 <text x="460.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 460.000 379)">HYPOT_XARG</text>
 <rect x="482.500" y="229.857" width="9" height="136.143" fill="#707070"/>
-<rect x="491.500" y="221.623" width="9" height="144.377" fill="#FBB85C"/>
+<rect x="491.500" y="221.623" width="9" height="144.377" fill="#E8837A"/>
 <rect x="500.500" y="238.090" width="9" height="127.910" fill="#6BA1F2"/>
 <text x="496.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 496.000 379)">DIST_XARG</text>
 <rect x="518.500" y="203.572" width="9" height="162.428" fill="#707070"/>
-<rect x="527.500" y="205.462" width="9" height="160.538" fill="#FBB85C"/>
+<rect x="527.500" y="205.462" width="9" height="160.538" fill="#E8837A"/>
 <rect x="536.500" y="201.682" width="9" height="164.318" fill="#6BA1F2"/>
 <text x="532.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 532.000 379)">SUMPROD_XELEM</text>
 <rect x="554.500" y="192.285" width="9" height="173.715" fill="#707070"/>
-<rect x="563.500" y="187.261" width="9" height="178.739" fill="#FBB85C"/>
+<rect x="563.500" y="187.261" width="9" height="178.739" fill="#E8837A"/>
 <rect x="572.500" y="197.309" width="9" height="168.691" fill="#6BA1F2"/>
 <text x="568.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 568.000 379)">DIV</text>
 <rect x="590.500" y="187.956" width="9" height="178.044" fill="#707070"/>
-<rect x="599.500" y="176.429" width="9" height="189.571" fill="#FBB85C"/>
+<rect x="599.500" y="176.429" width="9" height="189.571" fill="#E8837A"/>
 <rect x="608.500" y="199.484" width="9" height="166.516" fill="#6BA1F2"/>
 <text x="604.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 604.000 379)">FMOD</text>
 <rect x="626.500" y="180.481" width="9" height="185.519" fill="#707070"/>
-<rect x="635.500" y="179.280" width="9" height="186.720" fill="#FBB85C"/>
+<rect x="635.500" y="179.280" width="9" height="186.720" fill="#E8837A"/>
 <rect x="644.500" y="181.682" width="9" height="184.318" fill="#6BA1F2"/>
 <text x="640.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 640.000 379)">SQRT</text>
 <rect x="726.500" y="89.090" width="9" height="276.910" fill="#707070"/>
-<rect x="735.500" y="91.660" width="9" height="274.340" fill="#FBB85C"/>
+<rect x="735.500" y="91.660" width="9" height="274.340" fill="#E8837A"/>
 <rect x="744.500" y="86.520" width="9" height="279.480" fill="#6BA1F2"/>
 <text x="740.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 740.000 379)">SINH</text>
 <rect x="762.500" y="88.684" width="9" height="277.316" fill="#707070"/>
-<rect x="771.500" y="89.050" width="9" height="276.950" fill="#FBB85C"/>
+<rect x="771.500" y="89.050" width="9" height="276.950" fill="#E8837A"/>
 <rect x="780.500" y="88.318" width="9" height="277.682" fill="#6BA1F2"/>
 <text x="776.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 776.000 379)">TANH</text>
 <rect x="798.500" y="82.807" width="9" height="283.193" fill="#707070"/>
-<rect x="807.500" y="82.103" width="9" height="283.897" fill="#FBB85C"/>
+<rect x="807.500" y="82.103" width="9" height="283.897" fill="#E8837A"/>
 <rect x="816.500" y="83.510" width="9" height="282.490" fill="#6BA1F2"/>
 <text x="812.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 812.000 379)">GAMMA</text>
 <rect x="52.000" y="66.000" width="118.950" height="54.000" rx="4" fill="#242C37" fill-opacity="0.8"/>
 <rect x="58" y="72.000" width="10" height="10" rx="1" fill="#707070"/>
 <text x="74.000" y="80.000" font-size="11" fill="#B1BAC4">all architectures</text>
-<rect x="58" y="88.000" width="10" height="10" rx="1" fill="#FBB85C"/>
+<rect x="58" y="88.000" width="10" height="10" rx="1" fill="#E8837A"/>
 <text x="74.000" y="96.000" font-size="11" fill="#B1BAC4">arm64</text>
 <rect x="58" y="104.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
 <text x="74.000" y="112.000" font-size="11" fill="#B1BAC4">x86</text>

--- a/docs/images/flop_weights_dark.svg
+++ b/docs/images/flop_weights_dark.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840.000 476" width="840.000" height="476" font-family="system-ui, -apple-system, sans-serif">
+<rect x="0" y="0" width="840.000" height="476" fill="#0D1117"/>
+<text x="46" y="26" font-size="15" font-weight="600" fill="#E6EDF3">Built-in flop weights</text>
+<text x="46" y="44" font-size="11" fill="#B1BAC4">relative to ADD = 1, log scale</text>
+<line x1="46" y1="352.622" x2="830.000" y2="352.622" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="355.622" font-size="8" fill="#8B949E" text-anchor="end">0.2</text>
+<line x1="46" y1="333.766" x2="830.000" y2="333.766" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="320.388" x2="830.000" y2="320.388" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="310.011" x2="830.000" y2="310.011" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="313.011" font-size="8" fill="#8B949E" text-anchor="end">0.5</text>
+<line x1="46" y1="301.533" x2="830.000" y2="301.533" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="294.364" x2="830.000" y2="294.364" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="288.155" x2="830.000" y2="288.155" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="282.678" x2="830.000" y2="282.678" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="245.544" x2="830.000" y2="245.544" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="248.544" font-size="8" fill="#8B949E" text-anchor="end">2</text>
+<line x1="46" y1="226.689" x2="830.000" y2="226.689" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="213.311" x2="830.000" y2="213.311" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="202.934" x2="830.000" y2="202.934" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="205.934" font-size="8" fill="#8B949E" text-anchor="end">5</text>
+<line x1="46" y1="194.456" x2="830.000" y2="194.456" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="187.287" x2="830.000" y2="187.287" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="181.077" x2="830.000" y2="181.077" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="175.600" x2="830.000" y2="175.600" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="138.467" x2="830.000" y2="138.467" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="141.467" font-size="8" fill="#8B949E" text-anchor="end">20</text>
+<line x1="46" y1="119.612" x2="830.000" y2="119.612" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="106.234" x2="830.000" y2="106.234" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="95.857" x2="830.000" y2="95.857" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="98.857" font-size="8" fill="#8B949E" text-anchor="end">50</text>
+<line x1="46" y1="87.378" x2="830.000" y2="87.378" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="80.210" x2="830.000" y2="80.210" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="74.000" x2="830.000" y2="74.000" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="277.778" x2="830.000" y2="277.778" stroke="#636C76" stroke-width="1"/>
+<text x="38" y="281.278" font-size="10" fill="#B1BAC4" text-anchor="end">1</text>
+<line x1="46" y1="170.701" x2="830.000" y2="170.701" stroke="#636C76" stroke-width="1"/>
+<text x="38" y="174.201" font-size="10" fill="#B1BAC4" text-anchor="end">10</text>
+<line x1="46.000" y1="366" x2="666.000" y2="366" stroke="#6E7681" stroke-width="1"/>
+<line x1="714.000" y1="366" x2="830.000" y2="366" stroke="#6E7681" stroke-width="1"/>
+<line x1="666.000" y1="366" x2="714.000" y2="366" stroke="#6E7681" stroke-width="1" stroke-dasharray="4 4"/>
+<text x="690.000" y="382" font-size="8.5" fill="#8B949E" text-anchor="middle">28 more</text>
+<rect x="50.500" y="316.191" width="9" height="49.809" fill="#707070"/>
+<rect x="59.500" y="287.329" width="9" height="78.671" fill="#FBB85C"/>
+<rect x="68.500" y="345.053" width="9" height="20.947" fill="#6BA1F2"/>
+<text x="64.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 64.000 379)">MINUS</text>
+<rect x="86.500" y="294.287" width="9" height="71.713" fill="#707070"/>
+<rect x="95.500" y="276.987" width="9" height="89.013" fill="#FBB85C"/>
+<rect x="104.500" y="311.587" width="9" height="54.413" fill="#6BA1F2"/>
+<text x="100.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 100.000 379)">ABS</text>
+<rect x="122.500" y="278.860" width="9" height="87.140" fill="#707070"/>
+<rect x="131.500" y="299.578" width="9" height="66.422" fill="#FBB85C"/>
+<rect x="140.500" y="258.142" width="9" height="107.858" fill="#6BA1F2"/>
+<text x="136.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 136.000 379)">COMP</text>
+<rect x="158.500" y="277.778" width="9" height="88.222" fill="#707070"/>
+<rect x="167.500" y="277.778" width="9" height="88.222" fill="#FBB85C"/>
+<rect x="176.500" y="277.778" width="9" height="88.222" fill="#6BA1F2"/>
+<text x="172.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 172.000 379)">ADD</text>
+<rect x="194.500" y="277.743" width="9" height="88.257" fill="#707070"/>
+<rect x="203.500" y="277.695" width="9" height="88.305" fill="#FBB85C"/>
+<rect x="212.500" y="277.791" width="9" height="88.209" fill="#6BA1F2"/>
+<text x="208.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 208.000 379)">SUB</text>
+<rect x="230.500" y="270.875" width="9" height="95.125" fill="#707070"/>
+<rect x="239.500" y="253.821" width="9" height="112.179" fill="#FBB85C"/>
+<rect x="248.500" y="287.928" width="9" height="78.072" fill="#6BA1F2"/>
+<text x="244.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 244.000 379)">COPYSIGN</text>
+<rect x="266.500" y="262.099" width="9" height="103.901" fill="#707070"/>
+<rect x="275.500" y="259.244" width="9" height="106.756" fill="#FBB85C"/>
+<rect x="284.500" y="264.953" width="9" height="101.047" fill="#6BA1F2"/>
+<text x="280.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 280.000 379)">MUL</text>
+<rect x="302.500" y="253.095" width="9" height="112.905" fill="#707070"/>
+<rect x="311.500" y="248.375" width="9" height="117.625" fill="#FBB85C"/>
+<rect x="320.500" y="257.815" width="9" height="108.185" fill="#6BA1F2"/>
+<text x="316.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 316.000 379)">FMA</text>
+<rect x="338.500" y="250.489" width="9" height="115.511" fill="#707070"/>
+<rect x="347.500" y="255.454" width="9" height="110.546" fill="#FBB85C"/>
+<rect x="356.500" y="245.523" width="9" height="120.477" fill="#6BA1F2"/>
+<text x="352.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 352.000 379)">RND</text>
+<rect x="374.500" y="247.463" width="9" height="118.537" fill="#707070"/>
+<rect x="383.500" y="260.269" width="9" height="105.731" fill="#FBB85C"/>
+<rect x="392.500" y="234.658" width="9" height="131.342" fill="#6BA1F2"/>
+<text x="388.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 388.000 379)">F2I</text>
+<rect x="410.500" y="247.290" width="9" height="118.710" fill="#707070"/>
+<rect x="419.500" y="257.126" width="9" height="108.874" fill="#FBB85C"/>
+<rect x="428.500" y="237.454" width="9" height="128.546" fill="#6BA1F2"/>
+<text x="424.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 424.000 379)">I2F</text>
+<rect x="446.500" y="234.411" width="9" height="131.589" fill="#707070"/>
+<rect x="455.500" y="225.305" width="9" height="140.695" fill="#FBB85C"/>
+<rect x="464.500" y="243.516" width="9" height="122.484" fill="#6BA1F2"/>
+<text x="460.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 460.000 379)">HYPOT_XARG</text>
+<rect x="482.500" y="234.365" width="9" height="131.635" fill="#707070"/>
+<rect x="491.500" y="226.404" width="9" height="139.596" fill="#FBB85C"/>
+<rect x="500.500" y="242.325" width="9" height="123.675" fill="#6BA1F2"/>
+<text x="496.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 496.000 379)">DIST_XARG</text>
+<rect x="518.500" y="208.951" width="9" height="157.049" fill="#707070"/>
+<rect x="527.500" y="210.778" width="9" height="155.222" fill="#FBB85C"/>
+<rect x="536.500" y="207.123" width="9" height="158.877" fill="#6BA1F2"/>
+<text x="532.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 532.000 379)">SUMPROD_XELEM</text>
+<rect x="554.500" y="198.037" width="9" height="167.963" fill="#707070"/>
+<rect x="563.500" y="193.180" width="9" height="172.820" fill="#FBB85C"/>
+<rect x="572.500" y="202.895" width="9" height="163.105" fill="#6BA1F2"/>
+<text x="568.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 568.000 379)">DIV</text>
+<rect x="590.500" y="193.852" width="9" height="172.148" fill="#707070"/>
+<rect x="599.500" y="182.706" width="9" height="183.294" fill="#FBB85C"/>
+<rect x="608.500" y="204.998" width="9" height="161.002" fill="#6BA1F2"/>
+<text x="604.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 604.000 379)">FMOD</text>
+<rect x="626.500" y="186.624" width="9" height="179.376" fill="#707070"/>
+<rect x="635.500" y="185.463" width="9" height="180.537" fill="#FBB85C"/>
+<rect x="644.500" y="187.785" width="9" height="178.215" fill="#6BA1F2"/>
+<text x="640.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 640.000 379)">SQRT</text>
+<rect x="726.500" y="98.259" width="9" height="267.741" fill="#707070"/>
+<rect x="735.500" y="100.744" width="9" height="265.256" fill="#FBB85C"/>
+<rect x="744.500" y="95.775" width="9" height="270.225" fill="#6BA1F2"/>
+<text x="740.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 740.000 379)">SINH</text>
+<rect x="762.500" y="97.867" width="9" height="268.133" fill="#707070"/>
+<rect x="771.500" y="98.221" width="9" height="267.779" fill="#FBB85C"/>
+<rect x="780.500" y="97.513" width="9" height="268.487" fill="#6BA1F2"/>
+<text x="776.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 776.000 379)">TANH</text>
+<rect x="798.500" y="92.184" width="9" height="273.816" fill="#707070"/>
+<rect x="807.500" y="91.503" width="9" height="274.497" fill="#FBB85C"/>
+<rect x="816.500" y="92.864" width="9" height="273.136" fill="#6BA1F2"/>
+<text x="812.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 812.000 379)">GAMMA</text>
+<rect x="52.000" y="76.000" width="118.950" height="54.000" rx="4" fill="#242C37" fill-opacity="0.8"/>
+<rect x="58" y="82.000" width="10" height="10" rx="1" fill="#707070"/>
+<text x="74.000" y="90.000" font-size="11" fill="#B1BAC4">all architectures</text>
+<rect x="58" y="98.000" width="10" height="10" rx="1" fill="#FBB85C"/>
+<text x="74.000" y="106.000" font-size="11" fill="#B1BAC4">arm64</text>
+<rect x="58" y="114.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
+<text x="74.000" y="122.000" font-size="11" fill="#B1BAC4">x86</text>
+</svg>

--- a/docs/images/flop_weights_dark_docs.svg
+++ b/docs/images/flop_weights_dark_docs.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840.000 476" width="840.000" height="476" font-family="system-ui, -apple-system, sans-serif">
+<rect x="0" y="0" width="840.000" height="476" fill="#1E2129"/>
+<text x="46" y="26" font-size="15" font-weight="600" fill="#E6EDF3">Built-in flop weights</text>
+<text x="46" y="44" font-size="11" fill="#B1BAC4">relative to ADD = 1, log scale</text>
+<line x1="46" y1="352.622" x2="830.000" y2="352.622" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="355.622" font-size="8" fill="#8B949E" text-anchor="end">0.2</text>
+<line x1="46" y1="333.766" x2="830.000" y2="333.766" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="320.388" x2="830.000" y2="320.388" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="310.011" x2="830.000" y2="310.011" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="313.011" font-size="8" fill="#8B949E" text-anchor="end">0.5</text>
+<line x1="46" y1="301.533" x2="830.000" y2="301.533" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="294.364" x2="830.000" y2="294.364" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="288.155" x2="830.000" y2="288.155" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="282.678" x2="830.000" y2="282.678" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="245.544" x2="830.000" y2="245.544" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="248.544" font-size="8" fill="#8B949E" text-anchor="end">2</text>
+<line x1="46" y1="226.689" x2="830.000" y2="226.689" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="213.311" x2="830.000" y2="213.311" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="202.934" x2="830.000" y2="202.934" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="205.934" font-size="8" fill="#8B949E" text-anchor="end">5</text>
+<line x1="46" y1="194.456" x2="830.000" y2="194.456" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="187.287" x2="830.000" y2="187.287" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="181.077" x2="830.000" y2="181.077" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="175.600" x2="830.000" y2="175.600" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="138.467" x2="830.000" y2="138.467" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="141.467" font-size="8" fill="#8B949E" text-anchor="end">20</text>
+<line x1="46" y1="119.612" x2="830.000" y2="119.612" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="106.234" x2="830.000" y2="106.234" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="95.857" x2="830.000" y2="95.857" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="98.857" font-size="8" fill="#8B949E" text-anchor="end">50</text>
+<line x1="46" y1="87.378" x2="830.000" y2="87.378" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="80.210" x2="830.000" y2="80.210" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="74.000" x2="830.000" y2="74.000" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="277.778" x2="830.000" y2="277.778" stroke="#636C76" stroke-width="1"/>
+<text x="38" y="281.278" font-size="10" fill="#B1BAC4" text-anchor="end">1</text>
+<line x1="46" y1="170.701" x2="830.000" y2="170.701" stroke="#636C76" stroke-width="1"/>
+<text x="38" y="174.201" font-size="10" fill="#B1BAC4" text-anchor="end">10</text>
+<line x1="46.000" y1="366" x2="666.000" y2="366" stroke="#6E7681" stroke-width="1"/>
+<line x1="714.000" y1="366" x2="830.000" y2="366" stroke="#6E7681" stroke-width="1"/>
+<line x1="666.000" y1="366" x2="714.000" y2="366" stroke="#6E7681" stroke-width="1" stroke-dasharray="4 4"/>
+<text x="690.000" y="382" font-size="8.5" fill="#8B949E" text-anchor="middle">28 more</text>
+<rect x="50.500" y="316.191" width="9" height="49.809" fill="#707070"/>
+<rect x="59.500" y="287.329" width="9" height="78.671" fill="#FBB85C"/>
+<rect x="68.500" y="345.053" width="9" height="20.947" fill="#6BA1F2"/>
+<text x="64.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 64.000 379)">MINUS</text>
+<rect x="86.500" y="294.287" width="9" height="71.713" fill="#707070"/>
+<rect x="95.500" y="276.987" width="9" height="89.013" fill="#FBB85C"/>
+<rect x="104.500" y="311.587" width="9" height="54.413" fill="#6BA1F2"/>
+<text x="100.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 100.000 379)">ABS</text>
+<rect x="122.500" y="278.860" width="9" height="87.140" fill="#707070"/>
+<rect x="131.500" y="299.578" width="9" height="66.422" fill="#FBB85C"/>
+<rect x="140.500" y="258.142" width="9" height="107.858" fill="#6BA1F2"/>
+<text x="136.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 136.000 379)">COMP</text>
+<rect x="158.500" y="277.778" width="9" height="88.222" fill="#707070"/>
+<rect x="167.500" y="277.778" width="9" height="88.222" fill="#FBB85C"/>
+<rect x="176.500" y="277.778" width="9" height="88.222" fill="#6BA1F2"/>
+<text x="172.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 172.000 379)">ADD</text>
+<rect x="194.500" y="277.743" width="9" height="88.257" fill="#707070"/>
+<rect x="203.500" y="277.695" width="9" height="88.305" fill="#FBB85C"/>
+<rect x="212.500" y="277.791" width="9" height="88.209" fill="#6BA1F2"/>
+<text x="208.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 208.000 379)">SUB</text>
+<rect x="230.500" y="270.875" width="9" height="95.125" fill="#707070"/>
+<rect x="239.500" y="253.821" width="9" height="112.179" fill="#FBB85C"/>
+<rect x="248.500" y="287.928" width="9" height="78.072" fill="#6BA1F2"/>
+<text x="244.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 244.000 379)">COPYSIGN</text>
+<rect x="266.500" y="262.099" width="9" height="103.901" fill="#707070"/>
+<rect x="275.500" y="259.244" width="9" height="106.756" fill="#FBB85C"/>
+<rect x="284.500" y="264.953" width="9" height="101.047" fill="#6BA1F2"/>
+<text x="280.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 280.000 379)">MUL</text>
+<rect x="302.500" y="253.095" width="9" height="112.905" fill="#707070"/>
+<rect x="311.500" y="248.375" width="9" height="117.625" fill="#FBB85C"/>
+<rect x="320.500" y="257.815" width="9" height="108.185" fill="#6BA1F2"/>
+<text x="316.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 316.000 379)">FMA</text>
+<rect x="338.500" y="250.489" width="9" height="115.511" fill="#707070"/>
+<rect x="347.500" y="255.454" width="9" height="110.546" fill="#FBB85C"/>
+<rect x="356.500" y="245.523" width="9" height="120.477" fill="#6BA1F2"/>
+<text x="352.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 352.000 379)">RND</text>
+<rect x="374.500" y="247.463" width="9" height="118.537" fill="#707070"/>
+<rect x="383.500" y="260.269" width="9" height="105.731" fill="#FBB85C"/>
+<rect x="392.500" y="234.658" width="9" height="131.342" fill="#6BA1F2"/>
+<text x="388.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 388.000 379)">F2I</text>
+<rect x="410.500" y="247.290" width="9" height="118.710" fill="#707070"/>
+<rect x="419.500" y="257.126" width="9" height="108.874" fill="#FBB85C"/>
+<rect x="428.500" y="237.454" width="9" height="128.546" fill="#6BA1F2"/>
+<text x="424.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 424.000 379)">I2F</text>
+<rect x="446.500" y="234.411" width="9" height="131.589" fill="#707070"/>
+<rect x="455.500" y="225.305" width="9" height="140.695" fill="#FBB85C"/>
+<rect x="464.500" y="243.516" width="9" height="122.484" fill="#6BA1F2"/>
+<text x="460.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 460.000 379)">HYPOT_XARG</text>
+<rect x="482.500" y="234.365" width="9" height="131.635" fill="#707070"/>
+<rect x="491.500" y="226.404" width="9" height="139.596" fill="#FBB85C"/>
+<rect x="500.500" y="242.325" width="9" height="123.675" fill="#6BA1F2"/>
+<text x="496.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 496.000 379)">DIST_XARG</text>
+<rect x="518.500" y="208.951" width="9" height="157.049" fill="#707070"/>
+<rect x="527.500" y="210.778" width="9" height="155.222" fill="#FBB85C"/>
+<rect x="536.500" y="207.123" width="9" height="158.877" fill="#6BA1F2"/>
+<text x="532.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 532.000 379)">SUMPROD_XELEM</text>
+<rect x="554.500" y="198.037" width="9" height="167.963" fill="#707070"/>
+<rect x="563.500" y="193.180" width="9" height="172.820" fill="#FBB85C"/>
+<rect x="572.500" y="202.895" width="9" height="163.105" fill="#6BA1F2"/>
+<text x="568.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 568.000 379)">DIV</text>
+<rect x="590.500" y="193.852" width="9" height="172.148" fill="#707070"/>
+<rect x="599.500" y="182.706" width="9" height="183.294" fill="#FBB85C"/>
+<rect x="608.500" y="204.998" width="9" height="161.002" fill="#6BA1F2"/>
+<text x="604.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 604.000 379)">FMOD</text>
+<rect x="626.500" y="186.624" width="9" height="179.376" fill="#707070"/>
+<rect x="635.500" y="185.463" width="9" height="180.537" fill="#FBB85C"/>
+<rect x="644.500" y="187.785" width="9" height="178.215" fill="#6BA1F2"/>
+<text x="640.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 640.000 379)">SQRT</text>
+<rect x="726.500" y="98.259" width="9" height="267.741" fill="#707070"/>
+<rect x="735.500" y="100.744" width="9" height="265.256" fill="#FBB85C"/>
+<rect x="744.500" y="95.775" width="9" height="270.225" fill="#6BA1F2"/>
+<text x="740.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 740.000 379)">SINH</text>
+<rect x="762.500" y="97.867" width="9" height="268.133" fill="#707070"/>
+<rect x="771.500" y="98.221" width="9" height="267.779" fill="#FBB85C"/>
+<rect x="780.500" y="97.513" width="9" height="268.487" fill="#6BA1F2"/>
+<text x="776.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 776.000 379)">TANH</text>
+<rect x="798.500" y="92.184" width="9" height="273.816" fill="#707070"/>
+<rect x="807.500" y="91.503" width="9" height="274.497" fill="#FBB85C"/>
+<rect x="816.500" y="92.864" width="9" height="273.136" fill="#6BA1F2"/>
+<text x="812.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 812.000 379)">GAMMA</text>
+<rect x="52.000" y="76.000" width="118.950" height="54.000" rx="4" fill="#333846" fill-opacity="0.8"/>
+<rect x="58" y="82.000" width="10" height="10" rx="1" fill="#707070"/>
+<text x="74.000" y="90.000" font-size="11" fill="#B1BAC4">all architectures</text>
+<rect x="58" y="98.000" width="10" height="10" rx="1" fill="#FBB85C"/>
+<text x="74.000" y="106.000" font-size="11" fill="#B1BAC4">arm64</text>
+<rect x="58" y="114.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
+<text x="74.000" y="122.000" font-size="11" fill="#B1BAC4">x86</text>
+</svg>

--- a/docs/images/flop_weights_dark_docs.svg
+++ b/docs/images/flop_weights_dark_docs.svg
@@ -1,129 +1,130 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840.000 476" width="840.000" height="476" font-family="system-ui, -apple-system, sans-serif">
-<rect x="0" y="0" width="840.000" height="476" fill="#1E2129"/>
-<text x="46" y="26" font-size="15" font-weight="600" fill="#E6EDF3">Built-in flop weights</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840.000 470" width="840.000" height="470" font-family="system-ui, -apple-system, sans-serif">
+<rect x="0" y="0" width="840.000" height="470" fill="#1E2129"/>
+<text x="46" y="26" font-size="15" font-weight="600" fill="#E6EDF3">Built-in flop weights<tspan font-size="9" font-weight="400" dx="2" dy="-6" fill="#8B949E">(1)</tspan></text>
 <text x="46" y="44" font-size="11" fill="#B1BAC4">relative to ADD = 1, log scale</text>
-<line x1="46" y1="352.622" x2="830.000" y2="352.622" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="355.622" font-size="8" fill="#8B949E" text-anchor="end">0.2</text>
-<line x1="46" y1="333.766" x2="830.000" y2="333.766" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="320.388" x2="830.000" y2="320.388" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="310.011" x2="830.000" y2="310.011" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="313.011" font-size="8" fill="#8B949E" text-anchor="end">0.5</text>
-<line x1="46" y1="301.533" x2="830.000" y2="301.533" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="294.364" x2="830.000" y2="294.364" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="288.155" x2="830.000" y2="288.155" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="282.678" x2="830.000" y2="282.678" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="245.544" x2="830.000" y2="245.544" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="248.544" font-size="8" fill="#8B949E" text-anchor="end">2</text>
-<line x1="46" y1="226.689" x2="830.000" y2="226.689" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="213.311" x2="830.000" y2="213.311" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="202.934" x2="830.000" y2="202.934" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="205.934" font-size="8" fill="#8B949E" text-anchor="end">5</text>
-<line x1="46" y1="194.456" x2="830.000" y2="194.456" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="187.287" x2="830.000" y2="187.287" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="181.077" x2="830.000" y2="181.077" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="175.600" x2="830.000" y2="175.600" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="138.467" x2="830.000" y2="138.467" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="141.467" font-size="8" fill="#8B949E" text-anchor="end">20</text>
-<line x1="46" y1="119.612" x2="830.000" y2="119.612" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="106.234" x2="830.000" y2="106.234" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="95.857" x2="830.000" y2="95.857" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="98.857" font-size="8" fill="#8B949E" text-anchor="end">50</text>
-<line x1="46" y1="87.378" x2="830.000" y2="87.378" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="80.210" x2="830.000" y2="80.210" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="74.000" x2="830.000" y2="74.000" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="277.778" x2="830.000" y2="277.778" stroke="#636C76" stroke-width="1"/>
-<text x="38" y="281.278" font-size="10" fill="#B1BAC4" text-anchor="end">1</text>
-<line x1="46" y1="170.701" x2="830.000" y2="170.701" stroke="#636C76" stroke-width="1"/>
-<text x="38" y="174.201" font-size="10" fill="#B1BAC4" text-anchor="end">10</text>
+<line x1="46" y1="352.164" x2="830.000" y2="352.164" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="355.164" font-size="8" fill="#8B949E" text-anchor="end">0.2</text>
+<line x1="46" y1="332.663" x2="830.000" y2="332.663" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="318.826" x2="830.000" y2="318.826" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="308.094" x2="830.000" y2="308.094" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="311.094" font-size="8" fill="#8B949E" text-anchor="end">0.5</text>
+<line x1="46" y1="299.325" x2="830.000" y2="299.325" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="291.911" x2="830.000" y2="291.911" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="285.489" x2="830.000" y2="285.489" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="279.824" x2="830.000" y2="279.824" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="241.419" x2="830.000" y2="241.419" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="244.419" font-size="8" fill="#8B949E" text-anchor="end">2</text>
+<line x1="46" y1="221.918" x2="830.000" y2="221.918" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="208.082" x2="830.000" y2="208.082" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="197.350" x2="830.000" y2="197.350" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="200.350" font-size="8" fill="#8B949E" text-anchor="end">5</text>
+<line x1="46" y1="188.581" x2="830.000" y2="188.581" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="181.167" x2="830.000" y2="181.167" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="174.744" x2="830.000" y2="174.744" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="169.080" x2="830.000" y2="169.080" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="130.675" x2="830.000" y2="130.675" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="133.675" font-size="8" fill="#8B949E" text-anchor="end">20</text>
+<line x1="46" y1="111.174" x2="830.000" y2="111.174" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="97.337" x2="830.000" y2="97.337" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="86.605" x2="830.000" y2="86.605" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="89.605" font-size="8" fill="#8B949E" text-anchor="end">50</text>
+<line x1="46" y1="77.836" x2="830.000" y2="77.836" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="70.422" x2="830.000" y2="70.422" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="64.000" x2="830.000" y2="64.000" stroke="#444C56" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="274.757" x2="830.000" y2="274.757" stroke="#636C76" stroke-width="1"/>
+<text x="38" y="278.257" font-size="10" fill="#B1BAC4" text-anchor="end">1</text>
+<line x1="46" y1="164.012" x2="830.000" y2="164.012" stroke="#636C76" stroke-width="1"/>
+<text x="38" y="167.512" font-size="10" fill="#B1BAC4" text-anchor="end">10</text>
 <line x1="46.000" y1="366" x2="666.000" y2="366" stroke="#6E7681" stroke-width="1"/>
 <line x1="714.000" y1="366" x2="830.000" y2="366" stroke="#6E7681" stroke-width="1"/>
 <line x1="666.000" y1="366" x2="714.000" y2="366" stroke="#6E7681" stroke-width="1" stroke-dasharray="4 4"/>
 <text x="690.000" y="382" font-size="8.5" fill="#8B949E" text-anchor="middle">28 more</text>
-<rect x="50.500" y="316.191" width="9" height="49.809" fill="#707070"/>
-<rect x="59.500" y="287.329" width="9" height="78.671" fill="#FBB85C"/>
-<rect x="68.500" y="345.053" width="9" height="20.947" fill="#6BA1F2"/>
+<rect x="50.500" y="314.485" width="9" height="51.515" fill="#707070"/>
+<rect x="59.500" y="284.635" width="9" height="81.365" fill="#FBB85C"/>
+<rect x="68.500" y="344.336" width="9" height="21.664" fill="#6BA1F2"/>
 <text x="64.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 64.000 379)">MINUS</text>
-<rect x="86.500" y="294.287" width="9" height="71.713" fill="#707070"/>
-<rect x="95.500" y="276.987" width="9" height="89.013" fill="#FBB85C"/>
-<rect x="104.500" y="311.587" width="9" height="54.413" fill="#6BA1F2"/>
+<rect x="86.500" y="291.831" width="9" height="74.169" fill="#707070"/>
+<rect x="95.500" y="273.939" width="9" height="92.061" fill="#FBB85C"/>
+<rect x="104.500" y="309.723" width="9" height="56.277" fill="#6BA1F2"/>
 <text x="100.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 100.000 379)">ABS</text>
-<rect x="122.500" y="278.860" width="9" height="87.140" fill="#707070"/>
-<rect x="131.500" y="299.578" width="9" height="66.422" fill="#FBB85C"/>
-<rect x="140.500" y="258.142" width="9" height="107.858" fill="#6BA1F2"/>
+<rect x="122.500" y="275.876" width="9" height="90.124" fill="#707070"/>
+<rect x="131.500" y="297.303" width="9" height="68.697" fill="#FBB85C"/>
+<rect x="140.500" y="254.449" width="9" height="111.551" fill="#6BA1F2"/>
 <text x="136.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 136.000 379)">COMP</text>
-<rect x="158.500" y="277.778" width="9" height="88.222" fill="#707070"/>
-<rect x="167.500" y="277.778" width="9" height="88.222" fill="#FBB85C"/>
-<rect x="176.500" y="277.778" width="9" height="88.222" fill="#6BA1F2"/>
+<rect x="158.500" y="274.757" width="9" height="91.243" fill="#707070"/>
+<rect x="167.500" y="274.757" width="9" height="91.243" fill="#FBB85C"/>
+<rect x="176.500" y="274.757" width="9" height="91.243" fill="#6BA1F2"/>
 <text x="172.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 172.000 379)">ADD</text>
-<rect x="194.500" y="277.743" width="9" height="88.257" fill="#707070"/>
-<rect x="203.500" y="277.695" width="9" height="88.305" fill="#FBB85C"/>
-<rect x="212.500" y="277.791" width="9" height="88.209" fill="#6BA1F2"/>
+<rect x="194.500" y="274.721" width="9" height="91.279" fill="#707070"/>
+<rect x="203.500" y="274.671" width="9" height="91.329" fill="#FBB85C"/>
+<rect x="212.500" y="274.770" width="9" height="91.230" fill="#6BA1F2"/>
 <text x="208.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 208.000 379)">SUB</text>
-<rect x="230.500" y="270.875" width="9" height="95.125" fill="#707070"/>
-<rect x="239.500" y="253.821" width="9" height="112.179" fill="#FBB85C"/>
-<rect x="248.500" y="287.928" width="9" height="78.072" fill="#6BA1F2"/>
+<rect x="230.500" y="267.617" width="9" height="98.383" fill="#707070"/>
+<rect x="239.500" y="249.980" width="9" height="116.020" fill="#FBB85C"/>
+<rect x="248.500" y="285.255" width="9" height="80.745" fill="#6BA1F2"/>
 <text x="244.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 244.000 379)">COPYSIGN</text>
-<rect x="266.500" y="262.099" width="9" height="103.901" fill="#707070"/>
-<rect x="275.500" y="259.244" width="9" height="106.756" fill="#FBB85C"/>
-<rect x="284.500" y="264.953" width="9" height="101.047" fill="#6BA1F2"/>
+<rect x="266.500" y="258.541" width="9" height="107.459" fill="#707070"/>
+<rect x="275.500" y="255.588" width="9" height="110.412" fill="#FBB85C"/>
+<rect x="284.500" y="261.493" width="9" height="104.507" fill="#6BA1F2"/>
 <text x="280.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 280.000 379)">MUL</text>
-<rect x="302.500" y="253.095" width="9" height="112.905" fill="#707070"/>
-<rect x="311.500" y="248.375" width="9" height="117.625" fill="#FBB85C"/>
-<rect x="320.500" y="257.815" width="9" height="108.185" fill="#6BA1F2"/>
+<rect x="302.500" y="249.228" width="9" height="116.772" fill="#707070"/>
+<rect x="311.500" y="244.347" width="9" height="121.653" fill="#FBB85C"/>
+<rect x="320.500" y="254.110" width="9" height="111.890" fill="#6BA1F2"/>
 <text x="316.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 316.000 379)">FMA</text>
-<rect x="338.500" y="250.489" width="9" height="115.511" fill="#707070"/>
-<rect x="347.500" y="255.454" width="9" height="110.546" fill="#FBB85C"/>
-<rect x="356.500" y="245.523" width="9" height="120.477" fill="#6BA1F2"/>
+<rect x="338.500" y="246.533" width="9" height="119.467" fill="#707070"/>
+<rect x="347.500" y="251.668" width="9" height="114.332" fill="#FBB85C"/>
+<rect x="356.500" y="241.397" width="9" height="124.603" fill="#6BA1F2"/>
 <text x="352.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 352.000 379)">RND</text>
-<rect x="374.500" y="247.463" width="9" height="118.537" fill="#707070"/>
-<rect x="383.500" y="260.269" width="9" height="105.731" fill="#FBB85C"/>
-<rect x="392.500" y="234.658" width="9" height="131.342" fill="#6BA1F2"/>
+<rect x="374.500" y="243.404" width="9" height="122.596" fill="#707070"/>
+<rect x="383.500" y="256.648" width="9" height="109.352" fill="#FBB85C"/>
+<rect x="392.500" y="230.160" width="9" height="135.840" fill="#6BA1F2"/>
 <text x="388.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 388.000 379)">F2I</text>
-<rect x="410.500" y="247.290" width="9" height="118.710" fill="#707070"/>
-<rect x="419.500" y="257.126" width="9" height="108.874" fill="#FBB85C"/>
-<rect x="428.500" y="237.454" width="9" height="128.546" fill="#6BA1F2"/>
+<rect x="410.500" y="243.225" width="9" height="122.775" fill="#707070"/>
+<rect x="419.500" y="253.398" width="9" height="112.602" fill="#FBB85C"/>
+<rect x="428.500" y="233.052" width="9" height="132.948" fill="#6BA1F2"/>
 <text x="424.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 424.000 379)">I2F</text>
-<rect x="446.500" y="234.411" width="9" height="131.589" fill="#707070"/>
-<rect x="455.500" y="225.305" width="9" height="140.695" fill="#FBB85C"/>
-<rect x="464.500" y="243.516" width="9" height="122.484" fill="#6BA1F2"/>
+<rect x="446.500" y="229.904" width="9" height="136.096" fill="#707070"/>
+<rect x="455.500" y="220.487" width="9" height="145.513" fill="#FBB85C"/>
+<rect x="464.500" y="239.321" width="9" height="126.679" fill="#6BA1F2"/>
 <text x="460.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 460.000 379)">HYPOT_XARG</text>
-<rect x="482.500" y="234.365" width="9" height="131.635" fill="#707070"/>
-<rect x="491.500" y="226.404" width="9" height="139.596" fill="#FBB85C"/>
-<rect x="500.500" y="242.325" width="9" height="123.675" fill="#6BA1F2"/>
+<rect x="482.500" y="229.857" width="9" height="136.143" fill="#707070"/>
+<rect x="491.500" y="221.623" width="9" height="144.377" fill="#FBB85C"/>
+<rect x="500.500" y="238.090" width="9" height="127.910" fill="#6BA1F2"/>
 <text x="496.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 496.000 379)">DIST_XARG</text>
-<rect x="518.500" y="208.951" width="9" height="157.049" fill="#707070"/>
-<rect x="527.500" y="210.778" width="9" height="155.222" fill="#FBB85C"/>
-<rect x="536.500" y="207.123" width="9" height="158.877" fill="#6BA1F2"/>
+<rect x="518.500" y="203.572" width="9" height="162.428" fill="#707070"/>
+<rect x="527.500" y="205.462" width="9" height="160.538" fill="#FBB85C"/>
+<rect x="536.500" y="201.682" width="9" height="164.318" fill="#6BA1F2"/>
 <text x="532.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 532.000 379)">SUMPROD_XELEM</text>
-<rect x="554.500" y="198.037" width="9" height="167.963" fill="#707070"/>
-<rect x="563.500" y="193.180" width="9" height="172.820" fill="#FBB85C"/>
-<rect x="572.500" y="202.895" width="9" height="163.105" fill="#6BA1F2"/>
+<rect x="554.500" y="192.285" width="9" height="173.715" fill="#707070"/>
+<rect x="563.500" y="187.261" width="9" height="178.739" fill="#FBB85C"/>
+<rect x="572.500" y="197.309" width="9" height="168.691" fill="#6BA1F2"/>
 <text x="568.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 568.000 379)">DIV</text>
-<rect x="590.500" y="193.852" width="9" height="172.148" fill="#707070"/>
-<rect x="599.500" y="182.706" width="9" height="183.294" fill="#FBB85C"/>
-<rect x="608.500" y="204.998" width="9" height="161.002" fill="#6BA1F2"/>
+<rect x="590.500" y="187.956" width="9" height="178.044" fill="#707070"/>
+<rect x="599.500" y="176.429" width="9" height="189.571" fill="#FBB85C"/>
+<rect x="608.500" y="199.484" width="9" height="166.516" fill="#6BA1F2"/>
 <text x="604.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 604.000 379)">FMOD</text>
-<rect x="626.500" y="186.624" width="9" height="179.376" fill="#707070"/>
-<rect x="635.500" y="185.463" width="9" height="180.537" fill="#FBB85C"/>
-<rect x="644.500" y="187.785" width="9" height="178.215" fill="#6BA1F2"/>
+<rect x="626.500" y="180.481" width="9" height="185.519" fill="#707070"/>
+<rect x="635.500" y="179.280" width="9" height="186.720" fill="#FBB85C"/>
+<rect x="644.500" y="181.682" width="9" height="184.318" fill="#6BA1F2"/>
 <text x="640.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 640.000 379)">SQRT</text>
-<rect x="726.500" y="98.259" width="9" height="267.741" fill="#707070"/>
-<rect x="735.500" y="100.744" width="9" height="265.256" fill="#FBB85C"/>
-<rect x="744.500" y="95.775" width="9" height="270.225" fill="#6BA1F2"/>
+<rect x="726.500" y="89.090" width="9" height="276.910" fill="#707070"/>
+<rect x="735.500" y="91.660" width="9" height="274.340" fill="#FBB85C"/>
+<rect x="744.500" y="86.520" width="9" height="279.480" fill="#6BA1F2"/>
 <text x="740.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 740.000 379)">SINH</text>
-<rect x="762.500" y="97.867" width="9" height="268.133" fill="#707070"/>
-<rect x="771.500" y="98.221" width="9" height="267.779" fill="#FBB85C"/>
-<rect x="780.500" y="97.513" width="9" height="268.487" fill="#6BA1F2"/>
+<rect x="762.500" y="88.684" width="9" height="277.316" fill="#707070"/>
+<rect x="771.500" y="89.050" width="9" height="276.950" fill="#FBB85C"/>
+<rect x="780.500" y="88.318" width="9" height="277.682" fill="#6BA1F2"/>
 <text x="776.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 776.000 379)">TANH</text>
-<rect x="798.500" y="92.184" width="9" height="273.816" fill="#707070"/>
-<rect x="807.500" y="91.503" width="9" height="274.497" fill="#FBB85C"/>
-<rect x="816.500" y="92.864" width="9" height="273.136" fill="#6BA1F2"/>
+<rect x="798.500" y="82.807" width="9" height="283.193" fill="#707070"/>
+<rect x="807.500" y="82.103" width="9" height="283.897" fill="#FBB85C"/>
+<rect x="816.500" y="83.510" width="9" height="282.490" fill="#6BA1F2"/>
 <text x="812.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 812.000 379)">GAMMA</text>
-<rect x="52.000" y="76.000" width="118.950" height="54.000" rx="4" fill="#333846" fill-opacity="0.8"/>
-<rect x="58" y="82.000" width="10" height="10" rx="1" fill="#707070"/>
-<text x="74.000" y="90.000" font-size="11" fill="#B1BAC4">all architectures</text>
-<rect x="58" y="98.000" width="10" height="10" rx="1" fill="#FBB85C"/>
-<text x="74.000" y="106.000" font-size="11" fill="#B1BAC4">arm64</text>
-<rect x="58" y="114.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
-<text x="74.000" y="122.000" font-size="11" fill="#B1BAC4">x86</text>
+<rect x="52.000" y="66.000" width="118.950" height="54.000" rx="4" fill="#333846" fill-opacity="0.8"/>
+<rect x="58" y="72.000" width="10" height="10" rx="1" fill="#707070"/>
+<text x="74.000" y="80.000" font-size="11" fill="#B1BAC4">all architectures</text>
+<rect x="58" y="88.000" width="10" height="10" rx="1" fill="#FBB85C"/>
+<text x="74.000" y="96.000" font-size="11" fill="#B1BAC4">arm64</text>
+<rect x="58" y="104.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
+<text x="74.000" y="112.000" font-size="11" fill="#B1BAC4">x86</text>
+<text x="12" y="458" font-size="9" fill="#8B949E"><tspan font-size="7.5" font-weight="600" dy="-3" fill="#B1BAC4">(1)</tspan><tspan dx="3" dy="3">based on 21 benchmarks, 16 spec sheets, 12 third party measurements</tspan></text>
 </svg>

--- a/docs/images/flop_weights_dark_docs.svg
+++ b/docs/images/flop_weights_dark_docs.svg
@@ -126,5 +126,5 @@
 <text x="74.000" y="96.000" font-size="11" fill="#B1BAC4">arm64</text>
 <rect x="58" y="104.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
 <text x="74.000" y="112.000" font-size="11" fill="#B1BAC4">x86</text>
-<text x="12" y="458" font-size="9" fill="#8B949E"><tspan font-size="7.5" font-weight="600" dy="-3" fill="#B1BAC4">(1)</tspan><tspan dx="3" dy="3">based on 21 benchmarks, 16 spec sheets, 12 third party measurements</tspan></text>
+<text x="12" y="458" font-size="9" fill="#8B949E"><tspan font-size="7.5" font-weight="600" dy="-3" fill="#B1BAC4">(1)</tspan><tspan dx="3" dy="3">based on 21 benchmarks, 16 spec sheets, 12 third party measurements (Agner Fog, uops.info)</tspan></text>
 </svg>

--- a/docs/images/flop_weights_dark_docs.svg
+++ b/docs/images/flop_weights_dark_docs.svg
@@ -40,89 +40,89 @@
 <line x1="666.000" y1="366" x2="714.000" y2="366" stroke="#6E7681" stroke-width="1" stroke-dasharray="4 4"/>
 <text x="690.000" y="382" font-size="8.5" fill="#8B949E" text-anchor="middle">28 more</text>
 <rect x="50.500" y="314.485" width="9" height="51.515" fill="#707070"/>
-<rect x="59.500" y="284.635" width="9" height="81.365" fill="#FBB85C"/>
+<rect x="59.500" y="284.635" width="9" height="81.365" fill="#E8837A"/>
 <rect x="68.500" y="344.336" width="9" height="21.664" fill="#6BA1F2"/>
 <text x="64.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 64.000 379)">MINUS</text>
 <rect x="86.500" y="291.831" width="9" height="74.169" fill="#707070"/>
-<rect x="95.500" y="273.939" width="9" height="92.061" fill="#FBB85C"/>
+<rect x="95.500" y="273.939" width="9" height="92.061" fill="#E8837A"/>
 <rect x="104.500" y="309.723" width="9" height="56.277" fill="#6BA1F2"/>
 <text x="100.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 100.000 379)">ABS</text>
 <rect x="122.500" y="275.876" width="9" height="90.124" fill="#707070"/>
-<rect x="131.500" y="297.303" width="9" height="68.697" fill="#FBB85C"/>
+<rect x="131.500" y="297.303" width="9" height="68.697" fill="#E8837A"/>
 <rect x="140.500" y="254.449" width="9" height="111.551" fill="#6BA1F2"/>
 <text x="136.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 136.000 379)">COMP</text>
 <rect x="158.500" y="274.757" width="9" height="91.243" fill="#707070"/>
-<rect x="167.500" y="274.757" width="9" height="91.243" fill="#FBB85C"/>
+<rect x="167.500" y="274.757" width="9" height="91.243" fill="#E8837A"/>
 <rect x="176.500" y="274.757" width="9" height="91.243" fill="#6BA1F2"/>
 <text x="172.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 172.000 379)">ADD</text>
 <rect x="194.500" y="274.721" width="9" height="91.279" fill="#707070"/>
-<rect x="203.500" y="274.671" width="9" height="91.329" fill="#FBB85C"/>
+<rect x="203.500" y="274.671" width="9" height="91.329" fill="#E8837A"/>
 <rect x="212.500" y="274.770" width="9" height="91.230" fill="#6BA1F2"/>
 <text x="208.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 208.000 379)">SUB</text>
 <rect x="230.500" y="267.617" width="9" height="98.383" fill="#707070"/>
-<rect x="239.500" y="249.980" width="9" height="116.020" fill="#FBB85C"/>
+<rect x="239.500" y="249.980" width="9" height="116.020" fill="#E8837A"/>
 <rect x="248.500" y="285.255" width="9" height="80.745" fill="#6BA1F2"/>
 <text x="244.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 244.000 379)">COPYSIGN</text>
 <rect x="266.500" y="258.541" width="9" height="107.459" fill="#707070"/>
-<rect x="275.500" y="255.588" width="9" height="110.412" fill="#FBB85C"/>
+<rect x="275.500" y="255.588" width="9" height="110.412" fill="#E8837A"/>
 <rect x="284.500" y="261.493" width="9" height="104.507" fill="#6BA1F2"/>
 <text x="280.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 280.000 379)">MUL</text>
 <rect x="302.500" y="249.228" width="9" height="116.772" fill="#707070"/>
-<rect x="311.500" y="244.347" width="9" height="121.653" fill="#FBB85C"/>
+<rect x="311.500" y="244.347" width="9" height="121.653" fill="#E8837A"/>
 <rect x="320.500" y="254.110" width="9" height="111.890" fill="#6BA1F2"/>
 <text x="316.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 316.000 379)">FMA</text>
 <rect x="338.500" y="246.533" width="9" height="119.467" fill="#707070"/>
-<rect x="347.500" y="251.668" width="9" height="114.332" fill="#FBB85C"/>
+<rect x="347.500" y="251.668" width="9" height="114.332" fill="#E8837A"/>
 <rect x="356.500" y="241.397" width="9" height="124.603" fill="#6BA1F2"/>
 <text x="352.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 352.000 379)">RND</text>
 <rect x="374.500" y="243.404" width="9" height="122.596" fill="#707070"/>
-<rect x="383.500" y="256.648" width="9" height="109.352" fill="#FBB85C"/>
+<rect x="383.500" y="256.648" width="9" height="109.352" fill="#E8837A"/>
 <rect x="392.500" y="230.160" width="9" height="135.840" fill="#6BA1F2"/>
 <text x="388.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 388.000 379)">F2I</text>
 <rect x="410.500" y="243.225" width="9" height="122.775" fill="#707070"/>
-<rect x="419.500" y="253.398" width="9" height="112.602" fill="#FBB85C"/>
+<rect x="419.500" y="253.398" width="9" height="112.602" fill="#E8837A"/>
 <rect x="428.500" y="233.052" width="9" height="132.948" fill="#6BA1F2"/>
 <text x="424.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 424.000 379)">I2F</text>
 <rect x="446.500" y="229.904" width="9" height="136.096" fill="#707070"/>
-<rect x="455.500" y="220.487" width="9" height="145.513" fill="#FBB85C"/>
+<rect x="455.500" y="220.487" width="9" height="145.513" fill="#E8837A"/>
 <rect x="464.500" y="239.321" width="9" height="126.679" fill="#6BA1F2"/>
 <text x="460.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 460.000 379)">HYPOT_XARG</text>
 <rect x="482.500" y="229.857" width="9" height="136.143" fill="#707070"/>
-<rect x="491.500" y="221.623" width="9" height="144.377" fill="#FBB85C"/>
+<rect x="491.500" y="221.623" width="9" height="144.377" fill="#E8837A"/>
 <rect x="500.500" y="238.090" width="9" height="127.910" fill="#6BA1F2"/>
 <text x="496.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 496.000 379)">DIST_XARG</text>
 <rect x="518.500" y="203.572" width="9" height="162.428" fill="#707070"/>
-<rect x="527.500" y="205.462" width="9" height="160.538" fill="#FBB85C"/>
+<rect x="527.500" y="205.462" width="9" height="160.538" fill="#E8837A"/>
 <rect x="536.500" y="201.682" width="9" height="164.318" fill="#6BA1F2"/>
 <text x="532.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 532.000 379)">SUMPROD_XELEM</text>
 <rect x="554.500" y="192.285" width="9" height="173.715" fill="#707070"/>
-<rect x="563.500" y="187.261" width="9" height="178.739" fill="#FBB85C"/>
+<rect x="563.500" y="187.261" width="9" height="178.739" fill="#E8837A"/>
 <rect x="572.500" y="197.309" width="9" height="168.691" fill="#6BA1F2"/>
 <text x="568.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 568.000 379)">DIV</text>
 <rect x="590.500" y="187.956" width="9" height="178.044" fill="#707070"/>
-<rect x="599.500" y="176.429" width="9" height="189.571" fill="#FBB85C"/>
+<rect x="599.500" y="176.429" width="9" height="189.571" fill="#E8837A"/>
 <rect x="608.500" y="199.484" width="9" height="166.516" fill="#6BA1F2"/>
 <text x="604.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 604.000 379)">FMOD</text>
 <rect x="626.500" y="180.481" width="9" height="185.519" fill="#707070"/>
-<rect x="635.500" y="179.280" width="9" height="186.720" fill="#FBB85C"/>
+<rect x="635.500" y="179.280" width="9" height="186.720" fill="#E8837A"/>
 <rect x="644.500" y="181.682" width="9" height="184.318" fill="#6BA1F2"/>
 <text x="640.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 640.000 379)">SQRT</text>
 <rect x="726.500" y="89.090" width="9" height="276.910" fill="#707070"/>
-<rect x="735.500" y="91.660" width="9" height="274.340" fill="#FBB85C"/>
+<rect x="735.500" y="91.660" width="9" height="274.340" fill="#E8837A"/>
 <rect x="744.500" y="86.520" width="9" height="279.480" fill="#6BA1F2"/>
 <text x="740.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 740.000 379)">SINH</text>
 <rect x="762.500" y="88.684" width="9" height="277.316" fill="#707070"/>
-<rect x="771.500" y="89.050" width="9" height="276.950" fill="#FBB85C"/>
+<rect x="771.500" y="89.050" width="9" height="276.950" fill="#E8837A"/>
 <rect x="780.500" y="88.318" width="9" height="277.682" fill="#6BA1F2"/>
 <text x="776.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 776.000 379)">TANH</text>
 <rect x="798.500" y="82.807" width="9" height="283.193" fill="#707070"/>
-<rect x="807.500" y="82.103" width="9" height="283.897" fill="#FBB85C"/>
+<rect x="807.500" y="82.103" width="9" height="283.897" fill="#E8837A"/>
 <rect x="816.500" y="83.510" width="9" height="282.490" fill="#6BA1F2"/>
 <text x="812.000" y="379" font-size="9" fill="#B1BAC4" text-anchor="end" transform="rotate(-45 812.000 379)">GAMMA</text>
 <rect x="52.000" y="66.000" width="118.950" height="54.000" rx="4" fill="#333846" fill-opacity="0.8"/>
 <rect x="58" y="72.000" width="10" height="10" rx="1" fill="#707070"/>
 <text x="74.000" y="80.000" font-size="11" fill="#B1BAC4">all architectures</text>
-<rect x="58" y="88.000" width="10" height="10" rx="1" fill="#FBB85C"/>
+<rect x="58" y="88.000" width="10" height="10" rx="1" fill="#E8837A"/>
 <text x="74.000" y="96.000" font-size="11" fill="#B1BAC4">arm64</text>
 <rect x="58" y="104.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
 <text x="74.000" y="112.000" font-size="11" fill="#B1BAC4">x86</text>

--- a/docs/images/flop_weights_light.svg
+++ b/docs/images/flop_weights_light.svg
@@ -126,5 +126,5 @@
 <text x="74.000" y="96.000" font-size="11" fill="#57606A">arm64</text>
 <rect x="58" y="104.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
 <text x="74.000" y="112.000" font-size="11" fill="#57606A">x86</text>
-<text x="12" y="458" font-size="9" fill="#8C959F"><tspan font-size="7.5" font-weight="600" dy="-3" fill="#57606A">(1)</tspan><tspan dx="3" dy="3">based on 21 benchmarks, 16 spec sheets, 12 third party measurements</tspan></text>
+<text x="12" y="458" font-size="9" fill="#8C959F"><tspan font-size="7.5" font-weight="600" dy="-3" fill="#57606A">(1)</tspan><tspan dx="3" dy="3">based on 21 benchmarks, 16 spec sheets, 12 third party measurements (Agner Fog, uops.info)</tspan></text>
 </svg>

--- a/docs/images/flop_weights_light.svg
+++ b/docs/images/flop_weights_light.svg
@@ -40,89 +40,89 @@
 <line x1="666.000" y1="366" x2="714.000" y2="366" stroke="#AFB8C1" stroke-width="1" stroke-dasharray="4 4"/>
 <text x="690.000" y="382" font-size="8.5" fill="#8C959F" text-anchor="middle">28 more</text>
 <rect x="50.500" y="314.485" width="9" height="51.515" fill="#707070"/>
-<rect x="59.500" y="284.635" width="9" height="81.365" fill="#FBB85C"/>
+<rect x="59.500" y="284.635" width="9" height="81.365" fill="#E8837A"/>
 <rect x="68.500" y="344.336" width="9" height="21.664" fill="#6BA1F2"/>
 <text x="64.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 64.000 379)">MINUS</text>
 <rect x="86.500" y="291.831" width="9" height="74.169" fill="#707070"/>
-<rect x="95.500" y="273.939" width="9" height="92.061" fill="#FBB85C"/>
+<rect x="95.500" y="273.939" width="9" height="92.061" fill="#E8837A"/>
 <rect x="104.500" y="309.723" width="9" height="56.277" fill="#6BA1F2"/>
 <text x="100.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 100.000 379)">ABS</text>
 <rect x="122.500" y="275.876" width="9" height="90.124" fill="#707070"/>
-<rect x="131.500" y="297.303" width="9" height="68.697" fill="#FBB85C"/>
+<rect x="131.500" y="297.303" width="9" height="68.697" fill="#E8837A"/>
 <rect x="140.500" y="254.449" width="9" height="111.551" fill="#6BA1F2"/>
 <text x="136.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 136.000 379)">COMP</text>
 <rect x="158.500" y="274.757" width="9" height="91.243" fill="#707070"/>
-<rect x="167.500" y="274.757" width="9" height="91.243" fill="#FBB85C"/>
+<rect x="167.500" y="274.757" width="9" height="91.243" fill="#E8837A"/>
 <rect x="176.500" y="274.757" width="9" height="91.243" fill="#6BA1F2"/>
 <text x="172.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 172.000 379)">ADD</text>
 <rect x="194.500" y="274.721" width="9" height="91.279" fill="#707070"/>
-<rect x="203.500" y="274.671" width="9" height="91.329" fill="#FBB85C"/>
+<rect x="203.500" y="274.671" width="9" height="91.329" fill="#E8837A"/>
 <rect x="212.500" y="274.770" width="9" height="91.230" fill="#6BA1F2"/>
 <text x="208.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 208.000 379)">SUB</text>
 <rect x="230.500" y="267.617" width="9" height="98.383" fill="#707070"/>
-<rect x="239.500" y="249.980" width="9" height="116.020" fill="#FBB85C"/>
+<rect x="239.500" y="249.980" width="9" height="116.020" fill="#E8837A"/>
 <rect x="248.500" y="285.255" width="9" height="80.745" fill="#6BA1F2"/>
 <text x="244.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 244.000 379)">COPYSIGN</text>
 <rect x="266.500" y="258.541" width="9" height="107.459" fill="#707070"/>
-<rect x="275.500" y="255.588" width="9" height="110.412" fill="#FBB85C"/>
+<rect x="275.500" y="255.588" width="9" height="110.412" fill="#E8837A"/>
 <rect x="284.500" y="261.493" width="9" height="104.507" fill="#6BA1F2"/>
 <text x="280.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 280.000 379)">MUL</text>
 <rect x="302.500" y="249.228" width="9" height="116.772" fill="#707070"/>
-<rect x="311.500" y="244.347" width="9" height="121.653" fill="#FBB85C"/>
+<rect x="311.500" y="244.347" width="9" height="121.653" fill="#E8837A"/>
 <rect x="320.500" y="254.110" width="9" height="111.890" fill="#6BA1F2"/>
 <text x="316.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 316.000 379)">FMA</text>
 <rect x="338.500" y="246.533" width="9" height="119.467" fill="#707070"/>
-<rect x="347.500" y="251.668" width="9" height="114.332" fill="#FBB85C"/>
+<rect x="347.500" y="251.668" width="9" height="114.332" fill="#E8837A"/>
 <rect x="356.500" y="241.397" width="9" height="124.603" fill="#6BA1F2"/>
 <text x="352.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 352.000 379)">RND</text>
 <rect x="374.500" y="243.404" width="9" height="122.596" fill="#707070"/>
-<rect x="383.500" y="256.648" width="9" height="109.352" fill="#FBB85C"/>
+<rect x="383.500" y="256.648" width="9" height="109.352" fill="#E8837A"/>
 <rect x="392.500" y="230.160" width="9" height="135.840" fill="#6BA1F2"/>
 <text x="388.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 388.000 379)">F2I</text>
 <rect x="410.500" y="243.225" width="9" height="122.775" fill="#707070"/>
-<rect x="419.500" y="253.398" width="9" height="112.602" fill="#FBB85C"/>
+<rect x="419.500" y="253.398" width="9" height="112.602" fill="#E8837A"/>
 <rect x="428.500" y="233.052" width="9" height="132.948" fill="#6BA1F2"/>
 <text x="424.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 424.000 379)">I2F</text>
 <rect x="446.500" y="229.904" width="9" height="136.096" fill="#707070"/>
-<rect x="455.500" y="220.487" width="9" height="145.513" fill="#FBB85C"/>
+<rect x="455.500" y="220.487" width="9" height="145.513" fill="#E8837A"/>
 <rect x="464.500" y="239.321" width="9" height="126.679" fill="#6BA1F2"/>
 <text x="460.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 460.000 379)">HYPOT_XARG</text>
 <rect x="482.500" y="229.857" width="9" height="136.143" fill="#707070"/>
-<rect x="491.500" y="221.623" width="9" height="144.377" fill="#FBB85C"/>
+<rect x="491.500" y="221.623" width="9" height="144.377" fill="#E8837A"/>
 <rect x="500.500" y="238.090" width="9" height="127.910" fill="#6BA1F2"/>
 <text x="496.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 496.000 379)">DIST_XARG</text>
 <rect x="518.500" y="203.572" width="9" height="162.428" fill="#707070"/>
-<rect x="527.500" y="205.462" width="9" height="160.538" fill="#FBB85C"/>
+<rect x="527.500" y="205.462" width="9" height="160.538" fill="#E8837A"/>
 <rect x="536.500" y="201.682" width="9" height="164.318" fill="#6BA1F2"/>
 <text x="532.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 532.000 379)">SUMPROD_XELEM</text>
 <rect x="554.500" y="192.285" width="9" height="173.715" fill="#707070"/>
-<rect x="563.500" y="187.261" width="9" height="178.739" fill="#FBB85C"/>
+<rect x="563.500" y="187.261" width="9" height="178.739" fill="#E8837A"/>
 <rect x="572.500" y="197.309" width="9" height="168.691" fill="#6BA1F2"/>
 <text x="568.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 568.000 379)">DIV</text>
 <rect x="590.500" y="187.956" width="9" height="178.044" fill="#707070"/>
-<rect x="599.500" y="176.429" width="9" height="189.571" fill="#FBB85C"/>
+<rect x="599.500" y="176.429" width="9" height="189.571" fill="#E8837A"/>
 <rect x="608.500" y="199.484" width="9" height="166.516" fill="#6BA1F2"/>
 <text x="604.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 604.000 379)">FMOD</text>
 <rect x="626.500" y="180.481" width="9" height="185.519" fill="#707070"/>
-<rect x="635.500" y="179.280" width="9" height="186.720" fill="#FBB85C"/>
+<rect x="635.500" y="179.280" width="9" height="186.720" fill="#E8837A"/>
 <rect x="644.500" y="181.682" width="9" height="184.318" fill="#6BA1F2"/>
 <text x="640.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 640.000 379)">SQRT</text>
 <rect x="726.500" y="89.090" width="9" height="276.910" fill="#707070"/>
-<rect x="735.500" y="91.660" width="9" height="274.340" fill="#FBB85C"/>
+<rect x="735.500" y="91.660" width="9" height="274.340" fill="#E8837A"/>
 <rect x="744.500" y="86.520" width="9" height="279.480" fill="#6BA1F2"/>
 <text x="740.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 740.000 379)">SINH</text>
 <rect x="762.500" y="88.684" width="9" height="277.316" fill="#707070"/>
-<rect x="771.500" y="89.050" width="9" height="276.950" fill="#FBB85C"/>
+<rect x="771.500" y="89.050" width="9" height="276.950" fill="#E8837A"/>
 <rect x="780.500" y="88.318" width="9" height="277.682" fill="#6BA1F2"/>
 <text x="776.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 776.000 379)">TANH</text>
 <rect x="798.500" y="82.807" width="9" height="283.193" fill="#707070"/>
-<rect x="807.500" y="82.103" width="9" height="283.897" fill="#FBB85C"/>
+<rect x="807.500" y="82.103" width="9" height="283.897" fill="#E8837A"/>
 <rect x="816.500" y="83.510" width="9" height="282.490" fill="#6BA1F2"/>
 <text x="812.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 812.000 379)">GAMMA</text>
 <rect x="52.000" y="66.000" width="118.950" height="54.000" rx="4" fill="#F0F3F6" fill-opacity="0.8"/>
 <rect x="58" y="72.000" width="10" height="10" rx="1" fill="#707070"/>
 <text x="74.000" y="80.000" font-size="11" fill="#57606A">all architectures</text>
-<rect x="58" y="88.000" width="10" height="10" rx="1" fill="#FBB85C"/>
+<rect x="58" y="88.000" width="10" height="10" rx="1" fill="#E8837A"/>
 <text x="74.000" y="96.000" font-size="11" fill="#57606A">arm64</text>
 <rect x="58" y="104.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
 <text x="74.000" y="112.000" font-size="11" fill="#57606A">x86</text>

--- a/docs/images/flop_weights_light.svg
+++ b/docs/images/flop_weights_light.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840.000 476" width="840.000" height="476" font-family="system-ui, -apple-system, sans-serif">
+<rect x="0" y="0" width="840.000" height="476" fill="#FFFFFF"/>
+<text x="46" y="26" font-size="15" font-weight="600" fill="#1F2328">Built-in flop weights</text>
+<text x="46" y="44" font-size="11" fill="#57606A">relative to ADD = 1, log scale</text>
+<line x1="46" y1="352.622" x2="830.000" y2="352.622" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="355.622" font-size="8" fill="#8C959F" text-anchor="end">0.2</text>
+<line x1="46" y1="333.766" x2="830.000" y2="333.766" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="320.388" x2="830.000" y2="320.388" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="310.011" x2="830.000" y2="310.011" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="313.011" font-size="8" fill="#8C959F" text-anchor="end">0.5</text>
+<line x1="46" y1="301.533" x2="830.000" y2="301.533" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="294.364" x2="830.000" y2="294.364" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="288.155" x2="830.000" y2="288.155" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="282.678" x2="830.000" y2="282.678" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="245.544" x2="830.000" y2="245.544" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="248.544" font-size="8" fill="#8C959F" text-anchor="end">2</text>
+<line x1="46" y1="226.689" x2="830.000" y2="226.689" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="213.311" x2="830.000" y2="213.311" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="202.934" x2="830.000" y2="202.934" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="205.934" font-size="8" fill="#8C959F" text-anchor="end">5</text>
+<line x1="46" y1="194.456" x2="830.000" y2="194.456" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="187.287" x2="830.000" y2="187.287" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="181.077" x2="830.000" y2="181.077" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="175.600" x2="830.000" y2="175.600" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="138.467" x2="830.000" y2="138.467" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="141.467" font-size="8" fill="#8C959F" text-anchor="end">20</text>
+<line x1="46" y1="119.612" x2="830.000" y2="119.612" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="106.234" x2="830.000" y2="106.234" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="95.857" x2="830.000" y2="95.857" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="98.857" font-size="8" fill="#8C959F" text-anchor="end">50</text>
+<line x1="46" y1="87.378" x2="830.000" y2="87.378" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="80.210" x2="830.000" y2="80.210" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="74.000" x2="830.000" y2="74.000" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="277.778" x2="830.000" y2="277.778" stroke="#AFB8C1" stroke-width="1"/>
+<text x="38" y="281.278" font-size="10" fill="#57606A" text-anchor="end">1</text>
+<line x1="46" y1="170.701" x2="830.000" y2="170.701" stroke="#AFB8C1" stroke-width="1"/>
+<text x="38" y="174.201" font-size="10" fill="#57606A" text-anchor="end">10</text>
+<line x1="46.000" y1="366" x2="666.000" y2="366" stroke="#AFB8C1" stroke-width="1"/>
+<line x1="714.000" y1="366" x2="830.000" y2="366" stroke="#AFB8C1" stroke-width="1"/>
+<line x1="666.000" y1="366" x2="714.000" y2="366" stroke="#AFB8C1" stroke-width="1" stroke-dasharray="4 4"/>
+<text x="690.000" y="382" font-size="8.5" fill="#8C959F" text-anchor="middle">28 more</text>
+<rect x="50.500" y="316.191" width="9" height="49.809" fill="#707070"/>
+<rect x="59.500" y="287.329" width="9" height="78.671" fill="#FBB85C"/>
+<rect x="68.500" y="345.053" width="9" height="20.947" fill="#6BA1F2"/>
+<text x="64.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 64.000 379)">MINUS</text>
+<rect x="86.500" y="294.287" width="9" height="71.713" fill="#707070"/>
+<rect x="95.500" y="276.987" width="9" height="89.013" fill="#FBB85C"/>
+<rect x="104.500" y="311.587" width="9" height="54.413" fill="#6BA1F2"/>
+<text x="100.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 100.000 379)">ABS</text>
+<rect x="122.500" y="278.860" width="9" height="87.140" fill="#707070"/>
+<rect x="131.500" y="299.578" width="9" height="66.422" fill="#FBB85C"/>
+<rect x="140.500" y="258.142" width="9" height="107.858" fill="#6BA1F2"/>
+<text x="136.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 136.000 379)">COMP</text>
+<rect x="158.500" y="277.778" width="9" height="88.222" fill="#707070"/>
+<rect x="167.500" y="277.778" width="9" height="88.222" fill="#FBB85C"/>
+<rect x="176.500" y="277.778" width="9" height="88.222" fill="#6BA1F2"/>
+<text x="172.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 172.000 379)">ADD</text>
+<rect x="194.500" y="277.743" width="9" height="88.257" fill="#707070"/>
+<rect x="203.500" y="277.695" width="9" height="88.305" fill="#FBB85C"/>
+<rect x="212.500" y="277.791" width="9" height="88.209" fill="#6BA1F2"/>
+<text x="208.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 208.000 379)">SUB</text>
+<rect x="230.500" y="270.875" width="9" height="95.125" fill="#707070"/>
+<rect x="239.500" y="253.821" width="9" height="112.179" fill="#FBB85C"/>
+<rect x="248.500" y="287.928" width="9" height="78.072" fill="#6BA1F2"/>
+<text x="244.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 244.000 379)">COPYSIGN</text>
+<rect x="266.500" y="262.099" width="9" height="103.901" fill="#707070"/>
+<rect x="275.500" y="259.244" width="9" height="106.756" fill="#FBB85C"/>
+<rect x="284.500" y="264.953" width="9" height="101.047" fill="#6BA1F2"/>
+<text x="280.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 280.000 379)">MUL</text>
+<rect x="302.500" y="253.095" width="9" height="112.905" fill="#707070"/>
+<rect x="311.500" y="248.375" width="9" height="117.625" fill="#FBB85C"/>
+<rect x="320.500" y="257.815" width="9" height="108.185" fill="#6BA1F2"/>
+<text x="316.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 316.000 379)">FMA</text>
+<rect x="338.500" y="250.489" width="9" height="115.511" fill="#707070"/>
+<rect x="347.500" y="255.454" width="9" height="110.546" fill="#FBB85C"/>
+<rect x="356.500" y="245.523" width="9" height="120.477" fill="#6BA1F2"/>
+<text x="352.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 352.000 379)">RND</text>
+<rect x="374.500" y="247.463" width="9" height="118.537" fill="#707070"/>
+<rect x="383.500" y="260.269" width="9" height="105.731" fill="#FBB85C"/>
+<rect x="392.500" y="234.658" width="9" height="131.342" fill="#6BA1F2"/>
+<text x="388.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 388.000 379)">F2I</text>
+<rect x="410.500" y="247.290" width="9" height="118.710" fill="#707070"/>
+<rect x="419.500" y="257.126" width="9" height="108.874" fill="#FBB85C"/>
+<rect x="428.500" y="237.454" width="9" height="128.546" fill="#6BA1F2"/>
+<text x="424.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 424.000 379)">I2F</text>
+<rect x="446.500" y="234.411" width="9" height="131.589" fill="#707070"/>
+<rect x="455.500" y="225.305" width="9" height="140.695" fill="#FBB85C"/>
+<rect x="464.500" y="243.516" width="9" height="122.484" fill="#6BA1F2"/>
+<text x="460.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 460.000 379)">HYPOT_XARG</text>
+<rect x="482.500" y="234.365" width="9" height="131.635" fill="#707070"/>
+<rect x="491.500" y="226.404" width="9" height="139.596" fill="#FBB85C"/>
+<rect x="500.500" y="242.325" width="9" height="123.675" fill="#6BA1F2"/>
+<text x="496.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 496.000 379)">DIST_XARG</text>
+<rect x="518.500" y="208.951" width="9" height="157.049" fill="#707070"/>
+<rect x="527.500" y="210.778" width="9" height="155.222" fill="#FBB85C"/>
+<rect x="536.500" y="207.123" width="9" height="158.877" fill="#6BA1F2"/>
+<text x="532.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 532.000 379)">SUMPROD_XELEM</text>
+<rect x="554.500" y="198.037" width="9" height="167.963" fill="#707070"/>
+<rect x="563.500" y="193.180" width="9" height="172.820" fill="#FBB85C"/>
+<rect x="572.500" y="202.895" width="9" height="163.105" fill="#6BA1F2"/>
+<text x="568.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 568.000 379)">DIV</text>
+<rect x="590.500" y="193.852" width="9" height="172.148" fill="#707070"/>
+<rect x="599.500" y="182.706" width="9" height="183.294" fill="#FBB85C"/>
+<rect x="608.500" y="204.998" width="9" height="161.002" fill="#6BA1F2"/>
+<text x="604.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 604.000 379)">FMOD</text>
+<rect x="626.500" y="186.624" width="9" height="179.376" fill="#707070"/>
+<rect x="635.500" y="185.463" width="9" height="180.537" fill="#FBB85C"/>
+<rect x="644.500" y="187.785" width="9" height="178.215" fill="#6BA1F2"/>
+<text x="640.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 640.000 379)">SQRT</text>
+<rect x="726.500" y="98.259" width="9" height="267.741" fill="#707070"/>
+<rect x="735.500" y="100.744" width="9" height="265.256" fill="#FBB85C"/>
+<rect x="744.500" y="95.775" width="9" height="270.225" fill="#6BA1F2"/>
+<text x="740.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 740.000 379)">SINH</text>
+<rect x="762.500" y="97.867" width="9" height="268.133" fill="#707070"/>
+<rect x="771.500" y="98.221" width="9" height="267.779" fill="#FBB85C"/>
+<rect x="780.500" y="97.513" width="9" height="268.487" fill="#6BA1F2"/>
+<text x="776.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 776.000 379)">TANH</text>
+<rect x="798.500" y="92.184" width="9" height="273.816" fill="#707070"/>
+<rect x="807.500" y="91.503" width="9" height="274.497" fill="#FBB85C"/>
+<rect x="816.500" y="92.864" width="9" height="273.136" fill="#6BA1F2"/>
+<text x="812.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 812.000 379)">GAMMA</text>
+<rect x="52.000" y="76.000" width="118.950" height="54.000" rx="4" fill="#F0F3F6" fill-opacity="0.8"/>
+<rect x="58" y="82.000" width="10" height="10" rx="1" fill="#707070"/>
+<text x="74.000" y="90.000" font-size="11" fill="#57606A">all architectures</text>
+<rect x="58" y="98.000" width="10" height="10" rx="1" fill="#FBB85C"/>
+<text x="74.000" y="106.000" font-size="11" fill="#57606A">arm64</text>
+<rect x="58" y="114.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
+<text x="74.000" y="122.000" font-size="11" fill="#57606A">x86</text>
+</svg>

--- a/docs/images/flop_weights_light.svg
+++ b/docs/images/flop_weights_light.svg
@@ -1,129 +1,130 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840.000 476" width="840.000" height="476" font-family="system-ui, -apple-system, sans-serif">
-<rect x="0" y="0" width="840.000" height="476" fill="#FFFFFF"/>
-<text x="46" y="26" font-size="15" font-weight="600" fill="#1F2328">Built-in flop weights</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840.000 470" width="840.000" height="470" font-family="system-ui, -apple-system, sans-serif">
+<rect x="0" y="0" width="840.000" height="470" fill="#FFFFFF"/>
+<text x="46" y="26" font-size="15" font-weight="600" fill="#1F2328">Built-in flop weights<tspan font-size="9" font-weight="400" dx="2" dy="-6" fill="#8C959F">(1)</tspan></text>
 <text x="46" y="44" font-size="11" fill="#57606A">relative to ADD = 1, log scale</text>
-<line x1="46" y1="352.622" x2="830.000" y2="352.622" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="355.622" font-size="8" fill="#8C959F" text-anchor="end">0.2</text>
-<line x1="46" y1="333.766" x2="830.000" y2="333.766" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="320.388" x2="830.000" y2="320.388" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="310.011" x2="830.000" y2="310.011" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="313.011" font-size="8" fill="#8C959F" text-anchor="end">0.5</text>
-<line x1="46" y1="301.533" x2="830.000" y2="301.533" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="294.364" x2="830.000" y2="294.364" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="288.155" x2="830.000" y2="288.155" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="282.678" x2="830.000" y2="282.678" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="245.544" x2="830.000" y2="245.544" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="248.544" font-size="8" fill="#8C959F" text-anchor="end">2</text>
-<line x1="46" y1="226.689" x2="830.000" y2="226.689" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="213.311" x2="830.000" y2="213.311" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="202.934" x2="830.000" y2="202.934" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="205.934" font-size="8" fill="#8C959F" text-anchor="end">5</text>
-<line x1="46" y1="194.456" x2="830.000" y2="194.456" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="187.287" x2="830.000" y2="187.287" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="181.077" x2="830.000" y2="181.077" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="175.600" x2="830.000" y2="175.600" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="138.467" x2="830.000" y2="138.467" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="141.467" font-size="8" fill="#8C959F" text-anchor="end">20</text>
-<line x1="46" y1="119.612" x2="830.000" y2="119.612" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="106.234" x2="830.000" y2="106.234" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="95.857" x2="830.000" y2="95.857" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<text x="38" y="98.857" font-size="8" fill="#8C959F" text-anchor="end">50</text>
-<line x1="46" y1="87.378" x2="830.000" y2="87.378" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="80.210" x2="830.000" y2="80.210" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="74.000" x2="830.000" y2="74.000" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
-<line x1="46" y1="277.778" x2="830.000" y2="277.778" stroke="#AFB8C1" stroke-width="1"/>
-<text x="38" y="281.278" font-size="10" fill="#57606A" text-anchor="end">1</text>
-<line x1="46" y1="170.701" x2="830.000" y2="170.701" stroke="#AFB8C1" stroke-width="1"/>
-<text x="38" y="174.201" font-size="10" fill="#57606A" text-anchor="end">10</text>
+<line x1="46" y1="352.164" x2="830.000" y2="352.164" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="355.164" font-size="8" fill="#8C959F" text-anchor="end">0.2</text>
+<line x1="46" y1="332.663" x2="830.000" y2="332.663" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="318.826" x2="830.000" y2="318.826" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="308.094" x2="830.000" y2="308.094" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="311.094" font-size="8" fill="#8C959F" text-anchor="end">0.5</text>
+<line x1="46" y1="299.325" x2="830.000" y2="299.325" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="291.911" x2="830.000" y2="291.911" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="285.489" x2="830.000" y2="285.489" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="279.824" x2="830.000" y2="279.824" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="241.419" x2="830.000" y2="241.419" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="244.419" font-size="8" fill="#8C959F" text-anchor="end">2</text>
+<line x1="46" y1="221.918" x2="830.000" y2="221.918" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="208.082" x2="830.000" y2="208.082" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="197.350" x2="830.000" y2="197.350" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="200.350" font-size="8" fill="#8C959F" text-anchor="end">5</text>
+<line x1="46" y1="188.581" x2="830.000" y2="188.581" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="181.167" x2="830.000" y2="181.167" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="174.744" x2="830.000" y2="174.744" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="169.080" x2="830.000" y2="169.080" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="130.675" x2="830.000" y2="130.675" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="133.675" font-size="8" fill="#8C959F" text-anchor="end">20</text>
+<line x1="46" y1="111.174" x2="830.000" y2="111.174" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="97.337" x2="830.000" y2="97.337" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="86.605" x2="830.000" y2="86.605" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<text x="38" y="89.605" font-size="8" fill="#8C959F" text-anchor="end">50</text>
+<line x1="46" y1="77.836" x2="830.000" y2="77.836" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="70.422" x2="830.000" y2="70.422" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="64.000" x2="830.000" y2="64.000" stroke="#D0D7DE" stroke-width="0.75" stroke-dasharray="3 2"/>
+<line x1="46" y1="274.757" x2="830.000" y2="274.757" stroke="#AFB8C1" stroke-width="1"/>
+<text x="38" y="278.257" font-size="10" fill="#57606A" text-anchor="end">1</text>
+<line x1="46" y1="164.012" x2="830.000" y2="164.012" stroke="#AFB8C1" stroke-width="1"/>
+<text x="38" y="167.512" font-size="10" fill="#57606A" text-anchor="end">10</text>
 <line x1="46.000" y1="366" x2="666.000" y2="366" stroke="#AFB8C1" stroke-width="1"/>
 <line x1="714.000" y1="366" x2="830.000" y2="366" stroke="#AFB8C1" stroke-width="1"/>
 <line x1="666.000" y1="366" x2="714.000" y2="366" stroke="#AFB8C1" stroke-width="1" stroke-dasharray="4 4"/>
 <text x="690.000" y="382" font-size="8.5" fill="#8C959F" text-anchor="middle">28 more</text>
-<rect x="50.500" y="316.191" width="9" height="49.809" fill="#707070"/>
-<rect x="59.500" y="287.329" width="9" height="78.671" fill="#FBB85C"/>
-<rect x="68.500" y="345.053" width="9" height="20.947" fill="#6BA1F2"/>
+<rect x="50.500" y="314.485" width="9" height="51.515" fill="#707070"/>
+<rect x="59.500" y="284.635" width="9" height="81.365" fill="#FBB85C"/>
+<rect x="68.500" y="344.336" width="9" height="21.664" fill="#6BA1F2"/>
 <text x="64.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 64.000 379)">MINUS</text>
-<rect x="86.500" y="294.287" width="9" height="71.713" fill="#707070"/>
-<rect x="95.500" y="276.987" width="9" height="89.013" fill="#FBB85C"/>
-<rect x="104.500" y="311.587" width="9" height="54.413" fill="#6BA1F2"/>
+<rect x="86.500" y="291.831" width="9" height="74.169" fill="#707070"/>
+<rect x="95.500" y="273.939" width="9" height="92.061" fill="#FBB85C"/>
+<rect x="104.500" y="309.723" width="9" height="56.277" fill="#6BA1F2"/>
 <text x="100.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 100.000 379)">ABS</text>
-<rect x="122.500" y="278.860" width="9" height="87.140" fill="#707070"/>
-<rect x="131.500" y="299.578" width="9" height="66.422" fill="#FBB85C"/>
-<rect x="140.500" y="258.142" width="9" height="107.858" fill="#6BA1F2"/>
+<rect x="122.500" y="275.876" width="9" height="90.124" fill="#707070"/>
+<rect x="131.500" y="297.303" width="9" height="68.697" fill="#FBB85C"/>
+<rect x="140.500" y="254.449" width="9" height="111.551" fill="#6BA1F2"/>
 <text x="136.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 136.000 379)">COMP</text>
-<rect x="158.500" y="277.778" width="9" height="88.222" fill="#707070"/>
-<rect x="167.500" y="277.778" width="9" height="88.222" fill="#FBB85C"/>
-<rect x="176.500" y="277.778" width="9" height="88.222" fill="#6BA1F2"/>
+<rect x="158.500" y="274.757" width="9" height="91.243" fill="#707070"/>
+<rect x="167.500" y="274.757" width="9" height="91.243" fill="#FBB85C"/>
+<rect x="176.500" y="274.757" width="9" height="91.243" fill="#6BA1F2"/>
 <text x="172.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 172.000 379)">ADD</text>
-<rect x="194.500" y="277.743" width="9" height="88.257" fill="#707070"/>
-<rect x="203.500" y="277.695" width="9" height="88.305" fill="#FBB85C"/>
-<rect x="212.500" y="277.791" width="9" height="88.209" fill="#6BA1F2"/>
+<rect x="194.500" y="274.721" width="9" height="91.279" fill="#707070"/>
+<rect x="203.500" y="274.671" width="9" height="91.329" fill="#FBB85C"/>
+<rect x="212.500" y="274.770" width="9" height="91.230" fill="#6BA1F2"/>
 <text x="208.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 208.000 379)">SUB</text>
-<rect x="230.500" y="270.875" width="9" height="95.125" fill="#707070"/>
-<rect x="239.500" y="253.821" width="9" height="112.179" fill="#FBB85C"/>
-<rect x="248.500" y="287.928" width="9" height="78.072" fill="#6BA1F2"/>
+<rect x="230.500" y="267.617" width="9" height="98.383" fill="#707070"/>
+<rect x="239.500" y="249.980" width="9" height="116.020" fill="#FBB85C"/>
+<rect x="248.500" y="285.255" width="9" height="80.745" fill="#6BA1F2"/>
 <text x="244.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 244.000 379)">COPYSIGN</text>
-<rect x="266.500" y="262.099" width="9" height="103.901" fill="#707070"/>
-<rect x="275.500" y="259.244" width="9" height="106.756" fill="#FBB85C"/>
-<rect x="284.500" y="264.953" width="9" height="101.047" fill="#6BA1F2"/>
+<rect x="266.500" y="258.541" width="9" height="107.459" fill="#707070"/>
+<rect x="275.500" y="255.588" width="9" height="110.412" fill="#FBB85C"/>
+<rect x="284.500" y="261.493" width="9" height="104.507" fill="#6BA1F2"/>
 <text x="280.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 280.000 379)">MUL</text>
-<rect x="302.500" y="253.095" width="9" height="112.905" fill="#707070"/>
-<rect x="311.500" y="248.375" width="9" height="117.625" fill="#FBB85C"/>
-<rect x="320.500" y="257.815" width="9" height="108.185" fill="#6BA1F2"/>
+<rect x="302.500" y="249.228" width="9" height="116.772" fill="#707070"/>
+<rect x="311.500" y="244.347" width="9" height="121.653" fill="#FBB85C"/>
+<rect x="320.500" y="254.110" width="9" height="111.890" fill="#6BA1F2"/>
 <text x="316.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 316.000 379)">FMA</text>
-<rect x="338.500" y="250.489" width="9" height="115.511" fill="#707070"/>
-<rect x="347.500" y="255.454" width="9" height="110.546" fill="#FBB85C"/>
-<rect x="356.500" y="245.523" width="9" height="120.477" fill="#6BA1F2"/>
+<rect x="338.500" y="246.533" width="9" height="119.467" fill="#707070"/>
+<rect x="347.500" y="251.668" width="9" height="114.332" fill="#FBB85C"/>
+<rect x="356.500" y="241.397" width="9" height="124.603" fill="#6BA1F2"/>
 <text x="352.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 352.000 379)">RND</text>
-<rect x="374.500" y="247.463" width="9" height="118.537" fill="#707070"/>
-<rect x="383.500" y="260.269" width="9" height="105.731" fill="#FBB85C"/>
-<rect x="392.500" y="234.658" width="9" height="131.342" fill="#6BA1F2"/>
+<rect x="374.500" y="243.404" width="9" height="122.596" fill="#707070"/>
+<rect x="383.500" y="256.648" width="9" height="109.352" fill="#FBB85C"/>
+<rect x="392.500" y="230.160" width="9" height="135.840" fill="#6BA1F2"/>
 <text x="388.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 388.000 379)">F2I</text>
-<rect x="410.500" y="247.290" width="9" height="118.710" fill="#707070"/>
-<rect x="419.500" y="257.126" width="9" height="108.874" fill="#FBB85C"/>
-<rect x="428.500" y="237.454" width="9" height="128.546" fill="#6BA1F2"/>
+<rect x="410.500" y="243.225" width="9" height="122.775" fill="#707070"/>
+<rect x="419.500" y="253.398" width="9" height="112.602" fill="#FBB85C"/>
+<rect x="428.500" y="233.052" width="9" height="132.948" fill="#6BA1F2"/>
 <text x="424.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 424.000 379)">I2F</text>
-<rect x="446.500" y="234.411" width="9" height="131.589" fill="#707070"/>
-<rect x="455.500" y="225.305" width="9" height="140.695" fill="#FBB85C"/>
-<rect x="464.500" y="243.516" width="9" height="122.484" fill="#6BA1F2"/>
+<rect x="446.500" y="229.904" width="9" height="136.096" fill="#707070"/>
+<rect x="455.500" y="220.487" width="9" height="145.513" fill="#FBB85C"/>
+<rect x="464.500" y="239.321" width="9" height="126.679" fill="#6BA1F2"/>
 <text x="460.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 460.000 379)">HYPOT_XARG</text>
-<rect x="482.500" y="234.365" width="9" height="131.635" fill="#707070"/>
-<rect x="491.500" y="226.404" width="9" height="139.596" fill="#FBB85C"/>
-<rect x="500.500" y="242.325" width="9" height="123.675" fill="#6BA1F2"/>
+<rect x="482.500" y="229.857" width="9" height="136.143" fill="#707070"/>
+<rect x="491.500" y="221.623" width="9" height="144.377" fill="#FBB85C"/>
+<rect x="500.500" y="238.090" width="9" height="127.910" fill="#6BA1F2"/>
 <text x="496.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 496.000 379)">DIST_XARG</text>
-<rect x="518.500" y="208.951" width="9" height="157.049" fill="#707070"/>
-<rect x="527.500" y="210.778" width="9" height="155.222" fill="#FBB85C"/>
-<rect x="536.500" y="207.123" width="9" height="158.877" fill="#6BA1F2"/>
+<rect x="518.500" y="203.572" width="9" height="162.428" fill="#707070"/>
+<rect x="527.500" y="205.462" width="9" height="160.538" fill="#FBB85C"/>
+<rect x="536.500" y="201.682" width="9" height="164.318" fill="#6BA1F2"/>
 <text x="532.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 532.000 379)">SUMPROD_XELEM</text>
-<rect x="554.500" y="198.037" width="9" height="167.963" fill="#707070"/>
-<rect x="563.500" y="193.180" width="9" height="172.820" fill="#FBB85C"/>
-<rect x="572.500" y="202.895" width="9" height="163.105" fill="#6BA1F2"/>
+<rect x="554.500" y="192.285" width="9" height="173.715" fill="#707070"/>
+<rect x="563.500" y="187.261" width="9" height="178.739" fill="#FBB85C"/>
+<rect x="572.500" y="197.309" width="9" height="168.691" fill="#6BA1F2"/>
 <text x="568.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 568.000 379)">DIV</text>
-<rect x="590.500" y="193.852" width="9" height="172.148" fill="#707070"/>
-<rect x="599.500" y="182.706" width="9" height="183.294" fill="#FBB85C"/>
-<rect x="608.500" y="204.998" width="9" height="161.002" fill="#6BA1F2"/>
+<rect x="590.500" y="187.956" width="9" height="178.044" fill="#707070"/>
+<rect x="599.500" y="176.429" width="9" height="189.571" fill="#FBB85C"/>
+<rect x="608.500" y="199.484" width="9" height="166.516" fill="#6BA1F2"/>
 <text x="604.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 604.000 379)">FMOD</text>
-<rect x="626.500" y="186.624" width="9" height="179.376" fill="#707070"/>
-<rect x="635.500" y="185.463" width="9" height="180.537" fill="#FBB85C"/>
-<rect x="644.500" y="187.785" width="9" height="178.215" fill="#6BA1F2"/>
+<rect x="626.500" y="180.481" width="9" height="185.519" fill="#707070"/>
+<rect x="635.500" y="179.280" width="9" height="186.720" fill="#FBB85C"/>
+<rect x="644.500" y="181.682" width="9" height="184.318" fill="#6BA1F2"/>
 <text x="640.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 640.000 379)">SQRT</text>
-<rect x="726.500" y="98.259" width="9" height="267.741" fill="#707070"/>
-<rect x="735.500" y="100.744" width="9" height="265.256" fill="#FBB85C"/>
-<rect x="744.500" y="95.775" width="9" height="270.225" fill="#6BA1F2"/>
+<rect x="726.500" y="89.090" width="9" height="276.910" fill="#707070"/>
+<rect x="735.500" y="91.660" width="9" height="274.340" fill="#FBB85C"/>
+<rect x="744.500" y="86.520" width="9" height="279.480" fill="#6BA1F2"/>
 <text x="740.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 740.000 379)">SINH</text>
-<rect x="762.500" y="97.867" width="9" height="268.133" fill="#707070"/>
-<rect x="771.500" y="98.221" width="9" height="267.779" fill="#FBB85C"/>
-<rect x="780.500" y="97.513" width="9" height="268.487" fill="#6BA1F2"/>
+<rect x="762.500" y="88.684" width="9" height="277.316" fill="#707070"/>
+<rect x="771.500" y="89.050" width="9" height="276.950" fill="#FBB85C"/>
+<rect x="780.500" y="88.318" width="9" height="277.682" fill="#6BA1F2"/>
 <text x="776.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 776.000 379)">TANH</text>
-<rect x="798.500" y="92.184" width="9" height="273.816" fill="#707070"/>
-<rect x="807.500" y="91.503" width="9" height="274.497" fill="#FBB85C"/>
-<rect x="816.500" y="92.864" width="9" height="273.136" fill="#6BA1F2"/>
+<rect x="798.500" y="82.807" width="9" height="283.193" fill="#707070"/>
+<rect x="807.500" y="82.103" width="9" height="283.897" fill="#FBB85C"/>
+<rect x="816.500" y="83.510" width="9" height="282.490" fill="#6BA1F2"/>
 <text x="812.000" y="379" font-size="9" fill="#57606A" text-anchor="end" transform="rotate(-45 812.000 379)">GAMMA</text>
-<rect x="52.000" y="76.000" width="118.950" height="54.000" rx="4" fill="#F0F3F6" fill-opacity="0.8"/>
-<rect x="58" y="82.000" width="10" height="10" rx="1" fill="#707070"/>
-<text x="74.000" y="90.000" font-size="11" fill="#57606A">all architectures</text>
-<rect x="58" y="98.000" width="10" height="10" rx="1" fill="#FBB85C"/>
-<text x="74.000" y="106.000" font-size="11" fill="#57606A">arm64</text>
-<rect x="58" y="114.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
-<text x="74.000" y="122.000" font-size="11" fill="#57606A">x86</text>
+<rect x="52.000" y="66.000" width="118.950" height="54.000" rx="4" fill="#F0F3F6" fill-opacity="0.8"/>
+<rect x="58" y="72.000" width="10" height="10" rx="1" fill="#707070"/>
+<text x="74.000" y="80.000" font-size="11" fill="#57606A">all architectures</text>
+<rect x="58" y="88.000" width="10" height="10" rx="1" fill="#FBB85C"/>
+<text x="74.000" y="96.000" font-size="11" fill="#57606A">arm64</text>
+<rect x="58" y="104.000" width="10" height="10" rx="1" fill="#6BA1F2"/>
+<text x="74.000" y="112.000" font-size="11" fill="#57606A">x86</text>
+<text x="12" y="458" font-size="9" fill="#8C959F"><tspan font-size="7.5" font-weight="600" dy="-3" fill="#57606A">(1)</tspan><tspan dx="3" dy="3">based on 21 benchmarks, 16 spec sheets, 12 third party measurements</tspan></text>
 </svg>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,11 @@
+/* Light/dark image switching, completed.
+ *
+ * Material hides `#only-dark` images under the light scheme, but ships no counterpart rule for
+ * `#only-light` under the dark scheme -- so without this, a dark page shows both variants stacked.
+ *
+ * This keys on `data-md-color-scheme`, which is what the palette toggle sets. That matters: a
+ * `prefers-color-scheme` media query would follow the reader's operating system instead, and so would
+ * ignore the toggle in the header. */
+[data-md-color-scheme="slate"] img[src$="#only-light"] {
+  display: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,9 @@ plugins:
 hooks:
   - scripts/docs_changelog_hook.py
 
+extra_css:
+  - stylesheets/extra.css
+
 markdown_extensions:
   - admonition
   - attr_list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ replacement = '](https://raw.githubusercontent.com/bertpl/counted-float/v$HFPR_V
 # `<picture>`, whose paths live in attributes and so are invisible to the markdown pattern above.
 # PyPI's sanitiser drops `<picture>`/`<source>` and keeps the `<img>`, so PyPI shows the light
 # variant -- which is what it should, having no dark mode -- but only if this URL is absolute.
-pattern = '(src|srcset)="(images/[^"]+)"'
+pattern = '(src|srcset)="((?:docs/)?images/[^"]+)"'
 replacement = '\1="https://raw.githubusercontent.com/bertpl/counted-float/v$HFPR_VERSION/\2"'
 
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,14 @@ pattern = '\]\((images/[^)]+)\)'
 replacement = '](https://raw.githubusercontent.com/bertpl/counted-float/v$HFPR_VERSION/\1)'
 
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+# the same, for images embedded as HTML rather than markdown. The theme-switching chart needs a
+# `<picture>`, whose paths live in attributes and so are invisible to the markdown pattern above.
+# PyPI's sanitiser drops `<picture>`/`<source>` and keeps the `<img>`, so PyPI shows the light
+# variant -- which is what it should, having no dark mode -- but only if this URL is absolute.
+pattern = '(src|srcset)="(images/[^"]+)"'
+replacement = '\1="https://raw.githubusercontent.com/bertpl/counted-float/v$HFPR_VERSION/\2"'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
 # docs/*.md references: relative -> tag-pinned blob URL for PyPI
 pattern = '\]\((docs/[^)]+)\)'
 replacement = '](https://github.com/bertpl/counted-float/blob/v$HFPR_VERSION/\1)'

--- a/scripts/builtin_data_sources.py
+++ b/scripts/builtin_data_sources.py
@@ -1,0 +1,75 @@
+"""How the built-in weight data breaks down by kind of source.
+
+A fact about the dataset rather than about any one piece of documentation, and two generators need it
+-- the README's source-count bullet and the chart's provenance subtitle. It lives here so neither has
+to import the other, and so the two can never disagree about how many of each there are.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from counted_float import BuiltInData
+
+
+@dataclasses.dataclass(frozen=True)
+class SourceCounts:
+    """How many built-in data entries come from each kind of source.
+
+    Attributes:
+        benchmarks: Entries measured by running the benchmark suite.
+        spec_sheets: Entries taken from vendor documentation.
+        external_analyses: Entries from third party measurement projects.
+    """
+
+    benchmarks: int
+    spec_sheets: int
+    external_analyses: int
+
+
+def classified_source_keys() -> tuple[list[str], list[str], list[str]]:
+    """Split the built-in data keys into (benchmarks, spec sheets, external analyses).
+
+    Raises:
+        ValueError: If a key matches none of the three, which means the dataset grew a kind of source
+            this classification does not know about -- deliberately loud, since the alternative is a
+            published count that quietly omits it.
+    """
+    benchmarks: list[str] = []
+    specs: list[str] = []
+    third_party: list[str] = []
+    for key in BuiltInData.get_flop_weights_dict():
+        source_type, entry = key.split(".")[-2], key.split(".")[-1]
+        if source_type == "benchmarks":
+            benchmarks.append(key)
+        elif source_type == "specs" or entry.startswith("specs"):
+            specs.append(key)
+        elif entry.startswith("analysis_"):
+            third_party.append(key)
+        else:
+            raise ValueError(f"cannot classify built-in data key: {key}")
+    return benchmarks, specs, third_party
+
+
+def source_counts() -> SourceCounts:
+    """The three source-kind totals behind the shipped weights."""
+    benchmarks, specs, third_party = classified_source_keys()
+    return SourceCounts(
+        benchmarks=len(benchmarks),
+        spec_sheets=len(specs),
+        external_analyses=len(third_party),
+    )
+
+
+def source_summary() -> str:
+    """The dataset's composition, phrased once for every place that states it.
+
+    Callers frame it -- the README as a bullet naming the third-party projects, the chart as a
+    parenthetical -- but the counts and the wording come from here, so two surfaces cannot end up
+    describing the same dataset in different terms.
+    """
+    counts = source_counts()
+    return (
+        f"{counts.benchmarks} benchmarks, {counts.spec_sheets} spec sheets, "
+        f"{counts.external_analyses} third party measurements"
+    )

--- a/scripts/builtin_data_sources.py
+++ b/scripts/builtin_data_sources.py
@@ -61,15 +61,23 @@ def source_counts() -> SourceCounts:
     )
 
 
+# Named rather than derived. The keys do carry the project as a prefix, but turning
+# `analysis_uops_info_zen3` into "uops.info" needs a hardcoded mapping either way -- one buried in
+# parsing rather than written down -- and the set changes far too rarely to earn that.
+THIRD_PARTY_PROJECTS = ["Agner Fog", "uops.info"]
+
+
 def source_summary() -> str:
     """The dataset's composition, phrased once for every place that states it.
 
-    Callers frame it -- the README as a bullet naming the third-party projects, the chart as a
-    parenthetical -- but the counts and the wording come from here, so two surfaces cannot end up
-    describing the same dataset in different terms.
+    Callers frame it -- the README as a bullet, the chart as a footnote -- but the counts, the
+    wording and the named projects all come from here, so no two surfaces can end up describing the
+    same dataset differently. The projects are named because the chart travels further than the
+    README does: on the docs page and on PyPI it is the only place that says where the third-party
+    figures came from.
     """
     counts = source_counts()
     return (
         f"{counts.benchmarks} benchmarks, {counts.spec_sheets} spec sheets, "
-        f"{counts.external_analyses} third party measurements"
+        f"{counts.external_analyses} third party measurements ({', '.join(THIRD_PARTY_PROJECTS)})"
     )

--- a/scripts/flop_weight_chart.py
+++ b/scripts/flop_weight_chart.py
@@ -1,0 +1,354 @@
+"""Emit the built-in flop-weight bar chart as a deterministic SVG.
+
+Hand-emitted rather than plotted: a grouped bar chart is `<rect>` plus `<text>`, so this needs no
+plotting dependency and — unlike a raster render — its bytes are reproducible, which lets the
+committed file be checked by re-deriving and comparing rather than by hashing its inputs.
+
+Determinism is a requirement, not a happy accident. Every coordinate is rounded before formatting
+(`_n`), every float is formatted explicitly rather than through `repr`, and iteration order comes
+from sorted sequences — never a set. Without that, a last-ULP difference in `math.log10` between
+platforms would change the committed bytes and fail the drift check for no real reason.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from typing import TYPE_CHECKING
+
+from counted_float.config import get_builtin_flop_weights, get_default_consensus_flop_weights
+
+if TYPE_CHECKING:
+    from counted_float._core.models import FlopType
+
+# --- series ------------------------------------
+# True neutral grey for the all-architecture aggregate -- equal channels, no undertone -- so the two
+# ISA series carry all of the color. Checked for colorblind separation: the worst adjacent pair sits
+# around ΔE 25 under both protanopia and tritanopia, far above the ΔE 8 target.
+#
+# The blue is chroma-matched to the peach (both ~0.133 in OKLab) rather than lightness-matched, which
+# is what makes the pair read as equally soft. Matching lightness instead is not available: sRGB blue
+# cannot hold that chroma at the peach's lightness, and the pale blue it forces drops to half the
+# chroma and to ΔE 18 separation.
+#
+# The peach sits above the perceptual lightness band, which costs it contrast against white (roughly
+# 1.8:1) -- accepted deliberately, since the axis labels and legend carry identity anyway and a
+# band-compliant peach read muddy next to the blue.
+OVERALL_COLOR = "#707070"
+ARM_COLOR = "#FBB85C"
+X86_COLOR = "#6BA1F2"
+
+
+# --- neutral ramps -----------------------------
+# The series colors above hold up on either surface; only the neutrals have to change. So a theme is
+# exactly one ramp, and the two committed charts differ in nothing else -- same data, same layout,
+# same geometry, substituted inks. `Theme.surface` is opaque: the chart brings its own background so
+# it stays legible even when the page theme and the reader's `prefers-color-scheme` disagree.
+@dataclasses.dataclass(frozen=True)
+class Theme:
+    """One surface and the neutral inks that read against it.
+
+    Attributes:
+        name: Used in the committed file name.
+        surface: The chart's own background, opaque so the chart stays legible on any page.
+        legend_surface: The legend panel, one step off `surface` so it reads as a panel rather than
+            as a hole in the grid.
+        title_ink: The chart title.
+        label_ink: Axis labels, category labels, legend text -- anything meant to be read.
+        muted_ink: Secondary tick labels and the elision note.
+        grid_ink: Minor (non-decade) gridlines.
+        major_grid_ink: Decade gridlines.
+        axis_ink: The category axis.
+    """
+
+    name: str
+    surface: str
+    legend_surface: str
+    title_ink: str
+    label_ink: str
+    muted_ink: str
+    grid_ink: str
+    major_grid_ink: str
+    axis_ink: str
+
+
+LIGHT_THEME = Theme(
+    name="light",
+    surface="#FFFFFF",
+    legend_surface="#F0F3F6",
+    title_ink="#1F2328",
+    label_ink="#57606A",
+    muted_ink="#8C959F",
+    grid_ink="#D0D7DE",
+    major_grid_ink="#AFB8C1",
+    axis_ink="#AFB8C1",
+)
+DARK_THEME = Theme(
+    name="dark",
+    surface="#0D1117",
+    legend_surface="#242C37",
+    title_ink="#E6EDF3",
+    label_ink="#B1BAC4",
+    muted_ink="#8B949E",
+    grid_ink="#444C56",
+    major_grid_ink="#636C76",
+    axis_ink="#6E7681",
+)
+# mkdocs-material's slate surface, which is a different dark from GitHub's. Same ramp otherwise --
+# only the two surfaces move, so the docs page gets a chart whose panel edge does not show.
+DOCS_DARK_THEME = dataclasses.replace(DARK_THEME, name="dark_docs", surface="#1E2129", legend_surface="#333846")
+THEMES = [LIGHT_THEME, DARK_THEME, DOCS_DARK_THEME]
+
+LEGEND_BACKDROP_OPACITY = "0.8"
+# More dash than gap: a long gap reads as dots at this line weight.
+MINOR_DASH = "3 2"
+
+# Legend metrics. The panel is derived from the text's own bounds rather than from the row count, so
+# it stays centred on what it sits behind. SVG cannot measure text, so the label width is estimated
+# from the longest label at `LEGEND_CHAR_W` per character -- approximate by necessity, and the only
+# number here that is not exact.
+LEGEND_ROW_H = 16
+LEGEND_PAD = 6
+LEGEND_FONT = 11
+LEGEND_ASCENT = 8  # baseline to cap height, and also the swatch's rise above the baseline
+LEGEND_SWATCH = 10
+LEGEND_SWATCH_GAP = 6
+LEGEND_CHAR_W = 5.35
+
+# --- geometry ----------------------------------
+# Width is *derived* from the bar layout rather than fixed: a wider break or a wider bar silently
+# pushed the last group past a hardcoded right edge, where the viewBox clipped two bars away.
+HEIGHT = 476
+PLOT_LEFT = 46
+RIGHT_MARGIN = 10
+PLOT_TOP = 74
+PLOT_BOTTOM = 366
+
+BAR_W = 9  # three touching bars per flop type -- the group reads as one unit
+GROUP_GAP = 9
+# The omitted middle gets real width, and the category axis runs *dashed* across it -- a broken line
+# says "the sequence continues" without planting a mark that could be misread as data.
+BREAK_W = 64
+BREAK_DASH_SPAN = 48
+
+# How many flop types are shown at each end. The middle is elided: the point is the *range*, and
+# every flop type times three bars would be unreadable at README width.
+#
+# The split is deliberately lopsided. The cheap end carries the information -- it is where the two
+# ISAs actually disagree, and it stops just before the step up to REMAINDER, so the break lands on a
+# real discontinuity rather than an arbitrary cutoff. The expensive end is a plateau: everything from
+# rank 41 up sits within a few points of everything else, so extra bars there restate one fact.
+N_CHEAPEST = 17
+N_PRICIEST = 3
+
+# --- scale -------------------------------------
+# Log y, because the weights span well over two decades. Bounds are round numbers outside the data
+# on both ends; `_check_within_axis` fails the build if the data ever grows past them, since a bar
+# clipped to zero height disappears silently rather than looking wrong.
+Y_MIN = 0.15
+Y_MAX = 80.0
+# Decades are the majors: solid line, normal-size label. 1 is also ADD, the unit everything else is
+# relative to. Every integer multiple in between gets a dotted line so the log spacing is legible,
+# but only the 2 and the 5 of each decade are labelled -- enough to read the scale without turning
+# the plot into a ruler.
+Y_MAJOR_TICKS = [1.0, 10.0]
+Y_LABELLED_MULTIPLES = [2, 5]
+_DECADES = [0.1, 1.0, 10.0]
+
+_COORD_DECIMALS = 3
+
+
+def _minor_ticks() -> list[tuple[float, bool]]:
+    """Every in-range integer multiple within each decade, as (value, is labelled)."""
+    ticks: list[tuple[float, bool]] = []
+    for decade in _DECADES:
+        for multiple in range(2, 10):
+            value = round(decade * multiple, 6)
+            if Y_MIN <= value <= Y_MAX:
+                ticks.append((value, multiple in Y_LABELLED_MULTIPLES))
+    return ticks
+
+
+def _n(value: float) -> str:
+    """Format one coordinate, rounded so platform float noise cannot reach the committed bytes.
+
+    Three decimals is far below anything visible — at this viewBox one user unit is about two device
+    pixels on a high-DPI display — and far above the last-ULP variation `math.log10` can differ by
+    across platforms.
+    """
+    return f"{round(value, _COORD_DECIMALS):.3f}"
+
+
+def _y(value: float) -> float:
+    """Map a weight onto the log y axis, in user units from the top of the viewBox."""
+    span = math.log10(Y_MAX) - math.log10(Y_MIN)
+    frac = (math.log10(value) - math.log10(Y_MIN)) / span
+    return PLOT_BOTTOM - frac * (PLOT_BOTTOM - PLOT_TOP)
+
+
+def _omitted_count() -> int:
+    """How many flop types the break stands for -- derived, so it cannot drift from the data."""
+    total = len(get_default_consensus_flop_weights(rounding_mode=None).weights)
+    return total - N_CHEAPEST - N_PRICIEST
+
+
+def _check_within_axis(plotted: list[tuple[str, str, float]]) -> None:
+    """Fail if any plotted weight falls outside the axis bounds.
+
+    A value below `Y_MIN` renders as a zero-height bar — indistinguishable from a missing series
+    rather than obviously wrong — so this is checked rather than trusted. Widen the bounds and add a
+    tick when it fires.
+
+    Args:
+        plotted: (series name, flop type name, weight) for every bar the chart will draw.
+
+    Raises:
+        ValueError: If any weight lies outside `[Y_MIN, Y_MAX]`.
+    """
+    outside = [(series, name, value) for series, name, value in plotted if not Y_MIN <= value <= Y_MAX]
+    if outside:
+        detail = ", ".join(f"{series}/{name}={value:.4g}" for series, name, value in sorted(outside))
+        raise ValueError(f"weights outside the chart's y axis [{Y_MIN}, {Y_MAX}]: {detail}")
+
+
+def _shown_flop_types() -> tuple[list[FlopType], list[FlopType]]:
+    """The cheapest and priciest flop types by overall weight, as (cheapest, priciest).
+
+    Sorted by (weight, name) so two equal weights cannot reorder between runs.
+    """
+    overall = get_default_consensus_flop_weights(rounding_mode=None).weights
+    ordered = sorted(overall, key=lambda flop_type: (overall[flop_type], flop_type.name))
+    return ordered[:N_CHEAPEST], ordered[-N_PRICIEST:]
+
+
+def build_svg(theme: Theme) -> str:
+    """The full committed SVG for the built-in flop-weight chart, on one theme's surface.
+
+    Args:
+        theme: The neutral ramp and surface to draw against.
+    """
+    overall = get_default_consensus_flop_weights(rounding_mode=None).weights
+    arm = get_builtin_flop_weights(key_filter="arm", rounding_mode=None).weights
+    x86 = get_builtin_flop_weights(key_filter="x86", rounding_mode=None).weights
+    cheapest, priciest = _shown_flop_types()
+    series_by_name = [("all", overall), ("arm64", arm), ("x86", x86)]
+    _check_within_axis(
+        [
+            (series_name, flop_type.name, series[flop_type])
+            for series_name, series in series_by_name
+            for flop_type in [*cheapest, *priciest]
+        ]
+    )
+
+    # --- layout ---------------------------------
+    # Positions first, so the category axis can be drawn with a gap where the ellipsis goes, and so
+    # the canvas can be sized to whatever the bars actually need.
+    shown = [*cheapest, *priciest]
+    group_w = 3 * BAR_W
+    group_x: list[float] = []
+    break_centre = 0.0
+    x = float(PLOT_LEFT) + GROUP_GAP / 2
+    for index in range(len(shown)):
+        if index == N_CHEAPEST:
+            break_centre = x + BREAK_W / 2 - GROUP_GAP / 2
+            x += BREAK_W
+        group_x.append(x)
+        x += group_w + GROUP_GAP
+    plot_right = group_x[-1] + group_w + GROUP_GAP / 2
+    width = plot_right + RIGHT_MARGIN
+
+    out: list[str] = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {_n(width)} {HEIGHT}" '
+        f'width="{_n(width)}" height="{HEIGHT}" font-family="system-ui, -apple-system, sans-serif">',
+        f'<rect x="0" y="0" width="{_n(width)}" height="{HEIGHT}" fill="{theme.surface}"/>',
+        f'<text x="{PLOT_LEFT}" y="26" font-size="15" font-weight="600" fill="{theme.title_ink}">'
+        f"Built-in flop weights</text>",
+        f'<text x="{PLOT_LEFT}" y="44" font-size="11" fill="{theme.label_ink}">relative to ADD = 1, log scale</text>',
+    ]
+
+    # --- gridlines and y labels -----------------
+    for tick, labelled in _minor_ticks():
+        y = _y(tick)
+        out.append(
+            f'<line x1="{PLOT_LEFT}" y1="{_n(y)}" x2="{_n(plot_right)}" y2="{_n(y)}" '
+            f'stroke="{theme.grid_ink}" stroke-width="0.75" stroke-dasharray="{MINOR_DASH}"/>'
+        )
+        if labelled:
+            out.append(
+                f'<text x="{PLOT_LEFT - 8}" y="{_n(y + 3)}" font-size="8" fill="{theme.muted_ink}" '
+                f'text-anchor="end">{tick:g}</text>'
+            )
+    for tick in Y_MAJOR_TICKS:
+        y = _y(tick)
+        out.append(
+            f'<line x1="{PLOT_LEFT}" y1="{_n(y)}" x2="{_n(plot_right)}" y2="{_n(y)}" '
+            f'stroke="{theme.major_grid_ink}" stroke-width="1"/>'
+        )
+        out.append(
+            f'<text x="{PLOT_LEFT - 8}" y="{_n(y + 3.5)}" font-size="10" fill="{theme.label_ink}" '
+            f'text-anchor="end">{tick:g}</text>'
+        )
+
+    # --- category axis, dashed across the elision
+    dash_left = break_centre - BREAK_DASH_SPAN / 2
+    dash_right = break_centre + BREAK_DASH_SPAN / 2
+    for x1, x2 in [(float(PLOT_LEFT), dash_left), (dash_right, plot_right)]:
+        out.append(
+            f'<line x1="{_n(x1)}" y1="{PLOT_BOTTOM}" x2="{_n(x2)}" y2="{PLOT_BOTTOM}" '
+            f'stroke="{theme.axis_ink}" stroke-width="1"/>'
+        )
+    out.append(
+        f'<line x1="{_n(dash_left)}" y1="{PLOT_BOTTOM}" x2="{_n(dash_right)}" y2="{PLOT_BOTTOM}" '
+        f'stroke="{theme.axis_ink}" stroke-width="1" stroke-dasharray="4 4"/>'
+    )
+    out.append(
+        f'<text x="{_n(break_centre)}" y="{PLOT_BOTTOM + 16}" font-size="8.5" '
+        f'fill="{theme.muted_ink}" text-anchor="middle">{_omitted_count()} more</text>'
+    )
+
+    # --- bars -----------------------------------
+    for flop_type, left in zip(shown, group_x, strict=True):
+        for offset, (series, color) in enumerate([(overall, OVERALL_COLOR), (arm, ARM_COLOR), (x86, X86_COLOR)]):
+            top = _y(series[flop_type])
+            out.append(
+                f'<rect x="{_n(left + offset * BAR_W)}" y="{_n(top)}" width="{BAR_W}" '
+                f'height="{_n(PLOT_BOTTOM - top)}" fill="{color}"/>'
+            )
+        label_x = left + group_w / 2
+        out.append(
+            f'<text x="{_n(label_x)}" y="{PLOT_BOTTOM + 13}" font-size="9" fill="{theme.label_ink}" '
+            f'text-anchor="end" transform="rotate(-45 {_n(label_x)} {PLOT_BOTTOM + 13})">'
+            f"{flop_type.name}</text>"
+        )
+
+    # --- legend ---------------------------------
+    # Sits over the plot, so it gets a translucent panel one step off the chart background: enough to
+    # read as a panel and to fade the gridlines behind the text, without hiding them outright.
+    rows = [("all architectures", OVERALL_COLOR), ("arm64", ARM_COLOR), ("x86", X86_COLOR)]
+    legend_x = PLOT_LEFT + 12
+    legend_y = PLOT_TOP + 16
+    # Panel bounds come from the rows' own extent, so the padding is equal on every side. The swatches
+    # are the tallest thing in a row and no label carries a descender, so a row's visual top and
+    # bottom are the swatch's -- not a baseline plus an unused descent allowance.
+    content_top = legend_y - LEGEND_ASCENT
+    content_bottom = legend_y + (len(rows) - 1) * LEGEND_ROW_H + (LEGEND_SWATCH - LEGEND_ASCENT)
+    text_w = max(len(label) for label, _ in rows) * LEGEND_CHAR_W
+    out.append(
+        f'<rect x="{_n(legend_x - LEGEND_PAD)}" y="{_n(content_top - LEGEND_PAD)}" '
+        f'width="{_n(LEGEND_SWATCH + LEGEND_SWATCH_GAP + text_w + 2 * LEGEND_PAD)}" '
+        f'height="{_n(content_bottom - content_top + 2 * LEGEND_PAD)}" '
+        f'rx="4" fill="{theme.legend_surface}" fill-opacity="{LEGEND_BACKDROP_OPACITY}"/>'
+    )
+    for row, (label, color) in enumerate(rows):
+        y = legend_y + row * LEGEND_ROW_H
+        out.append(
+            f'<rect x="{legend_x}" y="{_n(y - LEGEND_ASCENT)}" width="{LEGEND_SWATCH}" '
+            f'height="{LEGEND_SWATCH}" rx="1" fill="{color}"/>'
+        )
+        out.append(
+            f'<text x="{_n(legend_x + LEGEND_SWATCH + LEGEND_SWATCH_GAP)}" y="{_n(y)}" '
+            f'font-size="{LEGEND_FONT}" fill="{theme.label_ink}">{label}</text>'
+        )
+
+    out.append("</svg>")
+    return "\n".join(out) + "\n"

--- a/scripts/flop_weight_chart.py
+++ b/scripts/flop_weight_chart.py
@@ -16,6 +16,8 @@ import dataclasses
 import math
 from typing import TYPE_CHECKING
 
+from builtin_data_sources import source_summary
+
 from counted_float.config import get_builtin_flop_weights, get_default_consensus_flop_weights
 
 if TYPE_CHECKING:
@@ -118,11 +120,19 @@ LEGEND_CHAR_W = 5.35
 # --- geometry ----------------------------------
 # Width is *derived* from the bar layout rather than fixed: a wider break or a wider bar silently
 # pushed the last group past a hardcoded right edge, where the viewBox clipped two bars away.
-HEIGHT = 476
+HEIGHT = 470
 PLOT_LEFT = 46
 RIGHT_MARGIN = 10
-PLOT_TOP = 74
+PLOT_TOP = 64
 PLOT_BOTTOM = 366
+
+# Provenance lives in a footnote rather than a third header line: the counts matter for trust, not for
+# reading the bars, so they belong out of the way with a marker pointing at them from the title.
+FOOTNOTE_MARKER = "1"
+FOOTNOTE_BASELINE = HEIGHT - 12
+# Tucked into the corner rather than aligned to the plot: it annotates the whole chart, not the axis.
+FOOTNOTE_LEFT = 12
+FOOTNOTE_MARKER_RISE = 3
 
 BAR_W = 9  # three touching bars per flop type -- the group reads as one unit
 GROUP_GAP = 9
@@ -231,6 +241,7 @@ def build_svg(theme: Theme) -> str:
     arm = get_builtin_flop_weights(key_filter="arm", rounding_mode=None).weights
     x86 = get_builtin_flop_weights(key_filter="x86", rounding_mode=None).weights
     cheapest, priciest = _shown_flop_types()
+    provenance = source_summary()
     series_by_name = [("all", overall), ("arm64", arm), ("x86", x86)]
     _check_within_axis(
         [
@@ -261,8 +272,11 @@ def build_svg(theme: Theme) -> str:
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {_n(width)} {HEIGHT}" '
         f'width="{_n(width)}" height="{HEIGHT}" font-family="system-ui, -apple-system, sans-serif">',
         f'<rect x="0" y="0" width="{_n(width)}" height="{HEIGHT}" fill="{theme.surface}"/>',
+        # the superscript marker points at the footnote at the foot of the chart; `dy` rather than
+        # `baseline-shift`, which renderers support unevenly
         f'<text x="{PLOT_LEFT}" y="26" font-size="15" font-weight="600" fill="{theme.title_ink}">'
-        f"Built-in flop weights</text>",
+        f'Built-in flop weights<tspan font-size="9" font-weight="400" dx="2" dy="-6" '
+        f'fill="{theme.muted_ink}">({FOOTNOTE_MARKER})</tspan></text>',
         f'<text x="{PLOT_LEFT}" y="44" font-size="11" fill="{theme.label_ink}">relative to ADD = 1, log scale</text>',
     ]
 
@@ -349,6 +363,16 @@ def build_svg(theme: Theme) -> str:
             f'<text x="{_n(legend_x + LEGEND_SWATCH + LEGEND_SWATCH_GAP)}" y="{_n(y)}" '
             f'font-size="{LEGEND_FONT}" fill="{theme.label_ink}">{label}</text>'
         )
+
+    # --- footnote -------------------------------
+    # The marker mirrors the one on the title -- raised and a step darker than the note itself, so it
+    # reads as a reference rather than as the first word of the sentence.
+    out.append(
+        f'<text x="{FOOTNOTE_LEFT}" y="{FOOTNOTE_BASELINE}" font-size="9" fill="{theme.muted_ink}">'
+        f'<tspan font-size="7.5" font-weight="600" dy="-{FOOTNOTE_MARKER_RISE}" '
+        f'fill="{theme.label_ink}">({FOOTNOTE_MARKER})</tspan>'
+        f'<tspan dx="3" dy="{FOOTNOTE_MARKER_RISE}">based on {provenance}</tspan></text>'
+    )
 
     out.append("</svg>")
     return "\n".join(out) + "\n"

--- a/scripts/flop_weight_chart.py
+++ b/scripts/flop_weight_chart.py
@@ -28,16 +28,15 @@ if TYPE_CHECKING:
 # ISA series carry all of the color. Checked for colorblind separation: the worst adjacent pair sits
 # around ΔE 25 under both protanopia and tritanopia, far above the ΔE 8 target.
 #
-# The blue is chroma-matched to the peach (both ~0.133 in OKLab) rather than lightness-matched, which
-# is what makes the pair read as equally soft. Matching lightness instead is not available: sRGB blue
-# cannot hold that chroma at the peach's lightness, and the pale blue it forces drops to half the
-# chroma and to ΔE 18 separation.
+# The red and blue echo the splash image's two accent hues, and are matched to each other in both
+# chroma (0.126 / 0.133) and lightness (0.718 / 0.706), so neither reads as the louder series.
 #
-# The peach sits above the perceptual lightness band, which costs it contrast against white (roughly
-# 1.8:1) -- accepted deliberately, since the axis labels and legend carry identity anyway and a
-# band-compliant peach read muddy next to the blue.
+# The red cannot go deeper than this, which is a hard limit rather than a preference: protanopia
+# darkens red toward mid-grey, so a deeper red collapses onto the grey aggregate it sits next to.
+# Measured against this grey, protan separation runs ΔE 12 here, 9 one step deeper, and 6 -- a
+# failure -- one step beyond that.
 OVERALL_COLOR = "#707070"
-ARM_COLOR = "#FBB85C"
+ARM_COLOR = "#E8837A"
 X86_COLOR = "#6BA1F2"
 
 

--- a/scripts/generate_docs_content.py
+++ b/scripts/generate_docs_content.py
@@ -58,6 +58,8 @@ from docs_artifacts import (
     read_lf,
     strip_ansi,
 )
+from flop_weight_chart import THEMES as CHART_THEMES
+from flop_weight_chart import build_svg as build_chart_svg
 
 from counted_float import BuiltInData
 from counted_float._core.counting._math_patching import (
@@ -527,6 +529,23 @@ def _screenshot_render_inputs(name: str) -> list[str]:
     ]
 
 
+def chart_files() -> list[GeneratedFile]:
+    """The flop-weight chart, one committed SVG per theme.
+
+    Byte-reproducible -- pure Python, no renderer -- so these are re-derived and compared rather than
+    fingerprinted, which catches a generator change as well as a data change. One file per theme
+    because the surface has to be opaque for the chart to stay legible on any page; see the chart
+    module for why the themes differ in nothing but neutral inks.
+    """
+    return [
+        GeneratedFile(
+            path=IMAGES_DIR / f"flop_weights_{theme.name}.svg",
+            produce=partial(build_chart_svg, theme),
+        )
+        for theme in CHART_THEMES
+    ]
+
+
 def render_images(captures: dict[Path, str]) -> list[Path]:
     """Render each capture to its committed screenshot.
 
@@ -552,8 +571,8 @@ def render_images(captures: dict[Path, str]) -> list[Path]:
 #  Entry point
 # ==================================================================================================
 def derived_files() -> list[DerivedFile]:
-    """Every committed file this script owns: marked blocks, then captures, then screenshots."""
-    return [*marked_block_files(MARKED_BLOCKS), *capture_files(), *screenshot_images()]
+    """Every committed file this script owns: marked blocks, captures, screenshots, charts."""
+    return [*marked_block_files(MARKED_BLOCKS), *capture_files(), *screenshot_images(), *chart_files()]
 
 
 def main() -> int:

--- a/scripts/generate_docs_content.py
+++ b/scripts/generate_docs_content.py
@@ -47,6 +47,7 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from builtin_data_sources import source_summary
 from docs_artifacts import (
     DocsArtifactManager,
     GeneratedFile,
@@ -178,31 +179,13 @@ def capture_snippet_stderr_ansi(snippet: Path) -> str:
 # ==================================================================================================
 #  Text-block generators
 # ==================================================================================================
-def _classified_source_keys() -> tuple[list[str], list[str], list[str]]:
-    """Split the built-in data keys into (benchmarks, spec sheets, third-party analyses)."""
-    benchmarks: list[str] = []
-    specs: list[str] = []
-    third_party: list[str] = []
-    for key in BuiltInData.get_flop_weights_dict():
-        source_type, entry = key.split(".")[-2], key.split(".")[-1]
-        if source_type == "benchmarks":
-            benchmarks.append(key)
-        elif source_type == "specs" or entry.startswith("specs"):
-            specs.append(key)
-        elif entry.startswith("analysis_"):
-            third_party.append(key)
-        else:
-            raise ValueError(f"cannot classify built-in data key: {key}")
-    return benchmarks, specs, third_party
-
-
 def generate_source_counts() -> str:
-    """The README bullet stating how many sources of each type back the shipped weights."""
-    benchmarks, specs, third_party = _classified_source_keys()
-    return (
-        f"- {len(benchmarks)} benchmarks, {len(specs)} spec sheets, "
-        f"{len(third_party)} third party measurements (Agner Fog, uops.info)"
-    )
+    """The README bullet stating how many sources of each type back the shipped weights.
+
+    The counts and their wording come from `source_summary`, which the chart's provenance subtitle
+    also uses; this only adds the projects the third-party figure refers to.
+    """
+    return f"- {source_summary()} (Agner Fog, uops.info)"
 
 
 def _show_block(import_line: str, call_line: str, show_call: Callable[[], None]) -> str:

--- a/scripts/generate_docs_content.py
+++ b/scripts/generate_docs_content.py
@@ -182,10 +182,10 @@ def capture_snippet_stderr_ansi(snippet: Path) -> str:
 def generate_source_counts() -> str:
     """The README bullet stating how many sources of each type back the shipped weights.
 
-    The counts and their wording come from `source_summary`, which the chart's provenance subtitle
-    also uses; this only adds the projects the third-party figure refers to.
+    Comes from `source_summary`, which the chart's provenance footnote also uses -- counts, wording
+    and named projects alike -- so the two statements cannot drift apart.
     """
-    return f"- {source_summary()} (Agner Fog, uops.info)"
+    return f"- {source_summary()}"
 
 
 def _show_block(import_line: str, call_line: str, show_call: Callable[[], None]) -> str:

--- a/tests/docs/test_flop_weight_chart.py
+++ b/tests/docs/test_flop_weight_chart.py
@@ -1,0 +1,132 @@
+"""The committed chart must be reproducible, in-bounds, and identical across themes but for its inks.
+
+The drift test already fails when the committed SVGs disagree with the generator. What it cannot see
+is *why* a difference appeared, so these pin the three properties the chart's correctness rests on:
+its output does not depend on the run, no bar is silently clipped away, and the per-theme files never
+diverge in anything but neutral inks.
+"""
+
+import dataclasses
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/ is not on the path for a test run
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
+from flop_weight_chart import (
+    DARK_THEME,
+    DOCS_DARK_THEME,
+    LIGHT_THEME,
+    N_CHEAPEST,
+    N_PRICIEST,
+    THEMES,
+    Y_MAX,
+    Y_MIN,
+    _check_within_axis,
+    _minor_ticks,
+    _omitted_count,
+    _shown_flop_types,
+    build_svg,
+)
+
+
+# ==================================================================================================
+#  Reproducibility
+# ==================================================================================================
+@pytest.mark.parametrize("theme", THEMES, ids=[theme.name for theme in THEMES])
+def test_svg_is_byte_identical_across_calls(theme):
+    """Byte-compare is only a usable check if the generator is deterministic."""
+    # --- act & assert -----------------------
+    assert build_svg(theme) == build_svg(theme)
+
+
+@pytest.mark.parametrize("dark", [DARK_THEME, DOCS_DARK_THEME], ids=["github", "docs"])
+def test_themes_differ_only_in_neutral_inks(dark):
+    """Substituting a dark theme's inks back out must reproduce the light SVG exactly.
+
+    This is what keeps the per-theme files from drifting: a layout or data change that landed in one
+    file and not the others could not survive this.
+    """
+    # --- arrange ----------------------------
+    substituted = build_svg(dark)
+
+    # --- act --------------------------------
+    for field in dataclasses.fields(LIGHT_THEME):
+        if field.name != "name":
+            substituted = substituted.replace(getattr(dark, field.name), getattr(LIGHT_THEME, field.name))
+
+    # --- assert -----------------------------
+    assert substituted == build_svg(LIGHT_THEME)
+
+
+def test_every_theme_gets_its_own_surface():
+    """Opaque, distinct surfaces are the whole reason there is more than one file."""
+    # --- act --------------------------------
+    surfaces = [theme.surface for theme in THEMES]
+
+    # --- assert -----------------------------
+    assert len(set(surfaces)) == len(surfaces)
+    for theme in THEMES:
+        assert f'fill="{theme.surface}"' in build_svg(theme)
+
+
+# ==================================================================================================
+#  Bounds and elision
+# ==================================================================================================
+def test_axis_bounds_cover_every_plotted_weight():
+    """A weight outside the axis renders as a zero-height bar, which looks like a missing series."""
+    # --- act & assert -----------------------
+    build_svg(LIGHT_THEME)  # raises via _check_within_axis if the data outgrew the axis
+
+
+def test_out_of_range_weight_is_rejected():
+    """The guard has to actually fire, or it is decoration."""
+    # --- arrange ----------------------------
+    too_small = [("arm64", "MINUS", Y_MIN / 2)]
+
+    # --- act & assert -----------------------
+    with pytest.raises(ValueError, match="outside the chart's y axis"):
+        _check_within_axis(too_small)
+
+    with pytest.raises(ValueError, match="outside the chart's y axis"):
+        _check_within_axis([("x86", "GAMMA", Y_MAX * 2)])
+
+
+def test_omitted_count_is_derived_from_the_data():
+    """The 'N more' note must follow the flop-type count, not a number typed next to it."""
+    # --- arrange ----------------------------
+    cheapest, priciest = _shown_flop_types()
+
+    # --- act --------------------------------
+    shown = len(cheapest) + len(priciest)
+
+    # --- assert -----------------------------
+    assert len(cheapest) == N_CHEAPEST
+    assert len(priciest) == N_PRICIEST
+    assert f"{_omitted_count()} more" in build_svg(LIGHT_THEME)
+    assert _omitted_count() > 0, f"nothing is elided at {shown} shown -- the break would be a lie"
+
+
+def test_shown_flop_types_are_sorted_and_disjoint():
+    """Sorted ascending by weight, and the two ends must not overlap."""
+    # --- arrange / act ----------------------
+    cheapest, priciest = _shown_flop_types()
+
+    # --- assert -----------------------------
+    assert not set(cheapest) & set(priciest)
+    names = [flop_type.name for flop_type in [*cheapest, *priciest]]
+    assert len(set(names)) == len(names)
+
+
+# ==================================================================================================
+#  Scale
+# ==================================================================================================
+def test_minor_ticks_are_in_range_and_labelled_at_two_and_five():
+    """Every integer multiple per decade, labelled only where the scale needs a number."""
+    # --- act --------------------------------
+    ticks = _minor_ticks()
+
+    # --- assert -----------------------------
+    assert all(Y_MIN <= value <= Y_MAX for value, _ in ticks)
+    assert [value for value, labelled in ticks if labelled] == [0.2, 0.5, 2.0, 5.0, 20.0, 50.0]


### PR DESCRIPTION
**TL;DR**: The README and docs now open on what the library is actually about — a log-scale bar chart of the built-in flop weights, with arm64 and x86 against the all-architecture consensus.

## Description

### Problem addressed

The README opened on badges and prose. The **flop-weight model is the whole product**, and it stayed invisible until you installed the package and ran the CLI — so a reader deciding whether the library is worth their time had nothing to look at, and no sense of the range involved.

That range is the interesting part: the weights span **0.44 to 54** relative to ADD, more than two decades, and the two architectures disagree most at the cheap end where the absolute numbers are smallest.

### Implementation

A pure-Python SVG generator, no plotting dependency — a grouped bar chart is `<rect>` plus `<text>`. That choice buys reproducible bytes, so the committed charts are checked by re-deriving and comparing rather than by hashing their inputs, which catches a change to the generator as well as a change to the data.

**The split is deliberately lopsided: 17 cheap, 3 expensive.** Everything from rank 41 up sits within a few points of everything else, so extra bars there restate one fact; the cheap end is where the ISAs diverge. It stops just before the step from `SQRT` (7.10) to `REMAINDER` (11.34), so the elision lands on a real discontinuity rather than an arbitrary cutoff, and the count of what is omitted is derived rather than typed.

**One file per surface**, because the chart carries its own opaque background — that keeps it legible even when a page's theme and the reader's `prefers-color-scheme` disagree. Only the neutral inks change between them, so layout, data and geometry are single-sourced, and a test pins that the files differ in nothing else.

Determinism is a requirement here rather than a nicety: coordinates are rounded before formatting and floats are never `repr`'d, because a last-ULP difference in `math.log10` across platforms would otherwise fail the drift check for no real reason.

## Attention points

- **Colors were validated, not eyeballed**, and the red is at a hard ceiling. Protanopia darkens red toward mid-grey, so it collapses onto the grey aggregate beside it: separation runs ΔE 12 at the chosen red, 9 one step deeper, and 6 — a failure — beyond that. Red and blue are chroma-matched (0.126 / 0.133) so neither reads as the louder series.
- **Theme selection works differently on each surface, and cannot be made uniform.** GitHub offers no hook for its own theme setting, so `<picture>` follows the reader's OS; mkdocs keys off `data-md-color-scheme`, so the docs chart follows the palette toggle. PyPI has no dark mode and gets the light variant.
- **Material ships only half its light/dark image convention** — it hides `#only-dark` under the light scheme but has no `#only-light` rule for dark, so both variants would stack on a dark docs page. Three lines of custom CSS complete it.
- **Two path bugs were found by building the artifacts rather than by reading.** The README referenced `images/`, which resolves to the repo root, while the chart lives under `docs/images/` — a broken image on GitHub. And the PyPI relative-to-absolute rewrite only matched markdown syntax, so paths inside a `<picture>` stayed relative, which is a broken image on PyPI.
- **A third surface exists for mkdocs** (`#1E2129`), since material's slate is not GitHub's `#0D1117` and the panel edge would otherwise show.

## Tests / Spikes

- **SPIKE:** built the docs against the pinned material 9.7.6 and grepped the emitted CSS, which is how the missing `#only-light` rule was found — the convention is documented as symmetric.
- **TEST:** built an sdist and read `PKG-INFO` to confirm the chart's URLs are absolute and tag-pinned; this is what surfaced both path bugs, and nothing in lint or tests would have.
- **TEST:** rendered every theme and inspected them, which caught two more a passing suite would not have — a bar clipped away by a hardcoded canvas width, and a series falling below the axis floor and rendering as nothing. Both now have guards, and the canvas width is derived from the bar layout.
- **TEST:** `make lint`, `make test` (1847 passed, 3 skipped), and the docs drift check all green.
- 11 unit tests added: per-theme determinism, the ink-only invariant across both dark themes, the axis-bounds guard firing in both directions, the derived omitted count, and the tick scheme.

## Changelog entry

Added:

```
- the README and docs now show a bar chart of the built-in flop weights, comparing arm64 and x86 against the all-architecture consensus
```


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
