### PR TITLE
chore: make a CodeQL finding fail the pull-request gate

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,23 +4,15 @@ name: CodeQL
 # (which lint the workflows, not the package code).
 #
 # Pull requests reach this through the PR pipeline, which calls it as a reusable
-# workflow so that pipeline's gate can depend on the result. That placement moves
-# the code-scanning analysis key from this file to the caller's, which retires an
-# earlier rule that every trigger had to live here to keep one key. The key's only
-# job was code scanning's introduced-versus-inherited comparison, and that
-# comparison has never worked on this repo: its check run is posted a second or two
-# before the analysis registers and is never re-evaluated, so it reported `neutral`
-# on eight consecutive pull requests. Nothing here consults it.
+# workflow so that pipeline's gate can depend on the result. Pushes to main and the
+# weekly schedule run it directly.
 #
-# What gates a merge is the last step below: it reads back the alerts this analysis
-# just uploaded and fails on any of them. `github/codeql-action/analyze` has no
-# fail-on-alerts input and exits 0 regardless, so without that step the scan runs
-# and nothing acts on it.
+# `github/codeql-action/analyze` exits 0 whether or not it finds anything, and code
+# scanning's own check run cannot be relied on to block a merge. The last step below
+# is what gates: it reads back the alerts this analysis uploaded and fails on any.
 #
-# Scope note, measured rather than assumed: the queries below report syntactic
-# findings reliably, but taint-tracking ones did not fire on planted argv-to-shell
-# and shell=True cases under either the default or the extended suite. Do not read
-# a green gate as evidence that injection-class defects are absent.
+# The queries report syntactic findings reliably. They are not a guarantee about
+# injection-class defects: a green result here is not evidence that none are present.
 
 on:
   workflow_call:
@@ -55,10 +47,7 @@ jobs:
         uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: python  # pure-Python package: no build step, CodeQL analyzes sources directly
-          # measured on this codebase: 43 rules -> 50, and zero findings either way, so the wider
-          # suite costs no false positives. It is taken as a free superset, not as a fix -- see the
-          # scope note in the header for what neither suite catches.
-          queries: security-extended
+          queries: security-extended  # superset of the default suite, at no false-positive cost here
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
@@ -68,15 +57,14 @@ jobs:
           # analysis key does that, and no category overrides it (see the header).
           category: python
 
-      # The gate. `analyze` above exits 0 whether or not it found anything, and code scanning's own
-      # check run is posted before the upload registers and never re-evaluated -- so neither can
-      # block a merge. This reads the alerts back and fails on any of them.
+      # The gate: neither `analyze` above nor code scanning's own check run can fail a build on
+      # findings, so this reads the alerts back and does it.
       #
-      # Filtered to CodeQL because Scorecard publishes to the same alert store and currently has
-      # open findings there; an unfiltered gate would be red on every pull request from day one.
-      # Gating on any open alert for the ref, rather than on the ones this PR introduced, because
-      # the introduced-versus-inherited comparison is exactly what does not work -- and any-open is
-      # already how pip-audit behaves in this pipeline.
+      # Filtered to CodeQL: Scorecard publishes to the same alert store, and what it reports is
+      # repository posture rather than anything this gate is answering for.
+      #
+      # Gating on any open alert for the ref rather than on the ones a pull request introduced,
+      # which is also how pip-audit behaves in this pipeline.
       - name: Fail on CodeQL findings
         shell: bash
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,24 +3,27 @@ name: CodeQL
 # Static analysis (SAST) for the Python package. Complements zizmor/actionlint
 # (which lint the workflows, not the package code).
 #
-# Every trigger lives here, and that is load-bearing rather than tidy. Code
-# scanning identifies a configuration by analysis key — `<workflow file>:<job>` —
-# and compares a pull request against the configurations recorded on its base
-# branch. Scanning pull requests from one workflow file and `main` from another
-# therefore produces two keys that never match, and every PR reports that the
-# alerts it introduced could not be determined. One file, one key, one comparison.
+# Pull requests reach this through the PR pipeline, which calls it as a reusable
+# workflow so that pipeline's gate can depend on the result. That placement moves
+# the code-scanning analysis key from this file to the caller's, which retires an
+# earlier rule that every trigger had to live here to keep one key. The key's only
+# job was code scanning's introduced-versus-inherited comparison, and that
+# comparison has never worked on this repo: its check run is posted a second or two
+# before the analysis registers and is never re-evaluated, so it reported `neutral`
+# on eight consecutive pull requests. Nothing here consults it.
 #
