### PR TITLE
chore: drop the roadmap URL from the package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ counted_float = "counted_float._core._cli_main:main"
 Source = "https://github.com/bertpl/counted-float"
 ChangeLog = "https://github.com/bertpl/counted-float/blob/main/CHANGELOG.md"
 Issues = "https://github.com/bertpl/counted-float/issues"
-Roadmap = "https://github.com/bertpl/counted-float/milestones"
 
 [project.optional-dependencies]
 # Everything the flops benchmark suite needs: the compiled probes, the arrays they run on, and the


### PR DESCRIPTION
**Problem**: The package metadata advertises a public Roadmap, which PyPI renders as a sidebar link on every release page — but the milestones page behind it carries no roadmap; the only open milestone predates the 2.x line.

**Solution**: Drop the `Roadmap` entry from the project URLs. `Source`, `ChangeLog` and `Issues` stay; advertising a roadmap is a standing commitment to maintain one, and the changelog is where the project's direction is actually visible.

**Changelog** (none): packaging metadata a reader sees on PyPI, not behavior — nobody's upgrade decision turns on it.


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
