### PR TITLE
chore: scope mutation testing by exclusion instead of inclusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,22 +267,12 @@ addopts = "-n auto --dist worksteal"
 # `mutants/` sandbox, so anything omitted becomes unimportable and test collection fails. The set of
 # files actually mutated is scoped by only_mutate below.
 source_paths = ["src/counted_float"]
-# Everything under _core except the hardware-timed benchmark loops; the pure-Python benchmark ports
-# are fast and tested, so they are in. (mutmut's globs match recursively, but the subfolders are
-# listed explicitly so the intent survives a version whose globbing is literal.)
-only_mutate = [
-    "src/counted_float/_core/counting/*.py",
-    "src/counted_float/_core/counting/config/*.py",
-    "src/counted_float/_core/counting/verbosity/*.py",
-    "src/counted_float/_core/compatibility/*.py",
-    "src/counted_float/_core/models/*.py",
-    "src/counted_float/_core/utils/*.py",
-    "src/counted_float/_core/_cli.py",
-    "src/counted_float/_core/_cli_main.py",
-    "src/counted_float/_core/benchmarking/flops/_sumprod_port.py",
-    "src/counted_float/_core/benchmarking/flops/_array_generator.py",
-    "src/counted_float/_core/benchmarking/flops/_libm_bindings.py",
-]
+# Mutation scope is defined by exclusion, never by inclusion. An inclusion list answers "what is in"
+# once, at the moment it is written, and then silently keeps answering it as the package moves
+# underneath -- a package added or renamed later is simply absent, and nothing anywhere says so. An
+# exclusion list rots the safe way instead: new code is in scope by default, and staying out costs
+# an entry with a reason next to it. The same rule governs the test selection further down.
+#
 # Excluded from mutation -- every surviving mutant here is a false signal, not a real gap:
 #   - _callsite.py is pure call-stack introspection, and mutmut runs tests through a trampoline that
 #     becomes the reported call site, so no test can exercise it.
@@ -292,31 +282,31 @@ only_mutate = [
 #     never exercises) by tests/counting/test_flop_weights_tree_view.py. What remains is purely
 #     cosmetic (color constants, column-packing widths) or equivalent (overwritten list inits, no-op
 #     strict= on always-equal-length zips), so pinning it would add churn, not signal.
+#   - _flops_probes.py holds the hardware-timed loops, which only ever execute compiled under numba.
+#     A mutant there changes what is measured rather than whether anything is correct, and no test
+#     can observe it -- the probes are vouched for by the machine-code drift test instead.
 do_not_mutate = [
     "src/counted_float/_core/counting/verbosity/_callsite.py",
     "src/counted_float/_core/counting/_flop_weights_tree_view.py",
+    "src/counted_float/_core/benchmarking/flops/_flops_probes.py",
 ]
 # -n 0 runs the suite serially (mutmut parallelizes across mutants itself); it overrides the
 # addopts `-n auto` -- `-p no:xdist` would instead make `-n` unrecognized and pytest refuse to start.
 # The --ignore/--deselect drop the tests that assert on the *real* call-site filename, which the
-# trampoline reports as `trampoline.py` (they pass under a normal `make test`).
+# trampoline reports as `trampoline.py` (they pass under a normal `make test`), plus tests/docs/,
+# which reads scripts/ and docs/ files mutmut does not copy into the sandbox.
 pytest_add_cli_args = [
     "-n", "0",
+    "--ignore=tests/docs",
     "--ignore=tests/counting/verbosity/test_callsite.py",
     "--deselect=tests/counting/verbosity/test_flop_counts_with_logging.py::test_the_logged_line_reports_the_incrementing_location",
     "--deselect=tests/counting/verbosity/test_flop_counts_with_logging.py::test_lines_without_a_note_carry_no_rationale",
     "--deselect=tests/counting/verbosity/test_info_counting.py::test_logged_lines_locate_the_user_expression_not_the_library",
     "--deselect=tests/counting/verbosity/test_uncounted_warnings.py::test_each_call_site_is_reported_separately",
 ]
-# Sandbox-safe unit tests only: tests/docs/ reads scripts/ and docs/ files mutmut does not copy in,
-# and the slow real-benchmark tests under tests/benchmarking/ are excluded (only the fast port tests).
-pytest_add_cli_args_test_selection = [
-    "tests/counting",
-    "tests/models",
-    "tests/utils",
-    "tests/shared",
-    "tests/cli",
-    "tests/benchmarking/flops/test_sumprod_port.py",
-    "tests/benchmarking/flops/test_array_generator.py",
-    "tests/benchmarking/flops/test_libm_bindings.py",
-]
+# The whole suite, minus what the sandbox genuinely cannot run (see --ignore above). Exclusion, not
+# inclusion, for the reason given at only_mutate's old home: a listed set of directories stops being
+# true the moment one is added, and it fails silently -- tests/evaluation/ and
+# tests/micro_benchmarking/ were invisible to mutmut from the day they were created, which is how
+# code with tests came to be reported as having none.
+pytest_add_cli_args_test_selection = ["tests"]


### PR DESCRIPTION
**TL;DR**: Mutation scope and test selection were inclusion lists that stopped being true as the package moved; both become exclusion lists, and the score drops to its first accurate reading.

## Description

### Problem addressed

Two hand-written lists decided what mutation testing covered: which source files to mutate, and which test directories to run. Both answer "what is in" once, at the moment they are written, and then keep answering it while the package changes underneath.

That failed silently and in the worst direction. **Two test directories created by the recent restructure were never added to the selection**, so mutmut ran without them — and reported code that *is* tested as having no tests at all. Meanwhile three source packages have never been mutated, not by any recorded decision, but because no glob happened to match them.

The score that came out of this was computed over roughly two-thirds of the eligible code, which is worse than a low score: it was a confident number about the wrong thing.

### Implementation

Scope is now **the whole package and the whole suite, minus named exceptions**. New code is in scope by default; staying out costs an entry with a reason beside it.

Only two exclusions are genuinely needed. `tests/docs/` reads files the sandbox does not copy in, and the hardware-timed probe loops only ever execute compiled, so a mutant there changes what gets measured rather than whether anything is correct.

The rest of the old exclusions turned out to be **collateral**: the benchmark tests were kept out as "slow real benchmarks", but the whole directory runs in a few seconds and reads nothing outside the sandbox. They now run.

## Attention points

- **The score drops from 88.1% to 77.3%**, and the badge with it. This is not a regression — it is the first reading taken over the real scope. The 88.1% was measured against a smaller denominator that excluded whole packages.
- **454 of the new survivors are concentrated in three modules.** Roughly half sit in the flops suite and are measurement-parameter mutants that no test can kill; the timing layer's are real, killable gaps. Deliberately not acted on here — a triage is worth more than a hasty exclusion, and hasty exclusions are what this PR exists to undo.
- **Runtime grows** with the scope: ~3000 mutants where there were ~1900.

## Tests / Spikes

- **SPIKE:** measured every currently-excluded benchmark test — slowest is 2.95s, the directory total is a few seconds, and none reads outside the copied set. That is what showed the "slow benchmark" rationale no longer held.
- **SPIKE:** sampled survivors per newly-covered module to check the drop is real rather than an artifact — the flops-suite ones mutate measurement parameters, the timing-layer ones mutate calibration logic.
- **TEST:** full suite and lint green; the mutation run completes clean with `no_tests` back to zero, having been 2.

## Changelog entry

None: test tooling configuration, with no user-facing effect.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
