### PR TITLE
chore: run tests and lint through the Makefile in CI

### DIFF
--- a/.github/actions/pre_commit/action.yml
+++ b/.github/actions/pre_commit/action.yml
@@ -1,6 +1,6 @@
 name: Pre-commit
 author: Bert Pluymers
-description: Set up uv and run the full pre-commit hook suite over all files (mirrors `make lint`).
+description: Set up uv and run the full pre-commit hook suite over all files, via `make lint`.
 
 inputs:
     uv_version:
@@ -22,13 +22,7 @@ runs:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
-      - name: Install dependencies
-        shell: bash
-        # --all-extras matters for ty rather than for the linters: it type-checks the code behind
-        # every extra, so a package sitting behind one still has to be resolvable here. This is what
-        # keeps CI's lint run equivalent to the local one, which syncs the same way.
-        run: uv sync --group dev --all-extras
-
       - name: Run pre-commit
         shell: bash
-        run: uv run pre-commit run --all-files --show-diff-on-failure
+        # the target owns both the sync and the hook run, so CI cannot drift from `make lint`
+        run: make lint PRE_COMMIT_ARGS=--show-diff-on-failure

--- a/.github/actions/unit_test/action.yml
+++ b/.github/actions/unit_test/action.yml
@@ -46,6 +46,13 @@ runs:
         shell: bash
         run: rm -f uv.lock  # with the tracked lock present, uv reuses its pins and ignores --resolution
 
+      # The Windows runner image ships no GNU make, and the invocation this action runs lives in
+      # the Makefile so it cannot drift from the local one. ubuntu and macOS already have it.
+      - name: Install GNU make
+        if: runner.os == 'Windows'
+        shell: bash
+        run: choco install make --no-progress --yes
+
       - name: Run tests
         shell: bash
         env:
@@ -64,12 +71,10 @@ runs:
           # that do support it are what supply the probe coverage the cumulative gate unions.
           NUMBA_JIT_COVERAGE: "1"
         run: |
-          EXTRA_FLAG=""
-          [ "$EXTRAS" = "true" ] && EXTRA_FLAG="--all-extras"
           COV_FLAG=""
           # --cov-fail-under=0: the gate is cumulative (coverage job), not per-combo
           [ "$COV" = "true" ] && COV_FLAG="--cov --cov-report= --cov-fail-under=0"
-          uv run --python "$PY" --resolution "$RES" $EXTRA_FLAG --no-default-groups --group test pytest ./tests $COV_FLAG --durations=20
+          make test PYTHON="$PY" RESOLUTION="$RES" ALL_EXTRAS="$EXTRAS" PYTEST_ARGS="$COV_FLAG --durations=20"
 
       - name: Dump collected node-ids (for the cross-combo test-count union)
         if: inputs.coverage == 'true'
@@ -79,12 +84,9 @@ runs:
           RES: ${{ inputs.dependency_resolution }}
           EXTRAS: ${{ inputs.include_all_extra_deps }}
         run: |
-          EXTRA_FLAG=""
-          [ "$EXTRAS" = "true" ] && EXTRA_FLAG="--all-extras"
-          # -o addopts="" clears `-n auto`, so collection runs single-process (xdist off);
-          # each combo records its own collected set so the coverage job can union them.
-          uv run --python "$PY" --resolution "$RES" $EXTRA_FLAG --no-default-groups --group test \
-            pytest ./tests --collect-only -q -o addopts="" \
+          # each combo records its own collected set so the coverage job can union them; the
+          # `::` filter drops make's own echo of the recipe along with pytest's summary line.
+          make test-collect-ids PYTHON="$PY" RESOLUTION="$RES" ALL_EXTRAS="$EXTRAS" \
             | grep '::' > "test-ids-${RUNNER_OS}-${PY}-${RES}-${EXTRAS}.txt"
 
       - name: Upload coverage + node-id data

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,24 @@
 file_path=
 