-# The `pull_request` trigger deliberately carries no base-branch filter, matching
-# the PR pipeline's own stance: a PR based on another feature branch is scanned
-# while it is being reviewed, which is the window that matters.
+# What gates a merge is the last step below: it reads back the alerts this analysis
+# just uploaded and fails on any of them. `github/codeql-action/analyze` has no
+# fail-on-alerts input and exits 0 regardless, so without that step the scan runs
+# and nothing acts on it.
 #
-# This step exits 0 whether or not it finds anything, so it gates nothing by
-# itself. What acts on findings is code scanning's own check run, which branch
-# protection requires — and requiring it is also what makes a merge wait for the
-# scan, since a required check has to report before the merge button unlocks.
+# Scope note, measured rather than assumed: the queries below report syntactic
+# findings reliably, but taint-tracking ones did not fire on planted argv-to-shell
+# and shell=True cases under either the default or the extended suite. Do not read
+# a green gate as evidence that injection-class defects are absent.
 
 on:
-  pull_request:
+  workflow_call:
   push:
     branches: [main]
   schedule:
@@ -30,7 +33,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # deliberately not ${{ github.workflow }}: when called, that resolves to the CALLER's
+  # name, so this would share a group with the PR pipeline and the two would cancel
+  # each other on every push.
+  group: codeql-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -49,6 +55,10 @@ jobs:
         uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: python  # pure-Python package: no build step, CodeQL analyzes sources directly
+          # measured on this codebase: 43 rules -> 50, and zero findings either way, so the wider
+          # suite costs no false positives. It is taken as a free superset, not as a fix -- see the
+          # scope note in the header for what neither suite catches.
+          queries: security-extended
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
@@ -57,3 +67,40 @@ jobs:
           # what makes a pull request comparable to its base branch — the
           # analysis key does that, and no category overrides it (see the header).
           category: python
+
+      # The gate. `analyze` above exits 0 whether or not it found anything, and code scanning's own
+      # check run is posted before the upload registers and never re-evaluated -- so neither can
+      # block a merge. This reads the alerts back and fails on any of them.
+      #
+      # Filtered to CodeQL because Scorecard publishes to the same alert store and currently has
+      # open findings there; an unfiltered gate would be red on every pull request from day one.
+      # Gating on any open alert for the ref, rather than on the ones this PR introduced, because
+      # the introduced-versus-inherited comparison is exactly what does not work -- and any-open is
+      # already how pip-audit behaves in this pipeline.
+      - name: Fail on CodeQL findings
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
+        run: |
+          # the alerts lag the upload by a second or two, so a first unavailable read means "not
+          # yet" rather than "clean" -- poll briefly before believing it
+          alerts="unavailable"
+          for attempt in 1 2 3 4 5; do
+            alerts=$(gh api "repos/${GITHUB_REPOSITORY}/code-scanning/alerts?ref=${REF}&state=open&per_page=100" \
+                       --jq '[.[] | select(.tool.name == "CodeQL")]' 2>/dev/null || echo "unavailable")
+            [ "$alerts" != "unavailable" ] && break
+            echo "code scanning has no data for ${REF} yet (attempt ${attempt}); waiting."
+            sleep 10
+          done
+          if [ "$alerts" = "unavailable" ]; then
+            echo "::error::could not read code scanning alerts for ${REF}"
+            exit 1
+          fi
+          count=$(echo "$alerts" | jq 'length')
+          if [ "$count" -gt 0 ]; then
+            echo "$alerts" | jq -r '.[] | "::error::CodeQL: \(.rule.id) — \(.rule.description) (\(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line))"'
+            echo "::error::${count} open CodeQL alert(s) on ${REF}"
+            exit 1
+          fi
+          echo "No open CodeQL alerts on ${REF}."

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -91,6 +91,17 @@ jobs:
     needs: [preflight]
     uses: ./.github/workflows/_package_check.yml
 
