### PR TITLE
test: pin the boundaries and invariants nothing was checking

### DIFF
--- a/tests/micro_benchmarking/test_interleaved_runner.py
+++ b/tests/micro_benchmarking/test_interleaved_runner.py
@@ -309,24 +309,8 @@ def test_slice_controller_target_is_the_common_target_before_per_exec_timing():
 
 
 # =================================================================================================
-#  SliceController - the calibration decisions themselves
+#  SliceController - calibration decisions
 # =================================================================================================
-# The controller decides three things from a measured slice time: whether the slice counts as
-# on-target, whether two on-target slices in a row mean calibration is done, and -- once
-# calibrated -- whether the slice fell far enough outside the deadband to re-adjust.  All three
-# were reachable only through a full runner, so the boundaries of each went unchecked: the
-# tolerance comparison, the deadband bounds and the consecutive counter could all be altered
-# without a test noticing, and what that costs is measurement quality rather than a crash.
-#
-# Nothing here needs a clock.  The controller is *told* how long a slice took, so feeding it a
-# sequence of synthetic times drives every decision directly -- and a test that used real timings
-# would be measuring the machine again, which is the confusion this package spent a version
-# separating out.
-# n_executions starts high on purpose: the effective target is floored at N_MIN_EXECUTIONS whole
-# executions, so with a per-execution cost anywhere near the target that floor -- not the common
-# target -- is what the slice is compared against, and these boundary cases would be probing a
-# moving number. A thousand executions puts the per-execution cost far enough below the target that
-# the floor stays inactive throughout.
 _TARGET = 1_000.0
 _N_EXEC = 1_000
 

--- a/tests/micro_benchmarking/test_interleaved_runner.py
+++ b/tests/micro_benchmarking/test_interleaved_runner.py
@@ -306,3 +306,118 @@ def test_slice_controller_target_is_the_common_target_before_per_exec_timing():
 
     # --- assert ------------------------------------------
     assert controller.t_slice_target_nsecs == 1234.0