+# Comments sit above their target rather than inside the recipe: CI runs the test targets on
+# Windows too, where make drives cmd.exe, which does not understand `#`.
+
+# Knobs for the test and lint targets. CI varies these per matrix leg by passing them on the
+# make command line; a bare `make test` / `make lint` uses the defaults.
+PYTHON ?= 3.13
+RESOLUTION ?= highest
+ALL_EXTRAS ?= true
+PYTEST_ARGS ?=
+PRE_COMMIT_ARGS ?=
+
+# The single definition of the environment the suite runs in, shared by both test targets.
+# --exact prunes whatever a previous target installed, so this environment matches CI's rather
+# than merely satisfying it; --no-default-groups is what actually narrows, since --group alone
+# only adds to the default set.
+UV_RUN_TEST = uv run --exact --no-default-groups --group test \
+              --python $(PYTHON) --resolution $(RESOLUTION) \
+              $(if $(filter true,$(ALL_EXTRAS)),--all-extras,)
+
 help:
 	@echo 'Commands:'
 	@echo ''
@@ -8,6 +27,7 @@ help:
 	@echo '  build		                    (Re)build package using uv.'
 	@echo ''
 	@echo '  test		                    Run pytest unit tests.'
+	@echo '  test-collect-ids              List the collected test node-ids (CI unions these across matrix legs).'
 	@echo '  lint		                    Run all pre-commit hooks on all files.'
 	@echo '  mutation		                Run local mutation testing (mutmut). MODULE=<substr> scopes it.'
 	@echo '  mutation-results	            List the surviving mutants from the last mutation run.'
@@ -24,21 +44,27 @@ help:
 	@echo 'Options:'
 	@echo ''
 	@echo '  format-single-file             - accepts `file_path=<path>` to pass the relative path of the file to be formatted.'
+	@echo '  test, test-collect-ids         - accept PYTHON=<x.y>, RESOLUTION=highest|lowest-direct, ALL_EXTRAS=true|false, PYTEST_ARGS=<args>.'
+	@echo '  lint                           - accepts PRE_COMMIT_ARGS=<args>.'
 
 build:
 	uv build;
 
 test:
-	# run all tests - with all extras & just 1 python version. --exact prunes whatever a previous target
-	# installed, so this environment matches CI's rather than merely satisfying it; --no-default-groups
-	# is what actually narrows, since --group alone only adds to the default set.
-	uv run --exact --no-default-groups --group test --all-extras --python 3.13 pytest ./tests
+	$(UV_RUN_TEST) pytest ./tests $(PYTEST_ARGS)
 
+# -o addopts= clears `-n auto`, so collection runs single-process (xdist off) and prints one
+# node-id per line.
+test-collect-ids:
+	$(UV_RUN_TEST) pytest ./tests --collect-only -q -o addopts=
+
+# uv sync reconciles the venv to the lockfile first, so the hooks run the pinned ruff/ty -- not
+# whatever a prior `uv run --exact` or interpreter switch left behind. --all-extras matters for ty
+# rather than for the linters: it type-checks the code behind every extra, so a package sitting
+# behind one still has to be resolvable.
 lint:
-	# reconcile the venv to the lockfile first, so the hooks run the pinned ruff/ty -- not whatever a
-	# prior `uv run --exact` or interpreter switch left behind, which would drift make lint from CI
 	uv sync --locked --all-extras
-	uv run pre-commit run --all-files
+	uv run pre-commit run --all-files $(PRE_COMMIT_ARGS)
 
 format:
 	uv run ruff format .;
@@ -48,15 +74,15 @@ format-single-file:
 	uv run ruff format ${file_path};
 	uv run ruff check --fix ${file_path};
 
+# local mutation testing over _core (config in [tool.mutmut]); MODULE=<substr> scopes to matching mutants
 mutation:
-	# local mutation testing over _core (config in [tool.mutmut]); MODULE=<substr> scopes to matching mutants
 	uv run --group mutation --all-extras --python 3.13 mutmut run $(if $(MODULE),"*$(MODULE)*",)
 
 mutation-results:
 	uv run --group mutation --all-extras --python 3.13 mutmut results
 
