### PR TITLE
refactor: name the CLI command for what it evaluates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - running the flops benchmark suite now requires the `benchmarking` extra; without it the suite says what to install instead of producing results it already warned were unusable
 - evaluating counting overhead has moved to `counted_float.evaluation.evaluate_counting_overhead`, since it measures the library rather than the machine; its printed report says "counting overhead" rather than "benchmark" to match
 - the base install is now counting-only; running the flops benchmark suite needs the new `benchmarking` extra, which cuts an install that only counts from ~181 MB to ~17 MB
+- the CLI command for measuring counting overhead is now `evaluate-overhead`, matching what it does rather than the machinery it uses
 
 ### Deprecated
 
 - `counted_float.benchmarking.run_counted_float_benchmark` still resolves but now warns; it will be dropped at the next major
+- the `benchmark-counted-float` CLI command is renamed `evaluate-overhead`; the old name still runs but warns, and will be dropped at the next major
 - the `numba` extra is renamed `benchmarking`; the old name still resolves to the same set but will be dropped at the next major
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ counts.total_count()         # 2
 
 `CountedFloat` adds counting overhead in two forms — the price of Python-level
 operator dispatch and result wrapping. Measured on an Apple M3 Max (measure your
-own machine with `counted_float benchmark-counted-float`):
+own machine with `counted_float evaluate-overhead`):
 
 - **native float ops** (`+`, `-`, `*`, `/`, comparisons): roughly **20–40×**
   slower than plain `float` per operation, environment-dependent (~21× on the M3

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -96,7 +96,7 @@ advised to use `CountedFloat` for production code, but just for research code
 for which you want to estimate the floating-point operation count.
 
 Micro-benchmarking of a bisection algorithm using
-`counted_float benchmark-counted-float` (see the
+`counted_float evaluate-overhead` (see the
 [CLI reference](cli.md)) teaches us this — again a frozen example, captured on
 an Apple M3 Max with counted-float 2.1.0:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -66,10 +66,10 @@ ALL                                                                      0.44   
 ```
 <!-- END generated: cli-show-data-slice -->
 
-## Test performance of `CountedFloat` vs `float`
+## Evaluate the counting overhead of `CountedFloat` vs `float`
 
 ```
-[~] counted_float benchmark-counted-float
+[~] counted_float evaluate-overhead
 ```
 
 See [Performance impact](benchmarking.md#performance-impact) for example

--- a/src/counted_float/_core/_cli.py
+++ b/src/counted_float/_core/_cli.py
@@ -48,7 +48,21 @@ def show_data(key_filter: str) -> None:
     )
 
 
-@cli.command(short_help="run benchmark of float vs CountedFloat performance")
-def benchmark_counted_float() -> None:
+@cli.command(short_help="evaluate the counting overhead of CountedFloat vs float")
+def evaluate_overhead() -> None:
     result = evaluate_counting_overhead()
     result.show()
+
+
+# `benchmark` is what the flops suite does to a machine; this measures the library, so it is named
+# for evaluation instead. Hidden rather than listed: the alias is for install strings already in
+# use, not something a new reader should discover and pick.
+@cli.command(name="benchmark-counted-float", hidden=True)
+@click.pass_context
+def benchmark_counted_float(ctx: click.Context) -> None:
+    click.echo(
+        "'benchmark-counted-float' is deprecated and will be removed in the next major version; "
+        "use 'evaluate-overhead' instead.",
+        err=True,
+    )
+    ctx.invoke(evaluate_overhead)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 
 from counted_float import BuiltInData
 from counted_float._core import _cli
-from counted_float._core._cli import benchmark, benchmark_counted_float, show_data
+from counted_float._core._cli import benchmark, benchmark_counted_float, evaluate_overhead, show_data
 from counted_float._core.models import FlopsBenchmarkResults
 
 
@@ -39,30 +39,61 @@ def test_show_data_key_filter_spellings(flag: str, monkeypatch) -> None:
     assert seen == ["arm"]
 
 
-def test_benchmark_counted_float_invokes_the_benchmark(monkeypatch):
-    """`benchmark-counted-float` runs the comparison benchmark and shows its result."""
+def test_evaluate_overhead_invokes_the_evaluation(monkeypatch):
+    """`evaluate-overhead` runs the counting-overhead evaluation and shows its result."""
 
     # --- arrange -----------------------------------------
-    # replace the real (slow) benchmark with a fast fake, and prove the command actually calls it
+    # replace the real (slow) evaluation with a fast fake, and prove the command actually calls it
     calls: list[bool] = []
 
     class _FakeResult:
         def show(self) -> None:
-            click.echo("fake benchmark shown")
+            click.echo("fake evaluation shown")
 
-    def _fake_benchmark() -> _FakeResult:
+    def _fake_evaluation() -> _FakeResult:
         calls.append(True)
         return _FakeResult()
 
-    monkeypatch.setattr(_cli, "evaluate_counting_overhead", _fake_benchmark)
+    monkeypatch.setattr(_cli, "evaluate_counting_overhead", _fake_evaluation)
+
+    # --- act ---------------------------------------------
+    result = CliRunner().invoke(evaluate_overhead)
+
+    # --- assert ------------------------------------------
+    assert result.exit_code == 0
+    assert calls == [True]  # the command invoked the (patched) evaluation exactly once
+    assert "fake evaluation shown" in result.output  # and rendered its result via .show()
+
+
+def test_the_old_command_name_still_runs_and_warns(monkeypatch):
+    """`benchmark-counted-float` still does the work, but says what to move to."""
+
+    # --- arrange -----------------------------------------
+    class _FakeResult:
+        def show(self) -> None:
+            click.echo("fake evaluation shown")
+
+    def _fake_evaluation() -> _FakeResult:
+        return _FakeResult()
+
+    monkeypatch.setattr(_cli, "evaluate_counting_overhead", _fake_evaluation)
 
     # --- act ---------------------------------------------
     result = CliRunner().invoke(benchmark_counted_float)
 
     # --- assert ------------------------------------------
     assert result.exit_code == 0
-    assert calls == [True]  # the command invoked the (patched) benchmark exactly once
-    assert "fake benchmark shown" in result.output  # and rendered its result via .show()
+    assert "fake evaluation shown" in result.output  # the alias still does the work
+    assert "deprecated" in result.output
+    assert "evaluate-overhead" in result.output  # and names its replacement
+
+
+def test_the_old_command_name_is_hidden_from_help():
+    """The alias exists for install strings already in use, not for new readers to discover."""
+    result = CliRunner().invoke(_cli.cli, ["--help"])
+    assert result.exit_code == 0
+    assert "evaluate-overhead" in result.output
+    assert "benchmark-counted-float" not in result.output
 
 
 def test_benchmark_output_round_trip(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
**TL;DR**: The CLI's counting-overhead command becomes `evaluate-overhead`, completing a rename already applied everywhere else; the old name stays as a hidden alias that warns.

## Description

### Problem addressed

This release draws a distinction between **benchmarking** — what the flops suite does to a machine — and **evaluating**, what the overhead measurement does to the library. That distinction reached the Python entry point, the internal class names and the printed report, but not the CLI.

The result was a command named `benchmark-counted-float`, whose help text said "benchmark", which printed `Evaluating counting overhead...` when actually run. Of the three surfaces, the one a user meets first was the one still speaking the old vocabulary.

### Implementation

The command is now `evaluate-overhead`. The old name survives as a **separate hidden command** that writes a deprecation notice to stderr and then delegates through `ctx.invoke`, so the alias shares the implementation instead of copying it.

Hidden rather than listed, deliberately: the alias exists for command lines already written down somewhere, not for a new reader to discover and then have to choose between two spellings of one thing.

The documentation references followed, along with the CLI reference's section heading — it described the command as testing performance, which is the same mismatch one level up.

## Attention points

- **The alias warns on stderr, not through `DeprecationWarning`.** A CLI user never sees Python warnings by default. The Python-level alias next door does use `DeprecationWarning`, because its audience is calling code rather than a terminal.
- **`evaluate-overhead`, not `evaluate-counting-overhead`.** The shorter form matches the CLI's existing convention, where `benchmark` already stands in for `run_flops_benchmark`. The trade-off is that the CLI name and the Python name are no longer character-identical.
- **This is cheaper now than later.** The rename needs a deprecation cycle whichever release it lands in, and this one is already running two others — so folding it in here costs one more alias rather than a whole second cycle.

## Tests / Spikes

- **TEST:** `counted_float --help` lists `evaluate-overhead` and omits the alias; `counted_float benchmark-counted-float` still resolves and runs.
- Three unit tests cover it: the new command invokes the evaluation, the alias still does the work while naming its replacement, and the alias stays out of `--help`. Net +2 on the suite total, since one existing test was renamed rather than added.

## Changelog entry

Under **Changed**:

```
- the CLI command for measuring counting overhead is now `evaluate-overhead`, matching what it does rather than the machinery it uses
```

Under **Deprecated**:

```
- the `benchmark-counted-float` CLI command is renamed `evaluate-overhead`; the old name still runs but warns, and will be dropped at the next major
```


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
