### PR TITLE
fix: fold absorbing pow constants to plain floats and re-wrap round

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `round(x, n)` on a counted value no longer returns a plain float, which silently stopped all downstream counting
+- `x ** 0` and `1.0 ** x` now fold to a plain-float constant the way a compiled port would, instead of producing a counted result that over-counted downstream work
+
 ### Security
 
 ## 2.1.1 (2026-07-29)

--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -8,7 +8,7 @@ package can name the rule it follows — and the few that deviate can say so exp
 
 ## How the imaginary port gets made
 
-Two conventions anchor every rule below.
+Three conventions anchor every rule below.
 
 **First: in counted code, a plain `float` operand is a compile-time
 [constant](glossary.md#constant)** — something the imaginary compiled program would know
@@ -45,6 +45,26 @@ actors, playing by two different rules.**
   optimization levels, no fast-math flag involved — the model's assumed compiler has it
   switched off (`-ffp-contract=off`), so the priced instruction stream is the same on
   every architecture.
+
+**Third: zero cost and countedness are independent axes.** A float-valued result that
+*depends on* a `CountedFloat` operand stays a `CountedFloat` even when the port emits no
+instruction for it (`+x`, `x * 1.0`, `x ** 1`) — the preserved type is what keeps
+downstream counting alive, and a container of floats carries countedness in its elements
+(`divmod` returns two `CountedFloat`s). The converse is a result whose **bits the
+operation's own semantics fix for every possible counted operand** — nan payloads and
+signed zeros included: that is a compile-time constant of the port, so it comes back as a
+**plain float**, and downstream folds keyed on its value mirror the port's constant
+propagation. The constant cases are enumerated, like the identity folds of rule 1.7:
+`x ** 0` (`pow(x, 0)` is `1.0` for every `x`), `1.0 ** x` (`pow(1, y)` likewise), and
+`float`'s `.imag` (`+0.0` for every receiver). Near-misses stay counted because they fail
+at bit level — `x * 0.0` is sign- and nan-dependent, `x + nan` carries a nan receiver's
+payload — and un-enumerated degeneracies stay conservatively counted as written.
+Countedness otherwise ends only where the *value* leaves the float domain (`bool`, `int`,
+`str` — priced where the port pays, e.g. F2I, COMP), through the one documented exit
+`float(x)` (safe because leaving the counted world is the explicit point of the call), or
+as a WARNING-reported gap (see the
+[`math` coverage table](math_patching.md#coverage-of-the-math-module)); a *silent*
+plain-float return from a counted operand is a defect in the model, not a judgment call.
 
 Every pricing decision below is an application of one question: **who produced this
 operation — the author, writing it into the source, or the compiler, translating the

--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -46,25 +46,40 @@ actors, playing by two different rules.**
   switched off (`-ffp-contract=off`), so the priced instruction stream is the same on
   every architecture.
 
-**Third: zero cost and countedness are independent axes.** A float-valued result that
-*depends on* a `CountedFloat` operand stays a `CountedFloat` even when the port emits no
-instruction for it (`+x`, `x * 1.0`, `x ** 1`) — the preserved type is what keeps
-downstream counting alive, and a container of floats carries countedness in its elements
-(`divmod` returns two `CountedFloat`s). The converse is a result whose **bits the
-operation's own semantics fix for every possible counted operand** — nan payloads and
-signed zeros included: that is a compile-time constant of the port, so it comes back as a
-**plain float**, and downstream folds keyed on its value mirror the port's constant
-propagation. The constant cases are enumerated, like the identity folds of rule 1.7:
-`x ** 0` (`pow(x, 0)` is `1.0` for every `x`), `1.0 ** x` (`pow(1, y)` likewise), and
-`float`'s `.imag` (`+0.0` for every receiver). Near-misses stay counted because they fail
-at bit level — `x * 0.0` is sign- and nan-dependent, `x + nan` carries a nan receiver's
-payload — and un-enumerated degeneracies stay conservatively counted as written.
-Countedness otherwise ends only where the *value* leaves the float domain (`bool`, `int`,
-`str` — priced where the port pays, e.g. F2I, COMP), through the one documented exit
-`float(x)` (safe because leaving the counted world is the explicit point of the call), or
-as a WARNING-reported gap (see the
-[`math` coverage table](math_patching.md#coverage-of-the-math-module)); a *silent*
-plain-float return from a counted operand is a defect in the model, not a judgment call.
+**Third: zero cost and countedness are independent axes.** Cost says what the port
+executes; countedness says what the result's *type* is. Which type a float-valued result
+gets turns on one question — does it depend on a counted operand?
+
+- **Depends on one → `CountedFloat`**, even at zero cost (`+x`, `x * 1.0`, `x ** 1`): the
+  preserved type is what keeps downstream counting alive. A container carries countedness
+  in its elements (`divmod` returns two `CountedFloat`s).
+- **Independent of every one → plain `float`**: the port knows this value at compile time,
+  so downstream folds keyed on it mirror the port's own constant propagation.
+
+"Independent" is a **bit-level** test — nan payloads and signed zeros included — and the
+cases are enumerated, like the identity folds of rule 1.7:
+
+| Constant case | Why the bits are fixed |
+|---|---|
+| `x ** 0` | IEEE 754 / C99 define `pow(x, 0)` as `1.0` for every `x`, nan and infinities included |
+| `1.0 ** x` | likewise, `pow(1, y)` is `1.0` for every `y` |
+| `float`'s `.imag` | `+0.0` for every receiver |
+
+Near-misses stay counted because they fail that test: `x * 0.0` is sign- and
+nan-dependent, `x + nan` carries a nan receiver's payload. Degeneracies outside the table
+stay conservatively counted as written.
+
+Countedness otherwise ends in exactly three places:
+
+- the *value* leaves the float domain (`bool`, `int`, `str`), priced where the port pays
+  (e.g. F2I, COMP);
+- the one documented exit, `float(x)` — safe because leaving the counted world is the
+  explicit point of the call;
+- a WARNING-reported gap (see the
+  [`math` coverage table](math_patching.md#coverage-of-the-math-module)).
+
+A *silent* plain-float return from a counted operand is none of those — it is a defect in
+the model, not a judgment call.
 
 Every pricing decision below is an application of one question: **who produced this
 operation — the author, writing it into the source, or the compiler, translating the

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -87,9 +87,9 @@ patched `math` functions:
    | `x / c`, power-of-two `c` | MUL — `x * (1/c)` is bit-identical exactly there, so a compiler folds it; any other constant divisor stays DIV |
    | `x ** 0.5` / `x ** -0.5` | SQRT / SQRT + DIV |
    | `x ** 1` | nothing (folds away to `x` itself; result stays `CountedFloat`) |
-   | `x ** 0` | nothing — `pow(x, 0)` is `1.0` for *every* `x` (nan and inf included), so the result is the port's compile-time constant and comes back as a **plain float** |
+   | `x ** 0` | nothing — IEEE 754 and C99 define `pow(x, 0)` as `1.0` for *every* `x` (nan and infinities included), so the result is the port's compile-time constant and comes back as a **plain float** |
    | `x ** c`, other values | POW |
-   | `1.0 ** x` | nothing — `pow(1, y)` is `1.0` for *every* `y`, the same absorbing case as `x ** 0`: a **plain float** constant |
+   | `1.0 ** x` | nothing — the same standards make `pow(1, y)` `1.0` for *every* `y`: the absorbing case on the other operand, likewise a **plain float** constant |
    | `2 ** x` / `10 ** x` | EXP2 / EXP10 (POW for other constant bases) |
    | `math.log(x, 2)` / `math.log(x, 10)` | LOG2 / LOG10 |
    | `math.log(x, c)`, other values | LOG + MUL (`1/log(c)` folds to a constant multiplier) |

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -86,8 +86,10 @@ patched `math` functions:
    | `x / 1.0` | nothing (folds away; result stays `CountedFloat`) |
    | `x / c`, power-of-two `c` | MUL — `x * (1/c)` is bit-identical exactly there, so a compiler folds it; any other constant divisor stays DIV |
    | `x ** 0.5` / `x ** -0.5` | SQRT / SQRT + DIV |
-   | `x ** 0`, `x ** 1` | nothing (folds away; result stays `CountedFloat`) |
+   | `x ** 1` | nothing (folds away to `x` itself; result stays `CountedFloat`) |
+   | `x ** 0` | nothing — `pow(x, 0)` is `1.0` for *every* `x` (nan and inf included), so the result is the port's compile-time constant and comes back as a **plain float** |
    | `x ** c`, other values | POW |
+   | `1.0 ** x` | nothing — `pow(1, y)` is `1.0` for *every* `y`, the same absorbing case as `x ** 0`: a **plain float** constant |
    | `2 ** x` / `10 ** x` | EXP2 / EXP10 (POW for other constant bases) |
    | `math.log(x, 2)` / `math.log(x, 10)` | LOG2 / LOG10 |
    | `math.log(x, c)`, other values | LOG + MUL (`1/log(c)` folds to a constant multiplier) |

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -15,7 +15,9 @@ def count_pow_with_constant_exponent(exponent: float) -> None:
     """Register the flops a compiled port would execute for ``x ** exponent`` with a constant exponent.
 
     Constants are folded by value (an int and an equal-valued plain float compile identically):
-      - 0, 1                     -> nothing (the expression folds away entirely)
+      - 0                        -> nothing (pow(x, 0) is 1.0 for every x, nan and inf included,
+                                    so the port ships the constant -- __pow__ returns it plain)
+      - 1                        -> nothing (the expression folds away to x itself, still counted)
       - 0.5 / -0.5               -> SQRT / SQRT + DIV
       - -1                       -> DIV (reciprocal)
       - integer 2 <= |n| <= 16   -> square-and-multiply MULs (x**3 -> 2 MUL, x**8 -> 3 MUL, ...),
@@ -114,9 +116,13 @@ def count_mul_with_identity_multiplier(multiplier: float) -> None:
 def count_pow_with_constant_base(base: float) -> None:
     """Register the flops a compiled port would execute for ``base ** x`` with a constant base.
 
-    Constants are folded by value: base 2 -> EXP2, base 10 -> EXP10, anything else -> POW.
+    Constants are folded by value: base 1 -> nothing (pow(1, y) is 1.0 for every y, nan
+    included, so the port ships the constant -- __rpow__ returns it plain), base 2 -> EXP2,
+    base 10 -> EXP10, anything else -> POW.
     """
     value = float(base)
+    if value == 1.0:
+        return
     try:
         cnt: CountsTarget = _TLS.flop_counts
     except AttributeError:  # first counted op on this thread
@@ -288,14 +294,17 @@ class CountedFloat(float):
         """Round to n decimal places, i.e. round(x, n).
 
         n = None -> round to nearest integer and return int (F2I)
-        n = 0    -> round to nearest integer and return float (RND)
-        n != 0   -> round to n decimal places and return float: a compiled port scales into
-                    the digit position, rounds, and scales back -- MUL + RND + DIV. The
+        n = 0    -> round to nearest integer and return CountedFloat (RND)
+        n != 0   -> round to n decimal places and return CountedFloat: a compiled port scales
+                    into the digit position, rounds, and scales back -- MUL + RND + DIV. The
                     unscale is a true divide (the scale factor is a power of ten, whose
                     reciprocal is not exact), so no reciprocal fold applies. Stated gap: the
                     port price knowingly omits the correctly-rounded decimal machinery
                     CPython itself runs (David Gay's algorithm), which has no fixed
                     instruction cost to price.
+
+        The float-returning overloads re-wrap: the result depends on the receiver and carries
+        counted work, so a plain-float return would silently stop all downstream counting.
         """
         result = float.__round__(self, n)  # compute first: round(inf/nan) with n=None raises (F2I) before counting
         if n is None:
@@ -303,7 +312,8 @@ class CountedFloat(float):
                 _TLS.flop_counts.F2I += 1  # rounded and returned int
             except AttributeError:  # first counted op on this thread
                 _create_thread_state().F2I += 1
-        elif operator.index(n) == 0:
+            return result
+        if operator.index(n) == 0:
             try:
                 _TLS.flop_counts.RND += 1  # rounded and returned float
             except AttributeError:  # first counted op on this thread
@@ -318,7 +328,7 @@ class CountedFloat(float):
             cnt.RND += 1
             cnt.DIV += 1
 
-        return result
+        return float.__new__(CountedFloat, result)
 
     def __floor__(self) -> int:
         """math.floor(x)."""
@@ -626,6 +636,11 @@ class CountedFloat(float):
         A negative base with a fractional exponent yields a complex result (as for plain float);
         complex values fall outside the counting model, so nothing is counted and the result is
         returned unwrapped.
+
+        A constant exponent 0 is the one absorbing case: pow(x, 0) is 1.0 for every x (nan and
+        inf included), so the result is a compile-time constant of the port and comes back as a
+        plain float — downstream folds keyed on its value then mirror the port's constant
+        propagation. A CountedFloat exponent of 0.0 stays the runtime-POW path above.
         """
         result = float.__pow__(self, other)
         if result is NotImplemented:
@@ -638,6 +653,8 @@ class CountedFloat(float):
             except AttributeError:  # first counted op on this thread
                 _create_thread_state().POW += 1
         else:
+            if float(other) == 0.0:
+                return result  # the port's constant 1.0 — plain, uncounted
             count_pow_with_constant_exponent(other)
         return float.__new__(CountedFloat, result)
 
@@ -652,6 +669,10 @@ class CountedFloat(float):
         A negative base with a fractional exponent yields a complex result (as for plain float);
         complex values fall outside the counting model, so nothing is counted and the result is
         returned unwrapped.
+
+        A constant base 1 is the one absorbing case: pow(1, y) is 1.0 for every y (nan
+        included), so the result is a compile-time constant of the port and comes back as a
+        plain float. A CountedFloat base of 1.0 stays the runtime-POW path above.
         """
         result = float.__rpow__(self, other)
         if result is NotImplemented:
@@ -664,5 +685,7 @@ class CountedFloat(float):
             except AttributeError:  # first counted op on this thread
                 _create_thread_state().POW += 1
         else:
+            if float(other) == 1.0:
+                return result  # the port's constant 1.0 — plain, uncounted
             count_pow_with_constant_base(other)
         return float.__new__(CountedFloat, result)

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -15,8 +15,9 @@ def count_pow_with_constant_exponent(exponent: float) -> None:
     """Register the flops a compiled port would execute for ``x ** exponent`` with a constant exponent.
 
     Constants are folded by value (an int and an equal-valued plain float compile identically):
-      - 0                        -> nothing (pow(x, 0) is 1.0 for every x, nan and inf included,
-                                    so the port ships the constant -- __pow__ returns it plain)
+      - 0                        -> nothing (IEEE 754 and C99 define pow(x, 0) as 1.0 for every
+                                    x, nan and infinities included, so the port ships the
+                                    constant -- __pow__ returns it plain)
       - 1                        -> nothing (the expression folds away to x itself, still counted)
       - 0.5 / -0.5               -> SQRT / SQRT + DIV
       - -1                       -> DIV (reciprocal)
@@ -118,9 +119,9 @@ def count_pow_with_constant_base(base: float) -> None:
 
     Constants are folded by value: base 2 -> EXP2, base 10 -> EXP10, anything else -> POW.
 
-    Base 1 never arrives here: pow(1, y) is 1.0 for every y (nan included), so the callers
-    return that constant as a plain float without counting, the way __pow__ handles a constant
-    exponent of 0.
+    Base 1 never arrives here: IEEE 754 and C99 make pow(1, y) 1.0 for every y (nan included),
+    so the callers return that constant as a plain float without counting, the way __pow__
+    handles a constant exponent of 0.
     """
     value = float(base)
     try:
@@ -637,10 +638,11 @@ class CountedFloat(float):
         complex values fall outside the counting model, so nothing is counted and the result is
         returned unwrapped.
 
-        A constant exponent 0 is the one absorbing case: pow(x, 0) is 1.0 for every x (nan and
-        inf included), so the result is a compile-time constant of the port and comes back as a
-        plain float — downstream folds keyed on its value then mirror the port's constant
-        propagation. A CountedFloat exponent of 0.0 stays the runtime-POW path above.
+        A constant exponent 0 is the one absorbing case: IEEE 754 and C99 define pow(x, 0) as
+        1.0 for every x (nan and infinities included), so the result is a compile-time constant
+        of the port and comes back as a plain float — downstream folds keyed on its value then
+        mirror the port's constant propagation. A CountedFloat exponent of 0.0 stays the
+        runtime-POW path above.
         """
         result = float.__pow__(self, other)
         if result is NotImplemented:
@@ -670,9 +672,9 @@ class CountedFloat(float):
         complex values fall outside the counting model, so nothing is counted and the result is
         returned unwrapped.
 
-        A constant base 1 is the one absorbing case: pow(1, y) is 1.0 for every y (nan
-        included), so the result is a compile-time constant of the port and comes back as a
-        plain float. A CountedFloat base of 1.0 stays the runtime-POW path above.
+        A constant base 1 is the one absorbing case: IEEE 754 and C99 make pow(1, y) 1.0 for
+        every y (nan included), so the result is a compile-time constant of the port and comes
+        back as a plain float. A CountedFloat base of 1.0 stays the runtime-POW path above.
         """
         result = float.__rpow__(self, other)
         if result is NotImplemented:

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -116,13 +116,13 @@ def count_mul_with_identity_multiplier(multiplier: float) -> None:
 def count_pow_with_constant_base(base: float) -> None:
     """Register the flops a compiled port would execute for ``base ** x`` with a constant base.
 
-    Constants are folded by value: base 1 -> nothing (pow(1, y) is 1.0 for every y, nan
-    included, so the port ships the constant -- __rpow__ returns it plain), base 2 -> EXP2,
-    base 10 -> EXP10, anything else -> POW.
+    Constants are folded by value: base 2 -> EXP2, base 10 -> EXP10, anything else -> POW.
+
+    Base 1 never arrives here: pow(1, y) is 1.0 for every y (nan included), so the callers
+    return that constant as a plain float without counting, the way __pow__ handles a constant
+    exponent of 0.
     """
     value = float(base)
-    if value == 1.0:
-        return
     try:
         cnt: CountsTarget = _TLS.flop_counts
     except AttributeError:  # first counted op on this thread

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -296,8 +296,12 @@ def math_pow(x: float, y: float) -> float | CountedFloat:
             except AttributeError:  # first counted op on this thread
                 _create_thread_state().POW += 1
         elif isinstance(x, CountedFloat):
+            if float(y) == 0.0:
+                return result  # pow(x, 0) is 1.0 for every x: the port's constant, plain and uncounted
             count_pow_with_constant_exponent(y)
         else:
+            if float(x) == 1.0:
+                return result  # pow(1, y) is 1.0 for every y: the port's constant, plain and uncounted
             count_pow_with_constant_base(x)
         return float.__new__(CountedFloat, result)
     return original_math_pow(x, y)

--- a/tests/counting/test_counted_float.py
+++ b/tests/counting/test_counted_float.py
@@ -311,7 +311,7 @@ def test_counted_float_math_round_n(f: float, n_digits: int):
     cf_round = round(cf, n_digits)
 
     # --- assert ------------------------------------------
-    assert isinstance(cf_round, float)
+    assert isinstance(cf_round, CountedFloat)  # the result carries counted work, so it re-wraps
     assert f_round == cf_round
 
 
@@ -442,7 +442,11 @@ def test_counted_float_math_pow(f1: float, f2: float, cf_left: bool, cf_right: b
     cf_pow = left**right
 
     # --- assert ------------------------------------------
-    assert isinstance(cf_pow, CountedFloat)
+    # the absorbing folds return the port's constant as a plain float: a *plain* exponent 0 or a
+    # *plain* base 1; a CountedFloat in either slot is the runtime opt-in and stays counted
+    absorbing = (not cf_right and float(f2) == 0.0) or (not cf_left and float(f1) == 1.0)
+    assert isinstance(cf_pow, float if absorbing else CountedFloat)
+    assert (type(cf_pow) is float) == absorbing
     assert f_pow == cf_pow
 
 

--- a/tests/counting/test_counted_float_counting.py
+++ b/tests/counting/test_counted_float_counting.py
@@ -197,9 +197,11 @@ def test_counted_float_counts_round(thread_counter, ndigits, expected_counts: di
     cf = CountedFloat(1.23456)
 
     # --- act ---------------------------------------------
-    _ = round(cf, ndigits)
+    result = round(cf, ndigits)
 
     # --- assert ------------------------------------------
+    # the float-returning overloads re-wrap (the result carries counted work); n=None returns int
+    assert isinstance(result, int if ndigits is None else CountedFloat)
     assert thread_counter.total_count() == sum(expected_counts.values())
     for field, expected in expected_counts.items():
         assert getattr(thread_counter, field) == expected
@@ -725,8 +727,7 @@ def test_counted_float_mod_floordiv_divmod_zero_division_counts_nothing(thread_c
 @pytest.mark.parametrize(
     ("exponent", "expected_counts"),
     [
-        (0, {}),  # folds away entirely
-        (1, {}),
+        (1, {}),  # folds away to x itself (exponent 0 is the absorbing fold, tested separately)
         (2, {"MUL": 1}),
         (2.0, {"MUL": 1}),  # constants fold by value: 2.0 compiles like 2
         (3, {"MUL": 2}),  # x*x, *x
@@ -793,6 +794,57 @@ def test_counted_float_rpow_constant_float_base_folds_by_value(thread_counter):
     assert thread_counter.EXP2 == 1
     assert thread_counter.EXP10 == 1
     assert thread_counter.POW == 1
+
+
+@pytest.mark.parametrize("exponent", [0, 0.0, -0.0], ids=["int", "float", "negative-zero"])
+@pytest.mark.parametrize("value", [1.23456, 0.0, math.nan, math.inf], ids=["ordinary", "zero", "nan", "inf"])
+def test_counted_float_pow_constant_exponent_zero_returns_plain_constant(thread_counter, value, exponent):
+    """pow(x, 0) is 1.0 for every x, so the result is the port's constant: plain and uncounted."""
+    # --- act ---------------------------------------------
+    result = CountedFloat(value) ** exponent
+
+    # --- assert ------------------------------------------
+    assert type(result) is float
+    assert result == 1.0
+    assert thread_counter.total_count() == 0
+
+
+@pytest.mark.parametrize("value", [1.23456, 0.0, math.nan, math.inf], ids=["ordinary", "zero", "nan", "inf"])
+def test_counted_float_rpow_constant_base_one_returns_plain_constant(thread_counter, value):
+    """pow(1, y) is 1.0 for every y, the same absorbing fold as a constant exponent 0."""
+    # --- act ---------------------------------------------
+    result = 1.0 ** CountedFloat(value)
+
+    # --- assert ------------------------------------------
+    assert type(result) is float
+    assert result == 1.0
+    assert thread_counter.total_count() == 0
+
+
+def test_counted_float_absorbing_pow_folds_mirrored_in_math_pow(thread_counter):
+    # --- act ---------------------------------------------
+    result_exponent_zero = math.pow(CountedFloat(1.23456), 0.0)
+    result_base_one = math.pow(1.0, CountedFloat(math.nan))
+
+    # --- assert ------------------------------------------
+    assert type(result_exponent_zero) is float
+    assert result_exponent_zero == 1.0
+    assert type(result_base_one) is float
+    assert result_base_one == 1.0
+    assert thread_counter.total_count() == 0
+
+
+def test_counted_float_counted_zero_exponent_and_one_base_stay_runtime(thread_counter):
+    """A CountedFloat operand is the opt-in: the absorbing values fold only as plain constants."""
+    # --- act ---------------------------------------------
+    result_exponent = CountedFloat(1.23456) ** CountedFloat(0.0)
+    result_base = CountedFloat(1.0) ** CountedFloat(2.5)
+
+    # --- assert ------------------------------------------
+    assert isinstance(result_exponent, CountedFloat)
+    assert isinstance(result_base, CountedFloat)
+    assert thread_counter.POW == 2
+    assert thread_counter.total_count() == 2
 
 
 def test_counted_float_pow_runtime_counted_exponent_counts_pow(thread_counter):


### PR DESCRIPTION
**TL;DR**: Two counting defects with opposite signs fixed, and the cost-model convention that decides both is now written down.

- `x ** 0` and `1.0 ** x` returned counted results, over-counting downstream work; they now fold to a plain `1.0`.
- `round(x, n)` returned a plain float, silently stopping all downstream counting; it now re-wraps.

## Description

### Problem addressed

- **`x ** 0` kept its result counted** even though `pow(x, 0)` is `1.0` for *every* x (nan and inf included) — so downstream expressions charged work a compiled port never does: `math.sqrt(x ** 0)` counted a full SQRT, `10.0 / (x ** 0)` a DIV, where the port ships a precomputed constant.
- **`1.0 ** x` had no fold at all** and charged a full POW, despite `pow(1, y)` being `1.0` unconditionally.
- **`round(x, n)` dropped countedness**: it counted its RND (and MUL + DIV for nonzero n) but returned the result as a plain float, contradicting the FLOP-types table's own "stays `CountedFloat`" row and silently ending all downstream counting.

### Implementation

- The cost model gains a **third anchoring convention**: zero cost and countedness are independent axes. A float-valued result that *depends on* a counted operand stays a `CountedFloat`; a result whose **bits the operation's semantics fix for every possible counted operand** is a compile-time constant of the port and comes back plain, so downstream folds mirror the port's constant propagation. The constant cases are enumerated (`x ** 0`, `1.0 ** x`, `float.imag`), with bit-level near-misses (`x * 0.0`, `x + nan`) staying counted.
- `__pow__` / `__rpow__` / the `math.pow` patch return the plain constant for a **plain** exponent 0 or base 1; a `CountedFloat` in either slot remains the runtime opt-in (POW, counted result).
- `__round__`'s float-returning overloads re-wrap via the same `float.__new__` idiom as every neighboring dunder.

## Attention points

- **Return types change** for `x ** 0`, `1.0 ** x` (now exactly `float`) and `round(x, n)` (now `CountedFloat`) — deliberate and user-visible, hence the two changelog lines.
- **The opt-in is type-based, not value-based**: `x ** CountedFloat(0.0)` still counts POW and stays counted — the fold applies only to plain (compile-time-constant) operands.

## Tests / Spikes

- **TEST:** end-to-end probe — `x ** 0` and `1.0 ** x` plain at 0 flops, `math.sqrt(x ** 0)` counts nothing, `round(x, 1)` returns a `CountedFloat` with MUL + RND + DIV, `x ** CountedFloat(0.0)` counts POW.
- 4 new test functions (absorbing folds across nan/inf receivers, `math.pow` mirror, counted-operand opt-ins); the constant-exponent parametrization and the round/pow contract tests updated to pin the new return types.

## Changelog entry

Fixed:

```
- `round(x, n)` on a counted value no longer returns a plain float, which silently stopped all downstream counting
- `x ** 0` and `1.0 ** x` now fold to a plain-float constant the way a compiled port would, instead of producing a counted result that over-counted downstream work
```


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