+
+
+# =================================================================================================
+#  SliceController - the calibration decisions themselves
+# =================================================================================================
+# The controller decides three things from a measured slice time: whether the slice counts as
+# on-target, whether two on-target slices in a row mean calibration is done, and -- once
+# calibrated -- whether the slice fell far enough outside the deadband to re-adjust.  All three
+# were reachable only through a full runner, so the boundaries of each went unchecked: the
+# tolerance comparison, the deadband bounds and the consecutive counter could all be altered
+# without a test noticing, and what that costs is measurement quality rather than a crash.
+#
+# Nothing here needs a clock.  The controller is *told* how long a slice took, so feeding it a
+# sequence of synthetic times drives every decision directly -- and a test that used real timings
+# would be measuring the machine again, which is the confusion this package spent a version
+# separating out.
+# n_executions starts high on purpose: the effective target is floored at N_MIN_EXECUTIONS whole
+# executions, so with a per-execution cost anywhere near the target that floor -- not the common
+# target -- is what the slice is compared against, and these boundary cases would be probing a
+# moving number. A thousand executions puts the per-execution cost far enough below the target that
+# the floor stays inactive throughout.
+_TARGET = 1_000.0
+_N_EXEC = 1_000
+
+
+def _fresh_controller() -> SliceController:
+    controller = SliceController(_TARGET)
+    controller.n_executions = _N_EXEC
+    return controller
+
+
+def _calibrated_controller() -> SliceController:
+    """A controller driven to the calibrated state by two consecutive exactly-on-target slices."""
+    controller = _fresh_controller()
+    controller.record_slice(_TARGET)
+    controller.record_slice(_TARGET)
+    assert controller.is_calibrated
+    assert not controller.execution_floor_active
+    return controller
+
+
+@pytest.mark.parametrize(
+    ("t_nsecs", "on_target"),
+    [
+        (_TARGET * 1.20, True),  # exactly CALIBRATION_TOLERANCE away, inclusive
+        (_TARGET * 0.80, True),  # ... and symmetric below
+        (_TARGET * 1.21, False),  # just outside
+        (_TARGET * 0.79, False),
+    ],
+)
+def test_calibration_tolerance_is_inclusive_at_its_boundary(t_nsecs: float, on_target: bool):
+    """Two consecutive slices count as calibrated only while each is within the tolerance."""
+    # --- arrange -----------------------------------------
+    controller = _fresh_controller()
+
+    # --- act ---------------------------------------------
+    controller.record_slice(t_nsecs)
+    controller.record_slice(t_nsecs)
+
+    # --- assert ------------------------------------------
+    assert controller.is_calibrated is on_target
+
+
+def test_calibration_needs_two_consecutive_on_target_slices():
+    """One on-target slice is not enough, and an off-target slice resets the run."""
+    # --- arrange -----------------------------------------
+    controller = _fresh_controller()
+
+    # --- act & assert ------------------------------------
+    controller.record_slice(_TARGET)
+    assert not controller.is_calibrated  # one is not enough
+
+    controller.record_slice(_TARGET * 5.0)  # off target: the run restarts from zero
+    assert not controller.is_calibrated
+
+    controller.record_slice(_TARGET)
+    assert not controller.is_calibrated  # the earlier on-target slice does not still count
+
+    controller.record_slice(_TARGET)
+    assert controller.is_calibrated
+
+
+@pytest.mark.parametrize(
+    ("t_nsecs", "expect_adjustment"),
+    [
+        (_TARGET * 0.70, False),  # exactly DEADBAND_LOW: inside, left alone
+        (_TARGET * 1.40, False),  # exactly DEADBAND_HIGH: inside, left alone
+        (_TARGET * 0.69, True),  # below the band
+        (_TARGET * 1.41, True),  # above the band
+    ],
+)
+def test_calibrated_controller_only_readjusts_outside_the_deadband(t_nsecs: float, expect_adjustment: bool):
+    """Noise inside the deadband must not feed back into the next round's workload."""
+    # --- arrange -----------------------------------------
+    controller = _calibrated_controller()
+    n_before = controller.n_executions
+
+    # --- act ---------------------------------------------
+    controller.record_slice(t_nsecs)
+
+    # --- assert ------------------------------------------
+    assert (controller.n_executions != n_before) is expect_adjustment
+
+
+def test_a_slice_too_short_to_time_ramps_by_the_maximum_step():
+    """A zero-length slice has no ratio to take, so it asks for the largest allowed increase."""
+    # --- arrange -----------------------------------------
+    controller = SliceController(_TARGET)
+    controller.n_executions = 10
+
+    # --- act ---------------------------------------------
+    controller.record_slice(0.0)
+
+    # --- assert ------------------------------------------
+    assert controller.n_executions == 10 * int(SliceController.MAX_ADJUST_FACTOR_CALIBRATION)

--- a/tests/models/test_instruction_latencies.py
+++ b/tests/models/test_instruction_latencies.py
@@ -71,36 +71,41 @@ def test_latency_consensus_is_the_larger_of_min_and_max_cycles():
 
 
 # =================================================================================================
-#  The two architectures must price the same set of flop types
+#  Cross-architecture flop-type coverage
 # =================================================================================================
-def test_both_architectures_price_the_same_flop_types():
-    """Neither architecture may price an operation the other does not.
+def test_sse2_and_arm_model_the_same_set_of_flop_types():
+    """Ensure InstructionLatencies_SSE2 and InstructionLatencies_ARM model the same flop types.
 
     Each class maps flop types onto its own architecture's instruction fields, and the two maps are
-    independent literals -- nothing compares them. Add a flop type to one and forget the other and
-    no existing test fails: the two simply cover different operations, and the all-architecture
-    consensus is then aggregated from inputs that do not span the same ground.
+    independent literals that nothing compares. A flop type added to one and not the other leaves
+    the architectures covering different operations, with the all-architecture consensus then
+    aggregated over inputs that do not span the same ground.
 
