### PR TITLE
chore: move the benchmarking dependencies behind the extra that names them

### DIFF
--- a/.github/actions/pre_commit/action.yml
+++ b/.github/actions/pre_commit/action.yml
@@ -24,7 +24,10 @@ runs:
 
       - name: Install dependencies
         shell: bash
-        run: uv sync --group dev
+        # --all-extras matters for ty rather than for the linters: it type-checks the code behind
+        # every extra, so a package sitting behind one still has to be resolvable here. This is what
+        # keeps CI's lint run equivalent to the local one, which syncs the same way.
+        run: uv sync --group dev --all-extras
 
       - name: Run pre-commit
         shell: bash

--- a/.github/actions/unit_test/action.yml
+++ b/.github/actions/unit_test/action.yml
@@ -16,7 +16,7 @@ inputs:
         default: "highest"
     include_all_extra_deps:
         required: false
-        description: "'true' (default) installs all optional extras (numba, cli); 'false' installs none."
+        description: "'true' (default) installs all optional extras (benchmarking, cli); 'false' installs none."
         default: "true"
     coverage:
         required: false

--- a/.github/workflows/_package_check.yml
+++ b/.github/workflows/_package_check.yml
@@ -61,7 +61,7 @@ jobs:
           name: dist
           path: dist
 
-      # Blind environment: test deps come lockfile-pinned from the dev group
+      # Blind environment: test deps come lockfile-pinned from the test group
       # (--no-emit-project keeps the project itself out), and counted_float can
       # only come from the built wheel — never an editable/source install.
       - name: Install the built wheel into a bare environment