+  # Static analysis of the package source. Called rather than left on its own trigger, so this
+  # pipeline's gate can depend on the result; permissions are declared here because a called
+  # workflow cannot hold more than its calling job grants.
+  codeql:
+    needs: [preflight]
+    permissions:
+      security-events: write  # upload the analysis, then read its alerts back
+      contents: read
+      actions: read
+    uses: ./.github/workflows/codeql.yml
+
   # Synchronous dependency-CVE gate: audits the locked runtime dependencies
   # against the advisory DB at PR time — the blocking complement to the async,
   # repo-level Dependabot alerts. Hard-fails on any advisory; accepted ones go
@@ -125,7 +136,7 @@ jobs:
     # `always()` is load-bearing — without it the gate is skipped when an
     # upstream job fails, and GitHub treats a skipped required check as passing.
     if: always()
-    needs: [preflight, pre-commit, test, package, pip-audit]
+    needs: [preflight, pre-commit, test, package, pip-audit, codeql]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job did not succeed


### PR DESCRIPTION
**TL;DR**: CodeQL has scanned every pull request without being able to block one; a finding now fails the pipeline gate.

## Description

### Problem addressed

The scan runs, uploads, and reports — and nothing consumes the result. `github/codeql-action/analyze` has no fail-on-alerts input and exits 0 regardless of what it finds, and branch protection requires exactly one context, the pipeline's own gate, which has never depended on CodeQL in any form.

The one check that *does* reflect findings is posted by GitHub's advanced-security app, and it cannot be relied on: measured across eight consecutive pull requests, it concluded **`neutral` eight times out of eight**, evaluated one to two seconds *before* the analysis it is meant to read had registered, and never re-evaluated. GitHub treats `neutral` as passing.

So the repository has had a security scanner wired to nothing, while the workflow's own header comment described a blocking arrangement that did not exist.

### Implementation

The pipeline now **calls** the CodeQL workflow and lists it as a gate dependency, and a step after the analysis reads back the alerts it just uploaded and fails on any of them.

Two details are deliberate. The alert query is **filtered to CodeQL**, because Scorecard publishes to the same store and has open findings there — an unfiltered gate would be red on every PR from the moment it landed. And it gates on **any open alert for the ref** rather than on the ones the PR introduced, because introduced-versus-inherited is precisely the comparison that does not work here; any-open is also how `pip-audit` already behaves in this pipeline.

The query suite moves to `security-extended`, and the header comment is rewritten — it was wrong on two counts.

## Attention points

- **The analysis key moves to the calling workflow.** That retires a documented rule that every trigger had to live in one file to keep one key. Accepted: the key's only job was the introduced-versus-inherited comparison, which has never functioned here, and this gate does not consult it.
- **`security-extended` is a free superset, not a fix.** Measured on this codebase: 43 rules to 50, **zero findings either way**. It buys no demonstrated capability — see below — but costs no false positives.
- **Measured scope limit, worth knowing before trusting a green gate:** four deliberate vulnerabilities were planted; both syntactic ones were reported and **both taint-based ones were missed under both suites** — argv into a shell, and a shell-true subprocess built from a string. The probe was re-shaped as a canonical `__main__` entry point in case an uncalled function was not an entry point for taint analysis; still nothing, with the file confirmed extracted and the analysis clean rather than filtered. This gate should not be expected to catch injection-class defects in Python.
- **The concurrency group is deliberately not keyed on `github.workflow`** — when called, that resolves to the *caller's* name, which would put this in the same group as the PR pipeline and have the two cancel each other.

## Tests / Spikes

- **SPIKE:** the gate was proven to fire before being trusted — planted findings produced two alerts, a red analysis job, a red pipeline gate, and annotations naming the rule, file and line for each.
- **SPIKE:** `workflow_call` was measured *not* to preserve the analysis key; it becomes the caller's path. That is what the header rewrite documents.
- **SPIKE:** the extended suite was measured against this codebase for false-positive volume before adoption, then against planted taint cases for added coverage. Zero on both counts.
- **TEST:** the assembled configuration — called workflow, extended suite, alerts gate — is verified end to end on this branch, clean and red, rather than only as separately-proven pieces.

## Changelog entry

None: CI configuration, with no user-facing effect.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