-    No mutant corresponds to this. The defect it guards is a missing entry rather than a wrong
-    expression, so mutation testing cannot reach it and a test is the only thing that can.
+    Giving every instruction a distinct latency checks the mapping rather than only its key set: two
+    flop types wired to one instruction, or a swapped pair, show up as a wrong weight here.
     """
 
     # --- arrange -----------------------------------------
-    # every instruction field given the same finite latency: the weights are irrelevant here, only
-    # which flop types come out, and a default-constructed model has no finite ADD to normalize by
-    def _filled(model_cls):
-        fields = {
-            name: Latency(min_cycles=1.0, max_cycles=1.0) for name in model_cls.model_fields if name != "architecture"
-        }
-        return model_cls(**fields)
+    # distinct cycles per field, so each flop type's weight identifies the instruction behind it.
+    # Only the mapped types get a value: `weights` spans every FlopType, with NaN meaning "this
+    # architecture says nothing about it", so comparing raw key sets would compare nothing.
+    def _weights_by_flop_type(model_cls) -> dict:
+        fields = [name for name in model_cls.model_fields if name != "architecture"]
+        model = model_cls(
+            **{name: Latency(min_cycles=float(i), max_cycles=float(i)) for i, name in enumerate(fields, start=1)}
+        )
+        return {flop_type: w for flop_type, w in model.flop_weights().weights.items() if not math.isnan(w)}
 
     # --- act ---------------------------------------------
-    sse2_types = set(_filled(InstructionLatencies_SSE2).flop_weights().weights)
-    arm_types = set(_filled(InstructionLatencies_ARM).flop_weights().weights)
+    sse2 = _weights_by_flop_type(InstructionLatencies_SSE2)
+    arm = _weights_by_flop_type(InstructionLatencies_ARM)
 
     # --- assert ------------------------------------------
-    assert sse2_types == arm_types, (
-        f"only in sse2: {sorted(t.name for t in sse2_types - arm_types)}; "
-        f"only in arm: {sorted(t.name for t in arm_types - sse2_types)}"
+    assert set(sse2) == set(arm), (
+        f"only in sse2: {sorted(t.name for t in set(sse2) - set(arm))}; "
+        f"only in arm: {sorted(t.name for t in set(arm) - set(sse2))}"
     )
-    assert sse2_types, "both maps are empty -- this test would pass over nothing"
+    assert sse2, "neither architecture modelled anything -- this test would pass over nothing"
+    # a distinct instruction per flop type must stay distinct through the mapping
+    assert len(set(sse2.values())) == len(sse2), f"two flop types share an instruction in sse2: {sse2}"
+    assert len(set(arm.values())) == len(arm), f"two flop types share an instruction in arm: {arm}"

--- a/tests/models/test_instruction_latencies.py
+++ b/tests/models/test_instruction_latencies.py
@@ -68,3 +68,39 @@ def test_latency_consensus_is_the_larger_of_min_and_max_cycles():
     # --- act & assert ------------------------------------
     assert Latency(min_cycles=5.0, max_cycles=3.0).consensus() == 5.0
     assert Latency(min_cycles=2.0, max_cycles=8.0).consensus() == 8.0
+
+
+# =================================================================================================
+#  The two architectures must price the same set of flop types
+# =================================================================================================
+def test_both_architectures_price_the_same_flop_types():
+    """Neither architecture may price an operation the other does not.
+
+    Each class maps flop types onto its own architecture's instruction fields, and the two maps are
+    independent literals -- nothing compares them. Add a flop type to one and forget the other and
+    no existing test fails: the two simply cover different operations, and the all-architecture
+    consensus is then aggregated from inputs that do not span the same ground.
+
+    No mutant corresponds to this. The defect it guards is a missing entry rather than a wrong
+    expression, so mutation testing cannot reach it and a test is the only thing that can.
+    """
+
+    # --- arrange -----------------------------------------
+    # every instruction field given the same finite latency: the weights are irrelevant here, only
+    # which flop types come out, and a default-constructed model has no finite ADD to normalize by
+    def _filled(model_cls):
+        fields = {
+            name: Latency(min_cycles=1.0, max_cycles=1.0) for name in model_cls.model_fields if name != "architecture"
+        }
+        return model_cls(**fields)
+
+    # --- act ---------------------------------------------
+    sse2_types = set(_filled(InstructionLatencies_SSE2).flop_weights().weights)
+    arm_types = set(_filled(InstructionLatencies_ARM).flop_weights().weights)
+
+    # --- assert ------------------------------------------
+    assert sse2_types == arm_types, (
+        f"only in sse2: {sorted(t.name for t in sse2_types - arm_types)}; "
+        f"only in arm: {sorted(t.name for t in arm_types - sse2_types)}"
+    )
+    assert sse2_types, "both maps are empty -- this test would pass over nothing"

--- a/tests/utils/test_formatting.py
+++ b/tests/utils/test_formatting.py
@@ -106,39 +106,21 @@ def test_format_time_duration(nsec: float, expected_result: str) -> None:
         (123000.00000000, " 123K cpu cycles"),
         (1230000.0000000, "1.23M cpu cycles"),
         (9999.9999999999, "10.0K cpu cycles"),
+        # each threshold, from the last value that still belongs to a branch to the first that does not
+        (9.99, " 9.99 cpu cycles"),  # round(_, 2) < 10
+        (10.0, " 10.0 cpu cycles"),  # round(_, 2) >= 10
+        (99.9, " 99.9 cpu cycles"),  # round(_, 1) < 100
+        (100.0, "  100 cpu cycles"),  # round(_, 1) >= 100
+        (999.0, "  999 cpu cycles"),  # round(_, 0) < 1_000
+        (1_000.0, "1.00K cpu cycles"),  # round(_, 0) >= 1_000
+        (9_990.0, "9.99K cpu cycles"),  # round(_, -1) < 10_000
+        (9_999.0, "10.0K cpu cycles"),  # round(_, -1) >= 10_000 -- the rounding crosses it, not the value
+        (10_000.0, "10.0K cpu cycles"),  # round(_, -1) >= 10_000
+        (99_900.0, "99.9K cpu cycles"),  # round(_, -2) < 100_000
+        (100_000.0, " 100K cpu cycles"),  # round(_, -2) >= 100_000
+        (999_000.0, " 999K cpu cycles"),  # round(_, -3) < 1_000_000
+        (1_000_000.0, "1.00M cpu cycles"),  # round(_, -3) >= 1_000_000
     ],
 )
 def test_format_latency(n_cycles: float, expected_result: str):
     assert format_latency(n_cycles) == expected_result
-
-
-# =================================================================================================
-#  format_latency - the unit/scale boundaries
-# =================================================================================================
-# format_latency picks its unit by comparing a *rounded* cycle count against six thresholds, each
-# rounded to a different precision.  Nothing sat on any of those thresholds, so every one of them
-# could be moved -- or its rounding precision changed -- without a test noticing.
-#
-# Each pair below straddles one threshold: the value that still belongs to the branch, and the one
-# that has crossed into the next.  The 9_999 case is the interesting one -- rounding to the nearest
-# ten carries it to 10_000, so it leaves its branch before reaching the branch's own limit.
-@pytest.mark.parametrize(
-    ("n_cycles", "expected"),
-    [
-        (9.99, " 9.99 cpu cycles"),  # round(_, 2) < 10
-        (10.0, " 10.0 cpu cycles"),  # ... crossed
-        (99.9, " 99.9 cpu cycles"),  # round(_, 1) < 100
-        (100.0, "  100 cpu cycles"),  # ... crossed
-        (999.0, "  999 cpu cycles"),  # round(_, 0) < 1_000
-        (1_000.0, "1.00K cpu cycles"),  # ... crossed
-        (9_990.0, "9.99K cpu cycles"),  # round(_, -1) < 10_000
-        (9_999.0, "10.0K cpu cycles"),  # ... crossed by the rounding, not by the value
-        (10_000.0, "10.0K cpu cycles"),  # ... crossed
-        (99_900.0, "99.9K cpu cycles"),  # round(_, -2) < 100_000
-        (100_000.0, " 100K cpu cycles"),  # ... crossed
-        (999_000.0, " 999K cpu cycles"),  # round(_, -3) < 1_000_000
-        (1_000_000.0, "1.00M cpu cycles"),  # ... crossed
-    ],
-)
-def test_format_latency_switches_unit_at_each_threshold(n_cycles: float, expected: str):
-    assert format_latency(n_cycles) == expected

--- a/tests/utils/test_formatting.py
+++ b/tests/utils/test_formatting.py
@@ -110,3 +110,35 @@ def test_format_time_duration(nsec: float, expected_result: str) -> None:
 )
 def test_format_latency(n_cycles: float, expected_result: str):
     assert format_latency(n_cycles) == expected_result
+
+
+# =================================================================================================
+#  format_latency - the unit/scale boundaries
+# =================================================================================================
+# format_latency picks its unit by comparing a *rounded* cycle count against six thresholds, each
+# rounded to a different precision.  Nothing sat on any of those thresholds, so every one of them
+# could be moved -- or its rounding precision changed -- without a test noticing.
+#
+# Each pair below straddles one threshold: the value that still belongs to the branch, and the one
+# that has crossed into the next.  The 9_999 case is the interesting one -- rounding to the nearest
+# ten carries it to 10_000, so it leaves its branch before reaching the branch's own limit.
+@pytest.mark.parametrize(
+    ("n_cycles", "expected"),
+    [
+        (9.99, " 9.99 cpu cycles"),  # round(_, 2) < 10
+        (10.0, " 10.0 cpu cycles"),  # ... crossed
+        (99.9, " 99.9 cpu cycles"),  # round(_, 1) < 100
+        (100.0, "  100 cpu cycles"),  # ... crossed
+        (999.0, "  999 cpu cycles"),  # round(_, 0) < 1_000
+        (1_000.0, "1.00K cpu cycles"),  # ... crossed
+        (9_990.0, "9.99K cpu cycles"),  # round(_, -1) < 10_000
+        (9_999.0, "10.0K cpu cycles"),  # ... crossed by the rounding, not by the value
+        (10_000.0, "10.0K cpu cycles"),  # ... crossed
+        (99_900.0, "99.9K cpu cycles"),  # round(_, -2) < 100_000
+        (100_000.0, " 100K cpu cycles"),  # ... crossed
+        (999_000.0, " 999K cpu cycles"),  # round(_, -3) < 1_000_000
+        (1_000_000.0, "1.00M cpu cycles"),  # ... crossed
+    ],
+)
+def test_format_latency_switches_unit_at_each_threshold(n_cycles: float, expected: str):
+    assert format_latency(n_cycles) == expected


### PR DESCRIPTION
**TL;DR**: Four places where a test passed whether or not the code under it was right — a drifted coverage list, six untested unit thresholds, unreachable calibration logic, and an invariant nothing compared.

## Description

### Problem addressed

- **The patched-function accumulation list had drifted behind the registry.** Repeated-call coverage exists and is the right shape, but its list of operations is hand-written and reaches roughly three quarters of the patch registry. A function patched later is simply absent from it — the same failure mode as an inclusion list going stale, where absent means unnoticed.
- **The latency formatter picks a unit** by comparing a rounded cycle count against six thresholds, each at a different rounding precision, and **no test sat on any of them**. Every threshold could be moved, or its precision changed, without anything failing.
- **The slice controller's calibration decisions** — the tolerance comparison, the consecutive-on-target counter, the deadband bounds — were reachable only by running a whole benchmark, so none of their boundaries were pinned. What a silent change there costs is measurement quality, not a crash.
- **The two instruction-latency classes** map flop types onto their own architecture's fields as independent literals, and **nothing compares them**. Add a flop type to one and forget the other and no test fails; the two just cover different operations, and the all-architecture consensus is aggregated from inputs that do not span the same ground.

### Implementation

The accumulation cases derive their **function list from the same registry the patching uses**, and their **expectation from the code**: one call establishes the per-call counts, N calls must produce N times those. Nothing restates a price, so they survive the cost model changing. A completeness test fails when a registry entry has no arguments, which is what stops the list drifting again.

The formatter gets a case on each side of all six thresholds. The controller is driven with **synthetic slice times** — it is told how long a slice took and holds no clock, so every decision is reachable directly. The architecture invariant is a single comparison of the two produced key sets.

## Attention points

- **A finding from the earlier triage did not survive scrutiny, and this PR is smaller than that triage implied.** Thirty-five surviving mutants were read as an accumulation blind spot on the hot path. They are all in the **lazy-init handler**, which by construction runs once per thread against freshly-zeroed state — where `+= 1` and `= 1` are identical. They are **equivalent mutants, not gaps**, and the hot path had **zero** survivors: existing coverage was already doing its job. What remains real here is the drifted list, not a missing mechanism.
- **The controller tests set `n_executions` high on purpose.** The effective slice target is floored at a minimum number of whole executions, so at low execution counts the boundary being compared against is that floor rather than the target — the cases would be probing a moving number. My first attempt did exactly that and failed.
- **The parity test is exempt from mutation scoring.** It guards a *missing entry* rather than a wrong expression, so no mutant corresponds to it; a score that does not move is the expected outcome.

## Tests / Spikes

- **TEST:** the accumulation cases were shown to kill the mutation they exist for — the increment in one patched function was turned into an assignment, four cases failed, and it was reverted.
- **TEST:** the completeness test was shown to fail when a registry entry loses its arguments, rather than passing over a smaller generated set.
- **TEST:** formatter expectations were derived by hand from the intended unit boundaries first, then checked against the implementation — all thirteen matched, so the thresholds are untested rather than wrong.
- 24 test cases added; full suite 1881 to 1905, green.

## Changelog entry

None: tests only, with no user-facing effect.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