+# machine-readable killed/survived/total of the last run -> mutants/mutmut-cicd-stats.json (release.py reads it)
 mutation-stats:
-	# machine-readable killed/survived/total of the last run -> mutants/mutmut-cicd-stats.json (release.py reads it)
 	uv run --group mutation --all-extras --python 3.13 mutmut export-cicd-stats
 
 precompute-weights:
@@ -68,8 +94,8 @@ regen-docs:
 regen-machine-code:
 	uv run --all-extras python scripts/generate_machine_code_docs.py
 
+# DRY_RUN=1 stops after the preconditions (mutation measurement included), writing nothing
 release:
-	# DRY_RUN=1 stops after the preconditions (mutation measurement included), writing nothing
 	@test -n "$(VERSION)" || (echo "Usage: make release VERSION=X.Y.Z [DRY_RUN=1]" && exit 1)
 	$(MAKE) test
 	uv run python scripts/release.py $(VERSION) $(if $(DRY_RUN),--dry-run,)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 	@echo '  build		                    (Re)build package using uv.'
 	@echo ''
 	@echo '  test		                    Run pytest unit tests.'
-	@echo '  test-collect-ids              List the collected test node-ids (CI unions these across matrix legs).'
+	@echo '  test-collect-ids               List the collected test node-ids (CI unions these across matrix legs).'
 	@echo '  lint		                    Run all pre-commit hooks on all files.'
 	@echo '  mutation		                Run local mutation testing (mutmut). MODULE=<substr> scopes it.'
 	@echo '  mutation-results	            List the surviving mutants from the last mutation run.'


### PR DESCRIPTION
**TL;DR**: CI now calls the make targets instead of restating their `uv` invocations, so how the suite and the linters run has a single definition.

## Description

### Problem addressed

The Makefile and the CI actions each spelled out how to run pytest and pre-commit, and the two had to be kept in step by hand. It has already gone wrong twice: the dependency-group flags had to be written into both separately, and the lint environment then needed `--all-extras` added in CI alone, because the local target had always carried it. Neither divergence was caught by anything except a red run.

### Implementation

The make targets take the axes CI varies as **variables** — `PYTHON`, `RESOLUTION`, `ALL_EXTRAS`, plus a `PYTEST_ARGS` passthrough for the coverage flags — and the composite actions call `make test` / `make lint` with those set. *Which* combinations run stays in the workflow matrix; *how* one combination runs now lives in the Makefile only.

A second target, `test-collect-ids`, covers the node-id collection step. It shares the same environment spec as the test run, and would otherwise remain a second place for the group flags to drift.

Recipe comments moved above their targets, because the test targets now also run on Windows, where make drives `cmd.exe` — which treats `#` as a command rather than a comment.

## Attention points

- **The Windows runner image ships no GNU make**, so the unit-test action installs it through Chocolatey on that leg alone. This is the one new CI dependency introduced here.
- **CI lint now syncs with `--locked`**, inherited from the local target. A stale lockfile fails at sync with a clear message rather than later, at the `uv lock --check` hook.
- **CI tests now run with `--exact`**, also inherited. It has no effect on a fresh runner; it is what stops a developer environment being laxer than CI's.
- **The coverage-combine job was left alone.** Its commands exist only in the workflow, so there is no second spelling for them to drift from.

## Tests / Spikes

- **SPIKE:** checked the Windows runner-image manifest for `make` — absent, and the bundled MSYS2 is not on PATH. That is what the Chocolatey step answers.
- **TEST:** `make test`, `make lint` and `make test-collect-ids` all run clean locally; `make -n` confirms the expanded commands for the defaults and for the extras-off / lowest-direct combination.
- **TEST:** the `::` filter CI applies to `make test-collect-ids` yields exactly the 1879 collected node-ids, so make's echo of the recipe does not leak into the artifact.
- No unit tests added or changed — this is build and CI plumbing.

## Changelog entry

None: CI and build plumbing, with no user-facing effect.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
