### PR TITLE
chore: spike codeql gate

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ name: CodeQL
 # scan, since a required check has to report before the merge button unlocks.
 
 on:
-  pull_request:
+  workflow_call:  # the PR pipeline calls this, so its gate can depend on the result
   push:
     branches: [main]
   schedule:
@@ -30,7 +30,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # deliberately not ${{ github.workflow }}: when called, that resolves to the CALLER's name, so
+  # this would share a group with the PR pipeline and the two would cancel each other
+  group: codeql-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -57,3 +59,35 @@ jobs:
           # what makes a pull request comparable to its base branch — the
           # analysis key does that, and no category overrides it (see the header).
           category: python
+
+      # `analyze` exits 0 whether or not it found anything, and code scanning's own check run is
+      # posted before the upload registers and never re-evaluated -- so neither of them can gate a
+      # merge. This step is what does: it reads back the alerts the analysis just uploaded and
+      # fails on any of them. Filtered to CodeQL because Scorecard publishes to the same alert
+      # store, and its findings are not this gate's business.
+      - name: Fail on CodeQL findings
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
+        run: |
+          # the alerts lag the upload by a second or two, so a first empty read means "not yet"
+          # rather than "clean" -- poll briefly before believing it
+          for attempt in 1 2 3 4 5; do
+            alerts=$(gh api "repos/${GITHUB_REPOSITORY}/code-scanning/alerts?ref=${REF}&state=open&per_page=100" \
+                       --jq '[.[] | select(.tool.name == "CodeQL")]' 2>/dev/null || echo "unavailable")
+            [ "$alerts" != "unavailable" ] && break
+            echo "code scanning has no data for ${REF} yet (attempt ${attempt}); waiting."
+            sleep 10
+          done
+          if [ "$alerts" = "unavailable" ]; then
+            echo "::error::could not read code scanning alerts for ${REF}"
+            exit 1
+          fi
+          count=$(echo "$alerts" | jq 'length')
+          if [ "$count" -gt 0 ]; then
+            echo "$alerts" | jq -r '.[] | "::error::CodeQL: \(.rule.id) — \(.rule.description) (\(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line))"'
+            echo "::error::${count} open CodeQL alert(s) on ${REF}"
+            exit 1
+          fi
+          echo "No open CodeQL alerts on ${REF}."

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -91,6 +91,17 @@ jobs:
     needs: [preflight]
     uses: ./.github/workflows/_package_check.yml
 
+  # Static analysis of the package source. Called rather than triggered on its own, so this
+  # pipeline's gate can depend on it; permissions are set here because a called workflow cannot
+  # hold more than its caller's job grants.
+  codeql:
+    needs: [preflight]
+    permissions:
+      security-events: write  # upload the analysis, then read back its alerts
+      contents: read
+      actions: read
+    uses: ./.github/workflows/codeql.yml
+
   # Synchronous dependency-CVE gate: audits the locked runtime dependencies
   # against the advisory DB at PR time — the blocking complement to the async,
   # repo-level Dependabot alerts. Hard-fails on any advisory; accepted ones go
@@ -125,7 +136,7 @@ jobs:
     # `always()` is load-bearing — without it the gate is skipped when an
     # upstream job fails, and GitHub treats a skipped required check as passing.
     if: always()
-    needs: [preflight, pre-commit, test, package, pip-audit]
+    needs: [preflight, pre-commit, test, package, pip-audit, codeql]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job did not succeed

--- a/scripts/_spike_vuln.py
+++ b/scripts/_spike_vuln.py
@@ -1,0 +1,12 @@
+"""TEMPORARY spike file -- deliberately vulnerable, to prove the CodeQL gate fails the build.
+
+Deleted before anything merges. `sys.argv` is a taint source for CodeQL's Python queries, so
+passing it into a shell trips py/command-line-injection from the default suite.
+"""
+
+import os
+import sys
+
+
+def run_it() -> None:
+    os.system("echo " + sys.argv[1])

--- a/scripts/_spike_vuln.py
+++ b/scripts/_spike_vuln.py
@@ -1,12 +1,33 @@
 """TEMPORARY spike file -- deliberately vulnerable, to prove the CodeQL gate fails the build.
 
-Deleted before anything merges. `sys.argv` is a taint source for CodeQL's Python queries, so
-passing it into a shell trips py/command-line-injection from the default suite.
+Deleted before anything merges. Several unrelated patterns, so the gate is proven by whichever
+of them the default query suite actually reports.
 """
 
 import os
+import socket
+import subprocess
 import sys
+import tempfile
 
 
-def run_it() -> None:
+def taint_into_shell() -> None:
+    """py/command-line-injection: sys.argv is a taint source, os.system a shell sink."""
     os.system("echo " + sys.argv[1])
+
+
+def taint_into_subprocess() -> None:
+    """py/shell-command-constructed-from-input, via shell=True on a built string."""
+    subprocess.call("ls " + sys.argv[1], shell=True)
+
+
+def bind_every_interface() -> int:
+    """py/bind-socket-all-network-interfaces: purely syntactic, no taint tracking needed."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("0.0.0.0", 8080))
+    return s.fileno()
+
+
+def racy_temp_file() -> str:
+    """py/insecure-temporary-file: mktemp is the classic TOCTOU temp-file bug."""
+    return tempfile.mktemp()


### PR DESCRIPTION
Spike — measuring whether `workflow_call` preserves the CodeQL analysis key, and whether the alerts gate fires. Not for merge.