### PR TITLE
refactor: resolve source files through a pydantic union

### DIFF
--- a/src/counted_float/_core/counting/_builtin_data.py
+++ b/src/counted_float/_core/counting/_builtin_data.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import json
 from functools import cache
 from importlib.resources import files
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, ValidationError
+from pydantic import TypeAdapter
 
 from counted_float._core.models import (
     FlopsBenchmarkResults,
@@ -16,10 +16,7 @@ from counted_float._core.models import (
 from ._flop_weights_tree_view import FlopWeightsTreeView
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
     from importlib.resources.abc import Traversable
-
-PydanticModelT = TypeVar("PydanticModelT", bound=BaseModel)
 
 DATA_PACKAGE = "counted_float.data"
 
@@ -33,6 +30,12 @@ PRECOMPUTED_WEIGHTS_FILE = "consensus_flop_weights.json"
 # a source tree is str-keyed all the way down: each level maps a name to either a deeper level or a
 # leaf FlopWeights. Recursive so the isinstance-driven descent below type-checks against itself.
 NestedFlopWeights = dict[str, "NestedFlopWeights | FlopWeights"]
+
+# Every source file is one of these two shapes. Their field sets are disjoint, so pydantic's
+# smart union resolves them on its own, and a file matching neither raises an error naming what
+# failed in each branch -- which a try-each-class loop can only approximate.
+_SourceFile = FlopsBenchmarkResults | InstructionLatencies
+_SOURCE_FILE_ADAPTER: TypeAdapter[_SourceFile] = TypeAdapter(_SourceFile)
 
 
 def _data_sources_root() -> Traversable:
@@ -99,7 +102,7 @@ class BuiltInData:
     @classmethod
     def benchmarks(cls) -> dict[str, FlopsBenchmarkResults]:
         return {
-            key: _deserialize_as_any_pydantic_class(json_str, [FlopsBenchmarkResults])
+            key: FlopsBenchmarkResults.model_validate_json(json_str)
             for key, json_str in _load_json_files_as_dict(_data_sources_root()).items()
             if "benchmark" in key
         }
@@ -205,25 +208,4 @@ def _construct_flop_weights_from_json_str(json_str: str) -> FlopWeights:
         FlopWeights instance extracted from the input data.
     """
     # try all supported classes, all of which have a .flop_weights property
-    return _deserialize_as_any_pydantic_class(
-        json_str,
-        [
-            FlopsBenchmarkResults,
-            InstructionLatencies,
-        ],
-    ).flop_weights()
-
-
-def _deserialize_as_any_pydantic_class(
-    json_str: str,
-    pydantic_classes: Sequence[type[PydanticModelT]],
-) -> PydanticModelT:
-    # try all supported classes
-    for pydantic_cls in pydantic_classes:
-        try:
-            return pydantic_cls.model_validate_json(json_str)
-        except ValidationError:
-            continue
-
-    # none of the supported classes worked
-    raise ValueError("Input JSON string does not represent a known data structure.")
+    return _SOURCE_FILE_ADAPTER.validate_json(json_str).flop_weights()

--- a/tests/counting/test_built_in_data.py
+++ b/tests/counting/test_built_in_data.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 
 from counted_float._core.counting._builtin_data import (
     BuiltInData,
@@ -167,10 +168,14 @@ def test_load_json_files_as_dict_uses_only_the_traversable_contract():
 
 
 def test_construct_flop_weights_rejects_unknown_json():
-    # JSON that matches none of the supported data schemas raises rather than degrading silently
+    # JSON matching none of the supported schemas raises rather than degrading silently, and the
+    # error says what failed in each of them rather than only that nothing matched
     # --- act / assert ------------------------------------
-    with pytest.raises(ValueError, match="known data structure"):
+    with pytest.raises(ValidationError) as excinfo:
         _construct_flop_weights_from_json_str('{"not": "a known schema"}')
+
+    assert "FlopsBenchmarkResults" in str(excinfo.value)
+    assert "InstructionLatencies" in str(excinfo.value)
 
 
 def test_show_renders_integer_weights():


### PR DESCRIPTION
**Problem**: A hand-rolled helper tried each candidate model in turn, swallowed every `ValidationError` on the way, and raised a bare *"does not represent a known data structure"* — reporting the symptom and discarding all the evidence. One of its two call sites passed a single-element list, so it was not resolving a union there at all.

**Solution**: The two source-file shapes have **disjoint field sets**, so a `TypeAdapter` over their union resolves them natively. The single-shape call site validates that model directly. The helper is deleted.

- **Attention:** the error improves as a side effect rather than by design. Pydantic's union error names what failed in **each** branch, which is strictly more than the chained-cause version this PR originally carried and needs no code of ours to produce.
- **Attention:** a test pinned the old message text and now pins the new behavior — that both branch names appear in the error — rather than a literal string.
- **TEST:** the smart union was checked against the **whole shipped corpus** before committing to it: all 49 source files resolve, 28 as `InstructionLatencies` and 21 as `FlopsBenchmarkResults`, none ambiguous.
- **TEST:** full suite green at 1906; `make lint` clean with the now-unused `BaseModel`, `ValidationError`, `TypeVar` and `Sequence` imports removed.

**Changelog** (none): both call sites read only the shipped data files, which are schema-tested, so no user-supplied input reaches this path.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