@@ -70,7 +70,58 @@ jobs:
           uv venv blind-venv
           uv pip install --python blind-venv/bin/python -r requirements.txt
           WHEEL=(dist/*.whl)
-          uv pip install --python blind-venv/bin/python "counted-float[numba,cli] @ file://$PWD/${WHEEL[0]}"
+          uv pip install --python blind-venv/bin/python "counted-float[benchmarking,cli] @ file://$PWD/${WHEEL[0]}"
+
+      # A second blind environment with no extras at all: the claim this package makes about its
+      # base install, checked rather than assumed. The absence assertion is what stops this passing
+      # on an environment that quietly still carries them -- which is how it would fail silently.
+      - name: Install the built wheel base-only, and check what that install can do
+        run: |
+          uv venv base-venv
+          WHEEL=(dist/*.whl)
+          uv pip install --python base-venv/bin/python "counted-float @ file://$PWD/${WHEEL[0]}"
+          base-venv/bin/python -c "
+          from importlib.metadata import PackageNotFoundError, distribution
+
+          for name in ('numba', 'numpy', 'psutil', 'py-cpuinfo', 'click'):
+              try:
+                  distribution(name)
+              except PackageNotFoundError:
+                  continue
+              raise SystemExit(f'{name} is installed in a base-only environment; this check proves nothing')
+          print('OK: none of the optional distributions are present')
+
+          from counted_float import BuiltInData, CountedFloat, FlopCountingContext
+          with FlopCountingContext() as ctx:
+              _ = CountedFloat(2.0) * CountedFloat(3.0) + CountedFloat(1.0)
+          assert ctx.flop_counts().ADD == 1 and ctx.flop_counts().MUL == 1
+          assert len(BuiltInData.benchmarks()) > 0
+          print('OK: counting works and the shipped data parses')
+
+          from counted_float.evaluation import evaluate_counting_overhead
+          evaluate_counting_overhead(t_target_sec=0.01, verbose=False)
+          print('OK: counting overhead can be evaluated')
+
+          from counted_float._core import benchmarking
+          try:
+              benchmarking.FlopsBenchmarkSuite
+          except ImportError as e:
+              assert 'counted-float[benchmarking]' in str(e), e
+              print(f'OK: the flops suite reports what to install -- {e}')
+          else:
+              raise SystemExit('the flops suite resolved without its extra')
+          "
+
+      - name: Check the deprecated extra name still resolves
+        run: |
+          uv venv alias-venv
+          WHEEL=(dist/*.whl)
+          uv pip install --python alias-venv/bin/python "counted-float[numba] @ file://$PWD/${WHEEL[0]}"
+          alias-venv/bin/python -c "
+          from importlib.metadata import distribution
+          distribution('numba')
+          print('OK: the numba extra still installs the benchmarking set')
+          "
 
       - name: Assert the environment is blind
         run: |

--- a/.github/workflows/_package_check.yml
+++ b/.github/workflows/_package_check.yml
@@ -102,14 +102,14 @@ jobs:
           evaluate_counting_overhead(t_target_sec=0.01, verbose=False)
           print('OK: counting overhead can be evaluated')
 
-          from counted_float._core import benchmarking
+          from counted_float.benchmarking import run_flops_benchmark
           try:
-              benchmarking.FlopsBenchmarkSuite
+              run_flops_benchmark()
           except ImportError as e:
               assert 'counted-float[benchmarking]' in str(e), e
               print(f'OK: the flops suite reports what to install -- {e}')
           else:
-              raise SystemExit('the flops suite resolved without its extra')
+              raise SystemExit('the flops suite ran without its extra')
           "
 
       - name: Check the deprecated extra name still resolves

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -17,7 +17,7 @@ jobs:
         # detection (psutil) and system-info collection (cpuinfo) paths are OS-dependent, and a
         # dependency bump can change their behavior on macOS or Windows -- so one leg on each keeps
         # those paths on the pull-request gate rather than only in the manual benchmark workflows.
-        # Combos cover every axis (all four Pythons, both resolution ends, numba on/off, all three
+        # Combos cover every axis (all four Pythons, both resolution ends, extras on/off, all three
         # OSes) strategically rather than as a full product.
         include:
           - { os: ubuntu-latest,  python: "3.11", resolution: highest,       all_extras: "true"  }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - running the flops benchmark suite now requires the `numba` extra; without it the suite says what to install instead of producing results it already warned were unusable
 - evaluating counting overhead has moved to `counted_float.evaluation.evaluate_counting_overhead`, since it measures the library rather than the machine; its printed report says "counting overhead" rather than "benchmark" to match
+- the base install is now counting-only; running the flops benchmark suite needs the new `benchmarking` extra, which cuts an install that only counts from ~181 MB to ~17 MB
 
 ### Deprecated
 
 - `counted_float.benchmarking.run_counted_float_benchmark` still resolves but now warns; it will be dropped at the next major
+- the `numba` extra is renamed `benchmarking`; the old name still resolves to the same set but will be dropped at the next major
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- running the flops benchmark suite now requires the `numba` extra; without it the suite says what to install instead of producing results it already warned were unusable
+- running the flops benchmark suite now requires the `benchmarking` extra; without it the suite says what to install instead of producing results it already warned were unusable
 - evaluating counting overhead has moved to `counted_float.evaluation.evaluate_counting_overhead`, since it measures the library rather than the machine; its printed report says "counting overhead" rather than "benchmark" to match
 - the base install is now counting-only; running the flops benchmark suite needs the new `benchmarking` extra, which cuts an install that only counts from ~181 MB to ~17 MB
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build:
 	uv build;
 
 test:
-	# run all tests - with numba & just 1 python version. --exact prunes whatever a previous target
+	# run all tests - with all extras & just 1 python version. --exact prunes whatever a previous target
 	# installed, so this environment matches CI's rather than merely satisfying it; --no-default-groups
 	# is what actually narrows, since --group alone only adds to the default set.
 	uv run --exact --no-default-groups --group test --all-extras --python 3.13 pytest ./tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,23 +8,17 @@ description = "Count floating-point operations in Python code & benchmark relati
 # X.Y.(Z+1).devN+g<sha> — so dev builds self-report their provenance (config below).
 dynamic = ["readme", "version"]
 requires-python = ">=3.11"
+# Counting only. Everything the flops benchmark suite needs -- which is everything that describes or
+# measures a machine -- sits behind the `benchmarking` extra instead, since counting numpy arrays is
+# an explicit non-goal and the base install's audience is people doing arithmetic in plain Python.
 dependencies = [
-    # Per-Python floors: each compiled dep's floor is the earliest version shipping a
-    # wheel for that CPython, so `lowest-direct` installs (not source-builds) everywhere.
-    "numpy>=1.23.2; python_version < '3.12'",
-    "numpy>=1.26.0; python_version == '3.12'",
-    "numpy>=2.1.0; python_version == '3.13'",
-    "numpy>=2.3.2; python_version >= '3.14'",
     # pydantic floor is a code requirement (auto model-rebuild of cross-module forward refs, from
     # 2.6; serialization `context` for the display-vs-stored key rendering, from 2.7), raised
     # further where a newer CPython needs a newer pydantic-core wheel.
     "pydantic>=2.7; python_version < '3.13'",
     "pydantic>=2.9; python_version == '3.13'",
     "pydantic>=2.12; python_version >= '3.14'",
-    "psutil>=5.9.4; python_version < '3.13'",
-    "psutil>=7.1.2; python_version >= '3.13'",
     "rich>=13.0.0",
-    "py-cpuinfo>=9.0.0",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -54,13 +48,30 @@ Issues = "https://github.com/bertpl/counted-float/issues"
 Roadmap = "https://github.com/bertpl/counted-float/milestones"
 
 [project.optional-dependencies]
-numba = [
+# Everything the flops benchmark suite needs: the compiled probes, the arrays they run on, and the
+# machine description stamped onto a result. Named for the capability rather than for its heaviest
+# package, which is what the old `numba` name did.
+benchmarking = [
     # per-Python floors: earliest numba with a wheel for that CPython (also fixes the
     # indirect llvmlite build failure — old numba>=0.50 dragged in unbuildable llvmlite 0.33)
     "numba>=0.57; python_version < '3.12'",
     "numba>=0.59; python_version == '3.12'",
     "numba>=0.61; python_version == '3.13'",
     "numba>=0.63; python_version >= '3.14'",
+    # per-Python floors, same rationale: earliest release shipping a wheel for that CPython, so a
+    # `lowest-direct` install resolves to a wheel rather than attempting a source build.
+    "numpy>=1.23.2; python_version < '3.12'",
+    "numpy>=1.26.0; python_version == '3.12'",
+    "numpy>=2.1.0; python_version == '3.13'",
+    "numpy>=2.3.2; python_version >= '3.14'",
+    "psutil>=5.9.4; python_version < '3.13'",
+    "psutil>=7.1.2; python_version >= '3.13'",
+    "py-cpuinfo>=9.0.0",
+]
+# Deprecated alias for `benchmarking`, kept so no existing install string stops resolving. Drops at
+# the next major; a self-referential extra is the standard way to spell "the same set as that one".
+numba = [
+    "counted-float[benchmarking]",
 ]
 cli = [
     "click>=8.0.0",

--- a/src/counted_float/_core/compatibility/_optional_dependencies.py
+++ b/src/counted_float/_core/compatibility/_optional_dependencies.py
@@ -55,7 +55,7 @@ class Capability(StrEnum):
     """
 
     CLI = "cli"
-    FLOPS_BENCHMARKING = "numba"
+    FLOPS_BENCHMARKING = "benchmarking"
 
     # -------------------------------------------------------------------------
     #  Main API

--- a/tests/shared/test_optional_dependencies.py
+++ b/tests/shared/test_optional_dependencies.py
@@ -59,10 +59,13 @@ def test_required_distributions_are_read_from_the_extra_that_installs_them():
 
 
 def test_required_distributions_collapse_an_extra_declared_once_per_python_version():
-    # the numba requirement is spelled four times, one per interpreter range; what a caller needs is
-    # the distribution, not the four version-pinned spellings of it
-    # --- act / assert ------------------------------------
-    assert Capability.FLOPS_BENCHMARKING.required_distributions() == {"numba"}
+    # several of these are spelled once per interpreter range; what a caller needs is the set of
+    # distributions, not the version-pinned spellings of each
+    # --- act ---------------------------------------------
+    required = Capability.FLOPS_BENCHMARKING.required_distributions()
+
+    # --- assert ------------------------------------------
+    assert required == {"numba", "numpy", "psutil", "py-cpuinfo"}
 
 
 # =================================================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -202,21 +202,29 @@ wheels = [
 name = "counted-float"
 source = { editable = "." }
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
-    { name = "psutil" },
-    { name = "py-cpuinfo" },
     { name = "pydantic" },
     { name = "rich" },
 ]
 
 [package.optional-dependencies]
+benchmarking = [
+    { name = "numba", version = "0.62.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numba", version = "0.66.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "psutil" },
+    { name = "py-cpuinfo" },
+]
 cli = [
     { name = "click" },
 ]
 numba = [
     { name = "numba", version = "0.62.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "numba", version = "0.66.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "psutil" },
+    { name = "py-cpuinfo" },
 ]
 
 [package.dev-dependencies]
@@ -255,23 +263,34 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "click", marker = "extra == 'cli'", specifier = ">=8.0.0" },
+    { name = "numba", marker = "python_full_version == '3.12.*' and extra == 'benchmarking'", specifier = ">=0.59" },
     { name = "numba", marker = "python_full_version == '3.12.*' and extra == 'numba'", specifier = ">=0.59" },
+    { name = "numba", marker = "python_full_version < '3.12' and extra == 'benchmarking'", specifier = ">=0.57" },
     { name = "numba", marker = "python_full_version < '3.12' and extra == 'numba'", specifier = ">=0.57" },
+    { name = "numba", marker = "python_full_version == '3.13.*' and extra == 'benchmarking'", specifier = ">=0.61" },
     { name = "numba", marker = "python_full_version == '3.13.*' and extra == 'numba'", specifier = ">=0.61" },
+    { name = "numba", marker = "python_full_version >= '3.14' and extra == 'benchmarking'", specifier = ">=0.63" },
     { name = "numba", marker = "python_full_version >= '3.14' and extra == 'numba'", specifier = ">=0.63" },
-    { name = "numpy", marker = "python_full_version < '3.12'", specifier = ">=1.23.2" },
-    { name = "numpy", marker = "python_full_version == '3.12.*'", specifier = ">=1.26.0" },
-    { name = "numpy", marker = "python_full_version == '3.13.*'", specifier = ">=2.1.0" },
-    { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
-    { name = "psutil", marker = "python_full_version < '3.13'", specifier = ">=5.9.4" },
-    { name = "psutil", marker = "python_full_version >= '3.13'", specifier = ">=7.1.2" },
-    { name = "py-cpuinfo", specifier = ">=9.0.0" },
+    { name = "numpy", marker = "python_full_version == '3.12.*' and extra == 'benchmarking'", specifier = ">=1.26.0" },
+    { name = "numpy", marker = "python_full_version == '3.12.*' and extra == 'numba'", specifier = ">=1.26.0" },
+    { name = "numpy", marker = "python_full_version < '3.12' and extra == 'benchmarking'", specifier = ">=1.23.2" },
+    { name = "numpy", marker = "python_full_version < '3.12' and extra == 'numba'", specifier = ">=1.23.2" },
+    { name = "numpy", marker = "python_full_version == '3.13.*' and extra == 'benchmarking'", specifier = ">=2.1.0" },
+    { name = "numpy", marker = "python_full_version == '3.13.*' and extra == 'numba'", specifier = ">=2.1.0" },
+    { name = "numpy", marker = "python_full_version >= '3.14' and extra == 'benchmarking'", specifier = ">=2.3.2" },
+    { name = "numpy", marker = "python_full_version >= '3.14' and extra == 'numba'", specifier = ">=2.3.2" },
+    { name = "psutil", marker = "python_full_version >= '3.13' and extra == 'benchmarking'", specifier = ">=7.1.2" },
+    { name = "psutil", marker = "python_full_version >= '3.13' and extra == 'numba'", specifier = ">=7.1.2" },
+    { name = "psutil", marker = "python_full_version < '3.13' and extra == 'benchmarking'", specifier = ">=5.9.4" },
+    { name = "psutil", marker = "python_full_version < '3.13' and extra == 'numba'", specifier = ">=5.9.4" },
+    { name = "py-cpuinfo", marker = "extra == 'benchmarking'", specifier = ">=9.0.0" },
+    { name = "py-cpuinfo", marker = "extra == 'numba'", specifier = ">=9.0.0" },
     { name = "pydantic", marker = "python_full_version < '3.13'", specifier = ">=2.7" },
     { name = "pydantic", marker = "python_full_version == '3.13.*'", specifier = ">=2.9" },
     { name = "pydantic", marker = "python_full_version >= '3.14'", specifier = ">=2.12" },
     { name = "rich", specifier = ">=13.0.0" },
 ]
-provides-extras = ["cli", "numba"]
+provides-extras = ["benchmarking", "cli", "numba"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
**TL;DR**: numpy, psutil and py-cpuinfo stop being base dependencies. An install that only counts flops falls from ~181 MB to ~17 MB, and the extra is renamed for the capability it gates rather than for its heaviest package.

## Description

### Problem addressed

Three install tiers existed and none of them said what it was for. The base install carried every dependency the flops benchmark suite needs, so someone who only counts flops paid for numpy, psutil and py-cpuinfo they never reach — while the extra that actually gates benchmarking was called `numba`, as if it were an accelerator rather than the capability.

The argument that previously settled this — that a numerical consumer already has numpy — does not survive contact with what the library documents. Counting numpy arrays is an explicit non-goal and mixing them raises, so the base install's whole audience is people doing arithmetic in plain Python.

### Implementation

The three packages move into the extra, which becomes `benchmarking`. The old `numba` name is kept as a self-referential alias resolving to the same set, so no existing install string stops working.

No code follows the rename beyond the capability's own declaration: the guards, messages and test conditions all read the extras back from the installed metadata, so moving a package between tiers is a packaging edit.

The package check gains two permutations — a base-only install, and one that installs through the deprecated name.

## Attention points

- **The base-only check asserts absence before asserting anything else.** Without that, a dev tool quietly supplying one of these packages would leave the permutation passing while proving nothing — which is the exact failure this whole tier boundary exists to make visible.
- **Two measured numbers, one of which corrects the premise.** Installed size falls from ~181 MB to ~17 MB, considerably more than the original ~33 MB framing suggested. But **import time is unchanged**: the heavy imports were already made lazy in 2.0.4, so the import-time motivation was fixed a version ago and is not something this change can claim. The size argument stands on its own.
- **The deprecated extra is spelled `counted-float[benchmarking]`** — a self-referential extra, which is the standard way to say "the same set as that one" without repeating it and letting the two drift.
- **Test assertions no longer hardcode the extra's name**, deriving it from the capability instead. Three of them broke on this rename; they would have broken on the next one too.

## Tests / Spikes

- **TEST:** built a base-only venv from the wheel and verified the version's whole claim end to end — the optional distributions are genuinely absent, counting works, the shipped data parses, counting overhead can still be evaluated, and reaching the flops suite reports the extra to install.
- **TEST:** measured size and import time for base and full installs side by side rather than quoting the plan's figures; that is where the import-time correction above came from.
- **TEST:** confirmed the deprecated extra name still installs the same set.

## Changelog entry

Under `### Changed` and `### Deprecated`:

```
- the base install is now counting-only; running the flops benchmark suite needs the new `benchmarking` extra, which cuts an install that only counts from ~181 MB to ~17 MB
- the `numba` extra is renamed `benchmarking`; the old name still resolves to the same set but will be dropped at the next major
```


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
