### PR TITLE
feat: classify the float surface and pin it with a drift-proof test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `as_integer_ratio()` on a counted value is now reported at WARNING verbosity, since its integer parts can silently re-enter float math uncounted
+
 ### Changed
 
 ### Deprecated
@@ -17,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `conjugate()` and `.real` on a counted value now preserve countedness instead of silently dropping it
+- `is_integer()` now counts the floor-and-compare a compiled port executes
+- `from_number()` (Python 3.14) now counts the int-to-float conversion for integer sources, like the constructor
 - `round(x, n)` on a counted value no longer returns a plain float, which silently stopped all downstream counting
 - `x ** 0` and `1.0 ** x` now fold to a plain-float constant the way a compiled port would, instead of producing a counted result that over-counted downstream work
 

--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -100,6 +100,15 @@ text) and `as_integer_ratio()` (a bit-field read plus an integer shift) count no
 it — carries a benchmarked weight: the boundary is the *domain of the operation*, not
 whether its machine code looks like manipulation or computation.
 
+The same precondition places Python's other numeric types outside the model:
+`decimal.Decimal` and `fractions.Fraction` are software towers a compiled port has no
+counterpart for, so nothing about them is priced. Converting one into the counting model
+(`CountedFloat(Decimal("1.5"))`) therefore counts nothing, where an `int` source counts the
+`I2F` its port instruction costs — a stated gap rather than an oversight. Mixing them into
+counted arithmetic is likewise outside the model; see
+[known limitations](known_limitations.md#other-limitations) for what each mixed operation
+does today.
+
 ## The rules
 
 **Rule 1 — operations that compile to CPU instructions only (no library call) are priced

--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -88,6 +88,18 @@ only when bit-exact. Whenever the rules mention what real compilers do at plain 
 that is *corroboration* that an admitted rewrite is real-world practice — never the
 admission criterion itself.
 
+## What the model prices
+
+One precondition scopes every rule below: **the model prices floating-point work only** —
+operations whose port emits floating-point instructions (rule 1) or floating-point library
+calls (rules 2–3). Work in any other domain — integer and bit manipulation, string
+conversion, arbitrary-precision arithmetic — has no FlopType and is counted nowhere, by
+scope rather than by exemption. That is why `hex()` (a mantissa-nibble read rendered as
+text) and `as_integer_ratio()` (a bit-field read plus an integer shift) count nothing while
+`math.copysign` — a value-level floating-point operation, whatever bit tricks implement
+it — carries a benchmarked weight: the boundary is the *domain of the operation*, not
+whether its machine code looks like manipulation or computation.
+
 ## The rules
 
 **Rule 1 — operations that compile to CPU instructions only (no library call) are priced
@@ -143,8 +155,11 @@ as a value-preserving [compiled port](glossary.md#compiled-port).**
 algorithm, contract included.**
 
 - **2.1** *(scope)* — applies whenever the call's cost is *deterministic per call*: a
-  fixed number of operations per invocation (or per element or coordinate), independent
-  of the data values. Anything else falls to rule 3.
+  fixed number of **floating-point** operations per invocation (or per element or
+  coordinate), independent of the data values. The qualifier is load-bearing — a
+  deterministic library call whose work is integer or string conversion (`strtod`,
+  `printf`-style rendering) fails the domain precondition above, not this rule. Anything
+  else floating-point falls to rule 3.
 - **2.2** *(consequence)* — the weight is measured on the very call wherever the
   toolchain can compile it ([libm](glossary.md#libm)'s `sin`, `log`, ...).
 - **2.3** *(nuance)* — where the toolchain cannot compile the real call, a faithful port

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -129,10 +129,12 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
 - **Counted Python operations:** `x == y`, `x != y`, `x <= y`, ... and
   `min(x,y)`, `max(x,y)` for `CountedFloat`
 - **Not counted:** Comparisons on non-CountedFloat, numpy comparisons, and
-  truthiness (`bool(x)`, `if x:`) — deliberately uncounted as pervasive
-  bookkeeping; write an algorithmic zero-test as `x != 0.0` to have it counted
-  (see the predicates row in
-  [Math patching semantics](math_patching.md#coverage-of-the-math-module))
+  truthiness (`bool(x)`, `if x:`, `assert x`) — a deliberate, labeled exception.
+  The interpreter inserts the test implicitly at every `if` / `while` / `and` /
+  `or` / `not` / `assert` with no opt-out, and `python -O` elides `assert`
+  entirely, so a truthiness count would price interpreter bookkeeping and vary
+  with interpreter flags — no port-faithful count does either. Write an
+  algorithmic zero-test as `x != 0.0` to have it counted
 - **Weight measurement:** [the machine code behind the `COMP` weight](machine_code/comp.md)
 
 ## FlopType.RND (`round`) { #flop-rnd }

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -5,7 +5,8 @@ from math import copysign as _copysign  # the raw builtin: math.copysign is patc
 from math import frexp as _frexp  # the raw builtin: math.frexp may later carry a reporting wrapper
 from typing import TYPE_CHECKING, SupportsIndex, final
 
-from ._thread_counter import _TLS, _create_thread_state
+from ._thread_counter import _TLS, _create_thread_state, thread_is_reporting
+from .verbosity import warn_uncounted_call
 
 if TYPE_CHECKING:
     from ._thread_counter import CountsTarget
@@ -173,9 +174,14 @@ class CountedFloat(float):
     def __new__(cls, value: float | int) -> CountedFloat:
         """Construct from a numeric source, counting I2F for int inputs.
 
+        The source matrix is the counting model's entry contract: an int (bool included) counts
+        I2F, the port's int->double conversion instruction; a float source costs nothing (no
+        conversion exists); Decimal and Fraction convert uncounted -- their conversion has no
+        FlopType, a stated gap, since non-float numeric types sit outside the model's scope.
         Numeric-source construction is the supported contract: counted code converts numbers,
         it does not parse them. Strings happen to work (the delegation to ``float(value)``
-        accepts them) but that is incidental, not part of the contract -- hence the annotation.
+        accepts them) but that is incidental, not part of the contract -- hence the annotation;
+        like fromhex, the parse is uncounted.
         """
         instance = super().__new__(cls, float(value))  # compute first: an oversized int raises before counting
         if isinstance(value, int):
@@ -185,14 +191,75 @@ class CountedFloat(float):
                 _create_thread_state().I2F += 1
         return instance
 
-    def __str__(self) -> str:
-        return self.__repr__()
-
     def __repr__(self) -> str:
+        """The loud counted-value repr — the single presentation mechanism.
+
+        float defines no __str__ of its own, so str(x), print(x), f"{x}" and format(x, "") all
+        land here, through object.__str__ and float.__format__'s empty-spec fast path. Loud on
+        purpose: whether a value silently fell out of the counting system is this library's
+        central hazard, and the repr is the zero-cost place it shows. Any non-empty format spec
+        (even a bare alignment) formats the plain value instead.
+        """
         return f"CountedFloat({float.__repr__(self)})"
 
     def __hash__(self) -> int:
         return float.__hash__(self)
+
+    # -------------------------------------------------------------------------
+    #  FLOAT-SURFACE MEMBERS
+    # -------------------------------------------------------------------------
+    # .imag deliberately stays inherited: it is +0.0 for every receiver (signs and nan payloads
+    # included), so it is a compile-time constant of the port and the plain-float return is the
+    # correct one -- see the cost model's constant-result convention. The two receiver-dependent
+    # members of the complex protocol are overridden below.
+    @property
+    def real(self) -> CountedFloat:
+        """The real part: the receiver itself, bit-identical (the complex protocol on a real).
+
+        A compiled port emits no instruction, so nothing is counted; the type is preserved so
+        downstream counting survives, as for __pos__. Returns self rather than the neighbors'
+        fresh-construction idiom: the class is final and immutable, so identity is unobservable
+        and an equal copy buys nothing.
+        """
+        return self
+
+    def conjugate(self) -> CountedFloat:
+        """The complex conjugate: the receiver itself, bit-identical for every real value.
+
+        Same contract as `real`: no instruction in the port, nothing counted, type preserved.
+        """
+        return self
+
+    def is_integer(self) -> bool:
+        """Whether the value is integral, counted as RND + COMP.
+
+        CPython computes `floor(x) == x` with C's double->double floor (Objects/floatobject.c,
+        float_is_integer), so the port pays one float->float round and one compare -- the price
+        of the counted spelling `x // 1.0 == x`, and RND rather than F2I because no int ever
+        materializes. The non-finite early return (False, nothing computed) is a regime fast
+        path; the price is charged unconditionally, per the cost model's input-range rules.
+        """
+        result = float.is_integer(self)
+        try:
+            cnt: CountsTarget = _TLS.flop_counts
+        except AttributeError:  # first counted op on this thread
+            cnt: CountsTarget = _create_thread_state()
+        cnt.RND += 1
+        cnt.COMP += 1
+        return result
+
+    def as_integer_ratio(self) -> tuple[int, int]:
+        """The exact integer ratio, uncounted but reported at WARNING verbosity.
+
+        The port's extraction is a bit-field read plus an integer shift -- integer-domain work
+        the model prices nowhere -- so nothing is counted. But `n / d` on the result silently
+        resumes float arithmetic at zero flops, the same re-entry math.frexp reports, so the
+        call is surfaced through the same channel. Unlike the math patches this override is
+        permanently installed; the method is cold and the reporting test is one TLS read.
+        """
+        if thread_is_reporting():
+            warn_uncounted_call("float.as_integer_ratio", "its integer parts re-enter float math uncounted")
+        return float.as_integer_ratio(self)
 
     # -------------------------------------------------------------------------
     #  OVERLOADED MATH OPERATIONS
@@ -691,3 +758,30 @@ class CountedFloat(float):
                 return result  # the port's constant 1.0 — plain, uncounted
             count_pow_with_constant_base(other)
         return float.__new__(CountedFloat, result)
+
+
+if hasattr(float, "from_number"):
+    # Python 3.14+ only. Attached conditionally, the way the math tables register version-gated
+    # functions: the member exists on CountedFloat exactly when it exists on float, so surface
+    # comparisons hold in both directions on every supported interpreter.
+    def _from_number(cls: type[CountedFloat], number: object) -> CountedFloat:
+        """Counted construction from a real number (float.from_number), I2F for int sources.
+
+        CPython's from_number converts to a C double before handing the subclass constructor a
+        plain float, so without this override an int source converts unpaid where
+        CountedFloat(n) counts I2F -- the same source, two constructors, two answers. The
+        source matrix mirrors __new__: int (bool included) counts I2F; float sources cost
+        nothing; Decimal and Fraction convert uncounted, a stated gap; strings are rejected by
+        the underlying call.
+        """
+        # resolved dynamically: on 3.13-era typeshed the member does not exist to reference
+        from_number = getattr(float, "from_number")  # noqa: B009
+        result = from_number(number)  # compute first: a str or oversized source raises before counting
+        if isinstance(number, int):
+            try:
+                _TLS.flop_counts.I2F += 1
+            except AttributeError:  # first counted op on this thread
+                _create_thread_state().I2F += 1
+        return float.__new__(CountedFloat, result)
+
+    CountedFloat.from_number = classmethod(_from_number)  # ty: ignore[unresolved-attribute] -- version-gated member

--- a/src/counted_float/_core/counting/_float_surface.py
+++ b/src/counted_float/_core/counting/_float_surface.py
@@ -1,0 +1,109 @@
+"""Classification of the float attribute surface that CountedFloat inherits unchanged.
+
+The math-surface tables pin every public `math` callable to a classification, so a function a
+future CPython adds fails a test instead of becoming a silently uncounted hole.  This module is
+the same pin for `float`'s own attribute surface: every member of `dir(float)` that CountedFloat
+does not override is listed here with the reason it needs no override, and the float-surface test
+holds `dir(float)` to the union of these tables and the class's own overrides -- in both
+directions, so a member that appears, disappears, or changes provenance fails loudly.
+
+Two tables, split by where the member is defined.  The provenance matters because the two halves
+drift for different reasons: the float-defined half moves with `float` itself, while the
+object-defined half moves with `object` (as `__getstate__` did when 3.11 added it) -- churn there
+is legible as plumbing, not as a counting question.  The test asserts each member's provenance,
+so a member migrating between halves (e.g. `float` growing its own `__str__`, which would change
+what `str(x)` prints) is a failure rather than a silent behavior change.
+
+Members are registered conditionally where CPython does the same, so both directions of the
+surface comparison hold on every supported interpreter without version checks in the test.
+"""
+
+# Float-defined inherited members: each computes on (or presents) the float's value, and each
+# needs no override for a stated reason.  The reasons are the load-bearing part -- they are what
+# a future maintainer cites when a new member looks similar to an existing one.
+_FLOAT_DEFINED_UNPATCHED: dict[str, str] = {
+    "imag": (
+        "plain +0.0 for every receiver, signs and nan payloads included: a compile-time constant "
+        "of the port, per the cost model's constant-result convention (the receiver-dependent "
+        "real / conjugate preserve countedness instead)"
+    ),
+    "hex": (
+        "produces a str that leaves the algorithm; the hex digits are the mantissa's own nibbles, "
+        "so the port emits no floating-point instruction -- the remaining work is integer/bit "
+        "manipulation, which this library counts nowhere"
+    ),
+    "fromhex": (
+        "preserves countedness: CPython wraps the parsed double through the subclass constructor, "
+        "so the result is a CountedFloat; the strtod-shaped parse itself has no FlopType -- a "
+        "stated gap (CountedFloat(3) costs I2F where fromhex('0x1.8p+1') costs nothing)"
+    ),
+    "__float__": (
+        "the documented escape hatch: an explicit, uncounted exit from the counting model -- "
+        "double->double identity, no instruction in the port. Safe because it is explicit at the "
+        "call site, which is exactly what the implicit property access real lacks"
+    ),
+    "__bool__": (
+        "truthiness is deliberately uncounted bookkeeping: the interpreter inserts it implicitly "
+        "at every if/while/and/or/not/assert with no opt-out, and python -O elides assert "
+        "entirely, so a count here would vary with interpreter flags; the algorithmic spelling "
+        "x != 0.0 counts COMP"
+    ),
+    "__format__": (
+        "formatting produces a str that leaves the algorithm; correctly-rounded decimal "
+        "conversion is the machinery round(x, n) declares unmodeled -- except the '%' "
+        "presentation type, which scales by 100 in binary64 first: one MUL, a labeled uncounted "
+        "exception (unobservable from Python, and the result cannot re-enter the algorithm)"
+    ),
+    "__getnewargs__": (
+        "pickling (protocol 2+) and copy/deepcopy: hands __new__ a plain-float 1-tuple, so "
+        "round-trips rebuild a CountedFloat at zero count -- deserialization is not the "
+        "algorithm converting an integer"
+    ),
+}
+if hasattr(float, "__getformat__"):
+    # CPython's own docstring disclaims this introspection helper; registered conditionally so
+    # its eventual removal fails nothing.
+    _FLOAT_DEFINED_UNPATCHED["__getformat__"] = (
+        "structurally not a float operation: binds to the type and reads no value (its return "
+        "string is endianness-dependent, so only existence is pinned)"
+    )
+
+# Object-defined inherited members: plumbing that computes no float value.  Pinned so that churn
+# in `object`'s surface -- or a member migrating to float-defined -- is a test failure with a
+# name attached rather than a silent hole.
+_OBJECT_PLUMBING = "object plumbing: computes no float value"
+_OBJECT_DEFINED_UNPATCHED: dict[str, str] = {
+    "__class__": _OBJECT_PLUMBING,
+    "__dir__": _OBJECT_PLUMBING,
+    "__getattribute__": _OBJECT_PLUMBING,
+    "__init__": (
+        "object.__init__ no-op: the narrowed __new__ is the sole arity gate, so "
+        "CountedFloat(1.0, 2.0) fails in __new__ before this ever runs"
+    ),
+    "__setattr__": "refuses attribute mutation (empty __slots__), matching plain float",
+    "__delattr__": "refuses attribute mutation (empty __slots__), matching plain float",
+    "__sizeof__": (
+        "reports memory, computes no float value (the byte count is build-dependent -- 3.14t "
+        "differs -- so only existence is pinned)"
+    ),
+    "__subclasshook__": _OBJECT_PLUMBING,
+    "__str__": (
+        "presentation: float defines no __str__ of its own, so str(x) falls through "
+        "object.__str__ to the loud CountedFloat.__repr__ -- the single presentation mechanism; "
+        "provenance is pinned because a future float-defined __str__ would silently change what "
+        "str(x) prints"
+    ),
+    "__getstate__": (
+        "pickling: returns None because __slots__ is empty -- no instance state exists to "
+        "serialize; pinned because it guards the __slots__ decision"
+    ),
+    "__reduce__": (
+        "pickling: delegates through copyreg and rebuilds a CountedFloat at zero count; "
+        "reachable only by direct call (pickle routes through __reduce_ex__)"
+    ),
+    "__reduce_ex__": (
+        "pickling (protocols 0-1): routes through copyreg and float(), rebuilding a CountedFloat "
+        "at zero count with no CountedFloat override participating -- pinned because that route "
+        "is pure CPython machinery"
+    ),
+}

--- a/src/counted_float/_core/counting/_float_surface.py
+++ b/src/counted_float/_core/counting/_float_surface.py
@@ -72,6 +72,11 @@ if hasattr(float, "__getformat__"):
 # in `object`'s surface -- or a member migrating to float-defined -- is a test failure with a
 # name attached rather than a silent hole.
 _OBJECT_PLUMBING = "object plumbing: computes no float value"
+# Members whose defining class moved between supported interpreters, so the provenance pin
+# tolerates either side for them. `float.__getattribute__` has its own entry in float.__dict__ on
+# 3.11 and falls through to object's from 3.12 on; the behavior is identical either way, and
+# pinning one arrangement would encode a single interpreter's layout as the contract.
+_PROVENANCE_VARIES_BY_VERSION = frozenset({"__getattribute__"})
 _OBJECT_DEFINED_UNPATCHED: dict[str, str] = {
     "__class__": _OBJECT_PLUMBING,
     "__dir__": _OBJECT_PLUMBING,

--- a/tests/counting/test_float_surface.py
+++ b/tests/counting/test_float_surface.py
@@ -26,7 +26,11 @@ from fractions import Fraction
 import pytest
 
 from counted_float import CountedFloat, FlopCountingContext, Verbosity
-from counted_float._core.counting._float_surface import _FLOAT_DEFINED_UNPATCHED, _OBJECT_DEFINED_UNPATCHED
+from counted_float._core.counting._float_surface import (
+    _FLOAT_DEFINED_UNPATCHED,
+    _OBJECT_DEFINED_UNPATCHED,
+    _PROVENANCE_VARIES_BY_VERSION,
+)
 
 _TABLES = {
     "_FLOAT_DEFINED_UNPATCHED (inherited from float - say why no override is needed)": _FLOAT_DEFINED_UNPATCHED,
@@ -109,9 +113,17 @@ def test_every_entry_carries_a_reason():
 
 
 def test_classified_members_have_their_stated_provenance():
+    # members whose defining class moved across supported interpreters are exempt by name, so the
+    # pin holds one arrangement to account without encoding a single version's layout
     # --- arrange / act -------------------------
-    not_float_defined = sorted(name for name in _FLOAT_DEFINED_UNPATCHED if name not in vars(float))
-    not_object_defined = sorted(name for name in _OBJECT_DEFINED_UNPATCHED if name in vars(float))
+    not_float_defined = sorted(
+        name
+        for name in _FLOAT_DEFINED_UNPATCHED
+        if name not in vars(float) and name not in _PROVENANCE_VARIES_BY_VERSION
+    )
+    not_object_defined = sorted(
+        name for name in _OBJECT_DEFINED_UNPATCHED if name in vars(float) and name not in _PROVENANCE_VARIES_BY_VERSION
+    )
 
     # --- assert --------------------------------
     assert not not_float_defined, f"classified as float-defined but not in float.__dict__: {not_float_defined}"
@@ -119,6 +131,12 @@ def test_classified_members_have_their_stated_provenance():
         f"classified as object plumbing but defined by float itself: {not_object_defined} — "
         "a member migrating to float-defined changes behavior (e.g. what str(x) prints) and "
         "must be re-triaged, not re-labeled"
+    )
+    # the exemptions are names, so a typo would silently exempt nothing forever
+    classified = set(_FLOAT_DEFINED_UNPATCHED) | set(_OBJECT_DEFINED_UNPATCHED)
+    unclassified_exemptions = sorted(_PROVENANCE_VARIES_BY_VERSION - classified)
+    assert not unclassified_exemptions, (
+        f"exempted from the provenance pin but not classified: {unclassified_exemptions}"
     )
 
 

--- a/tests/counting/test_float_surface.py
+++ b/tests/counting/test_float_surface.py
@@ -1,0 +1,358 @@
+"""Every attribute of `float` must be accounted for: overridden, or classified with a reason.
+
+The math-surface test pins `math`'s callables so a function CPython adds later fails a test
+instead of becoming a silently uncounted hole.  This is the same pin for `float`'s own attribute
+surface, with two extensions that surface needs and the math one does not:
+
+* **Behavior pins on the overridden members** — an override that exists but returns the wrong
+  type (or counts the wrong thing) is invisible to a name-level check, so the pins assert count
+  and return type, not mere presence.
+* **Provenance pins on the classified members** — the float-defined and object-defined halves
+  drift for different reasons, and a member migrating between them (e.g. `float` growing its own
+  `__str__`) would change behavior without changing any name.
+
+Enumeration is by *name* over `dir(float)` on the running interpreter — never by defining class:
+`__getattribute__` sat in `float.__dict__` on 3.11 but not on 3.12+, so a `vars(float)`-based
+sweep breaks across supported versions while the name set stays stable.
+"""
+
+import copy
+import math
+import pickle
+import struct
+from decimal import Decimal
+from fractions import Fraction
+
+import pytest
+
+from counted_float import CountedFloat, FlopCountingContext, Verbosity
+from counted_float._core.counting._float_surface import _FLOAT_DEFINED_UNPATCHED, _OBJECT_DEFINED_UNPATCHED
+
+_TABLES = {
+    "_FLOAT_DEFINED_UNPATCHED (inherited from float - say why no override is needed)": _FLOAT_DEFINED_UNPATCHED,
+    "_OBJECT_DEFINED_UNPATCHED (inherited object plumbing - pinned for drift)": _OBJECT_DEFINED_UNPATCHED,
+}
+
+
+# =================================================================================================
+#  Helpers
+# =================================================================================================
+def _unclassified(surface: set[str]) -> set[str]:
+    """The members of `surface` that are neither overridden by CountedFloat nor classified."""
+    overridden = surface & set(vars(CountedFloat))
+    classified = set().union(*(set(table) for table in _TABLES.values()))
+    return surface - overridden - classified
+
+
+def _bits(value: float) -> bytes:
+    """The exact binary64 representation, so nan payloads and zero signs compare too."""
+    return struct.pack(">d", value)
+
+
+# =================================================================================================
+#  The surface is fully accounted for
+# =================================================================================================
+def test_every_float_attribute_is_classified_or_overridden():
+    # --- arrange / act -------------------------
+    unclassified = _unclassified(set(dir(float)))
+
+    # --- assert --------------------------------
+    assert not unclassified, (
+        f"unclassified float attribute(s): {sorted(unclassified)}.\n"
+        "Each one is either overridden on CountedFloat (and behavior-pinned below) or belongs "
+        "in exactly one of:\n" + "\n".join(f"  - {table}" for table in _TABLES)
+    )
+
+
+def test_a_fake_member_is_reported_by_name():
+    # the check must fail loudly on an unknown name -- a surface test that passes over an
+    # augmented enumeration would also pass over a real CPython addition
+    # --- arrange / act -------------------------
+    unclassified = _unclassified(set(dir(float)) | {"definitely_not_a_float_member"})
+
+    # --- assert --------------------------------
+    assert unclassified == {"definitely_not_a_float_member"}
+
+
+def test_no_table_classifies_an_absent_or_overridden_member():
+    # --- arrange -------------------------------
+    surface = set(dir(float))
+    overridden = surface & set(vars(CountedFloat))
+
+    # --- act -----------------------------------
+    phantom = {name: table for table, names in _TABLES.items() for name in set(names) - surface}
+    stale = {name: table for table, names in _TABLES.items() for name in set(names) & overridden}
+
+    # --- assert --------------------------------
+    assert not phantom, f"classified but absent from float on this interpreter: {phantom}"
+    assert not stale, f"classified but overridden on CountedFloat (stale table entry): {stale}"
+
+
+def test_the_tables_do_not_overlap():
+    # --- arrange / act -------------------------
+    overlapping = {
+        name
+        for name in set().union(*(set(t) for t in _TABLES.values()))
+        if sum(name in table for table in _TABLES.values()) > 1
+    }
+
+    # --- assert --------------------------------
+    assert not overlapping, f"float attribute(s) classified more than once: {overlapping}"
+
+
+def test_every_entry_carries_a_reason():
+    # --- arrange / act -------------------------
+    reasonless = [name for table in _TABLES.values() for name, reason in table.items() if not reason.strip()]
+
+    # --- assert --------------------------------
+    assert not reasonless, f"entries with no stated reason: {reasonless}"
+
+
+def test_classified_members_have_their_stated_provenance():
+    # --- arrange / act -------------------------
+    not_float_defined = sorted(name for name in _FLOAT_DEFINED_UNPATCHED if name not in vars(float))
+    not_object_defined = sorted(name for name in _OBJECT_DEFINED_UNPATCHED if name in vars(float))
+
+    # --- assert --------------------------------
+    assert not not_float_defined, f"classified as float-defined but not in float.__dict__: {not_float_defined}"
+    assert not not_object_defined, (
+        f"classified as object plumbing but defined by float itself: {not_object_defined} — "
+        "a member migrating to float-defined changes behavior (e.g. what str(x) prints) and "
+        "must be re-triaged, not re-labeled"
+    )
+
+
+# =================================================================================================
+#  Behavior pins - the complex protocol
+# =================================================================================================
+@pytest.mark.parametrize("value", [1.5, -2.5, 0.0, -0.0, math.inf, -math.inf, math.nan], ids=repr)
+def test_real_and_conjugate_preserve_countedness_at_zero_cost(thread_counter, value):
+    # --- arrange -------------------------------
+    x = CountedFloat(value)
+
+    # --- act -----------------------------------
+    results = [x.real, x.conjugate()]
+
+    # --- assert --------------------------------
+    for result in results:
+        assert isinstance(result, CountedFloat)
+        assert _bits(result) == _bits(value)  # bit-identical, nan sign and payload included
+    assert thread_counter.total_count() == 0
+
+
+def test_real_dropping_countedness_no_longer_kills_downstream_counting(thread_counter):
+    # the defect that motivated the override: a plain-float .real demoted runtime data to a
+    # value-folded constant, so 10.0 / x.real counted MUL or DIV depending on x's value
+    # --- act -----------------------------------
+    _ = CountedFloat(10.0) / CountedFloat(3.0).real
+
+    # --- assert --------------------------------
+    assert thread_counter.DIV == 1
+    assert thread_counter.total_count() == 1
+
+
+@pytest.mark.parametrize("value", [1.5, -0.0, math.nan, -math.nan, math.inf], ids=repr)
+def test_imag_is_the_ports_plain_constant(thread_counter, value):
+    # --- act -----------------------------------
+    result = CountedFloat(value).imag
+
+    # --- assert --------------------------------
+    assert type(result) is float  # receiver-independent: the port's compile-time constant
+    assert _bits(result) == _bits(0.0)  # exactly +0.0, whatever the receiver's sign or payload
+    assert thread_counter.total_count() == 0
+
+
+# =================================================================================================
+#  Behavior pins - is_integer
+# =================================================================================================
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(1.5, False), (2.0, True), (-0.0, True), (2.0**53, True), (math.inf, False), (math.nan, False)],
+    ids=repr,
+)
+def test_is_integer_counts_the_floor_and_compare(thread_counter, value, expected):
+    # --- act -----------------------------------
+    result = CountedFloat(value).is_integer()
+
+    # --- assert --------------------------------
+    assert result is expected
+    assert type(result) is bool
+    # RND, not F2I: C's floor is double->double and no int materializes -- the price of the
+    # counted spelling  x // 1.0 == x.  Charged unconditionally, non-finite fast path included.
+    assert thread_counter.RND == 1
+    assert thread_counter.COMP == 1
+    assert thread_counter.total_count() == 2
+
+
+# =================================================================================================
+#  Behavior pins - as_integer_ratio
+# =================================================================================================
+def test_as_integer_ratio_is_uncounted_and_warns_when_reporting(thread_counter, capsys):
+    # --- arrange -------------------------------
+    from counted_float._core.counting.verbosity import _uncounted_warnings
+
+    _uncounted_warnings._reported.clear()  # the reported-sites record is process-wide
+
+    # --- act -----------------------------------
+    quiet = CountedFloat(1.5).as_integer_ratio()
+    with FlopCountingContext(verbosity=Verbosity.WARNING):
+        loud = CountedFloat(1.5).as_integer_ratio()
+
+    # --- assert --------------------------------
+    assert quiet == loud == (3, 2)
+    assert thread_counter.total_count() == 0
+    lines = [line for line in capsys.readouterr().err.splitlines() if line.strip()]
+    (line,) = lines  # the quiet call reported nothing; the reporting context exactly one line
+    assert line.split()[:2] == ["WARN", "float.as_integer_ratio"]
+
+
+# =================================================================================================
+#  Behavior pins - construction and exits
+# =================================================================================================
+def test_new_source_matrix(thread_counter):
+    """int counts I2F; float, str, Decimal and Fraction convert uncounted (stated gaps)."""
+    # --- act / assert --------------------------
+    for source, expected_i2f in [(3, 1), (True, 1), (1.5, 0), ("1.5", 0), (Decimal("1.5"), 0), (Fraction(3, 2), 0)]:
+        thread_counter.reset()
+        result = CountedFloat(source)  # ty: ignore[invalid-argument-type] -- str/Decimal sources are the incidental paths under test
+        assert isinstance(result, CountedFloat)
+        assert expected_i2f == thread_counter.I2F
+        assert thread_counter.total_count() == expected_i2f
+
+
+def test_float_call_is_the_explicit_uncounted_exit(thread_counter):
+    # --- act -----------------------------------
+    result = float(CountedFloat(1.5))
+
+    # --- assert --------------------------------
+    assert type(result) is float  # exactly plain: the value has left the counting model
+    assert thread_counter.total_count() == 0
+
+
+def test_fromhex_preserves_countedness_at_zero_cost(thread_counter):
+    # --- act -----------------------------------
+    result = CountedFloat.fromhex("0x1.8p+1")
+
+    # --- assert --------------------------------
+    assert isinstance(result, CountedFloat)
+    assert float(result) == 3.0  # compared through the uncounted exit, so the pin below holds
+    assert thread_counter.total_count() == 0  # the parse is a stated gap: no FlopType prices it
+    assert float(CountedFloat.fromhex(CountedFloat(1.5).hex())) == 1.5  # round-trips through hex()
+
+
+@pytest.mark.skipif(not hasattr(float, "from_number"), reason="float.from_number exists from Python 3.14")
+def test_from_number_counts_i2f_for_int_sources(thread_counter):
+    """The 3.14 constructor answers like CountedFloat(n): same source, same price."""
+    # --- act / assert --------------------------
+    for source, expected_i2f in [(3, 1), (True, 1), (1.5, 0), (CountedFloat(2.5), 0), (Decimal("1.5"), 0)]:
+        thread_counter.reset()
+        result = CountedFloat.from_number(source)
+        assert isinstance(result, CountedFloat)
+        assert expected_i2f == thread_counter.I2F
+        assert thread_counter.total_count() == expected_i2f
+    with pytest.raises(TypeError):
+        CountedFloat.from_number("1.5")  # rejected by the underlying call, nothing counted
+    assert thread_counter.total_count() == 0  # compute-first contract: the raising call left no phantom flop
+
+
+# =================================================================================================
+#  Behavior pins - presentation
+# =================================================================================================
+def test_repr_is_the_single_loud_presentation_mechanism(thread_counter):
+    # --- arrange -------------------------------
+    x = CountedFloat(1.5)
+
+    # --- act / assert --------------------------
+    # float defines no __str__, so every empty-spec spelling falls through to __repr__
+    assert "__str__" not in vars(CountedFloat)
+    for loud in (str(x), f"{x}", format(x, ""), repr(x)):
+        assert loud == "CountedFloat(1.5)"
+    # any non-empty spec formats the plain value -- the loud/quiet boundary is exactly spec == ''
+    assert f"{x:.2f}" == "1.50"
+    assert format(x, ">5") == "  1.5"
+    assert thread_counter.total_count() == 0
+
+
+def test_percent_formatting_stays_uncounted(thread_counter):
+    # the '%' presentation type multiplies by 100 in binary64 first -- a labeled uncounted
+    # exception, pinned so the zero is a decision rather than an accident
+    # --- act -----------------------------------
+    rendered = format(CountedFloat(0.07), ".1%")
+
+    # --- assert --------------------------------
+    assert rendered == "7.0%"
+    assert thread_counter.total_count() == 0
+
+
+def test_truthiness_stays_uncounted_and_the_counted_spelling_counts(thread_counter):
+    # --- arrange -------------------------------
+    x = CountedFloat(1.5)
+
+    # --- act / assert --------------------------
+    assert bool(x)
+    assert not CountedFloat(0.0)  # the implicit spelling, through `not`
+    assert thread_counter.total_count() == 0  # implicit interpreter tests are bookkeeping
+    assert x != 0.0
+    assert thread_counter.COMP == 1  # the algorithmic spelling pays its COMP
+
+
+def test_hex_is_an_uncounted_str_exit(thread_counter):
+    # --- act -----------------------------------
+    result = CountedFloat(1.5).hex()
+
+    # --- assert --------------------------------
+    assert type(result) is str
+    assert thread_counter.total_count() == 0
+
+
+# =================================================================================================
+#  Behavior pins - pickling, both routes
+# =================================================================================================
+@pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+@pytest.mark.parametrize("value", [1.5, -0.0, math.inf, math.nan], ids=repr)
+def test_pickle_round_trip_preserves_countedness_at_zero_count(thread_counter, value, protocol):
+    """Protocols 0-1 rebuild via copyreg and float(); 2+ via __getnewargs__ and __new__.
+
+    The two routes share no code, so a single-protocol test leaves half of this unguarded.
+    """
+    # --- act -----------------------------------
+    restored = pickle.loads(pickle.dumps(CountedFloat(value), protocol=protocol))  # noqa: S301
+
+    # --- assert --------------------------------
+    assert isinstance(restored, CountedFloat)
+    assert thread_counter.total_count() == 0  # deserialization is not the algorithm converting
+    if protocol >= 1:
+        # protocol 0 pickles floats as repr text, which loses nan payloads -- plain-float
+        # behavior, so bit-exactness is only the contract from protocol 1 up
+        assert _bits(restored) == _bits(value)
+    else:
+        assert restored == value or (math.isnan(restored) and math.isnan(value))
+
+
+@pytest.mark.parametrize("copier", [copy.copy, copy.deepcopy], ids=["copy", "deepcopy"])
+def test_copy_preserves_countedness_at_zero_count(thread_counter, copier):
+    # --- act -----------------------------------
+    result = copier(CountedFloat(1.5))
+
+    # --- assert --------------------------------
+    assert isinstance(result, CountedFloat)
+    assert float(result) == 1.5  # compared through the uncounted exit, so the pin below holds
+    assert thread_counter.total_count() == 0
+
+
+def test_pickle_mechanism_pins(thread_counter):
+    """Pin the mechanism, not just the outcome: what each pickle member hands the machinery."""
+    # --- arrange -------------------------------
+    x = CountedFloat(1.5)
+
+    # --- act -----------------------------------
+    newargs = x.__getnewargs__()
+    state = x.__getstate__()
+    reconstructor, args = x.__reduce__()[:2]
+
+    # --- assert --------------------------------
+    assert newargs == (1.5,)
+    assert type(newargs[0]) is float  # a plain float: re-entry counts nothing
+    assert state is None  # no instance state exists, because __slots__ is empty
+    assert isinstance(reconstructor(*args), CountedFloat)  # the direct-call route also rebuilds counted
+    assert thread_counter.total_count() == 0

--- a/tests/counting/test_fresh_thread_first_op.py
+++ b/tests/counting/test_fresh_thread_first_op.py
@@ -103,6 +103,7 @@ _OPERATORS: list[tuple[str, Callable[[], object]]] = [
     ("trunc", lambda: math.trunc(CF(2.5))),
     ("int", lambda: int(CF(2.5))),
     ("new_from_int", lambda: CF(3)),
+    ("is_integer", lambda: CF(2.0).is_integer()),
     ("eq", lambda: CF(1.5) == CF(2.5)),
     ("ne", lambda: CF(1.5) != CF(2.5)),
     ("lt", lambda: CF(1.5) < CF(2.5)),
@@ -120,6 +121,9 @@ _OPERATORS: list[tuple[str, Callable[[], object]]] = [
     ("rsub_minus_zero", lambda: CF(2.0).__rsub__(-0.0)),
     ("rpow_countedfloat_base", lambda: CF(2.0).__rpow__(CF(3.0))),
 ]
+if hasattr(float, "from_number"):
+    # Python 3.14+ only, registered conditionally like the version-gated math patches below
+    _OPERATORS.append(("from_number_int", lambda: CF.from_number(3)))
 
 
 @pytest.mark.parametrize(("op_id", "call"), _OPERATORS, ids=[op_id for op_id, _ in _OPERATORS])


### PR DESCRIPTION
**TL;DR**: Every member of `dir(float)` is now counted, warned, or classified with a stated reason — pinned by a test that enumerates the surface on the running interpreter.

- Contagion restored: `conjugate()` / `.real` preserve countedness; `is_integer()` and `from_number()` (3.14) now count.
- `as_integer_ratio()` becomes the float surface's one WARNING-reported member.
- New classification tables + surface test make the next CPython addition a test failure, not a silent hole.

## Description

### Problem addressed

`tests/counting/test_math_surface.py` pins the `math` module so new CPython functions cannot become silently uncounted holes — but `float`'s own attribute surface had no equivalent. Measured consequences: `x.conjugate() * 3.0` counted nothing where `x * 3.0` counts a MUL; `is_integer()` was exempted by a criterion its own implementation contradicts; Python 3.14's `from_number` accepted an int and skipped the I2F the constructor charges; and `n, d = x.as_integer_ratio(); n / d` silently resumed float math at zero flops.

### Implementation

- **Overrides**, each citing its cost-model ground: `conjugate()`/`.real` return `self` (bit-identical to `+x`, so zero cost with the type preserved; `self` because the class is final and immutable); `is_integer()` counts **RND + COMP** (CPython computes `floor(x) == x` in doubles — the price of the counted spelling `x // 1.0 == x`); `from_number()` counts **I2F for int/bool sources**, attached conditionally on 3.14+; `as_integer_ratio()` reports through the existing WARNING channel. `.imag` deliberately stays inherited — `+0.0` for every receiver is the port's compile-time constant.
- **Classification tables** (`_float_surface.py`) cover every inherited member with a reason, split by provenance (float-defined vs object plumbing) so churn in `object`'s surface stays legible.
- **The surface test** enumerates `dir(float)` *by name*, checks completeness / phantoms / overlaps / reasons / provenance, and pins behavior: the complex protocol bit-exactly, the constructor source matrix, both pickle routes (protocols 0–5, `copy`/`deepcopy`), presentation loudness, and truthiness.
- **Docs**: the cost model gains its scope statement (floating-point work only — why `hex()` counts nothing while `copysign` carries a weight) and rule 2's floating-point qualifier; the truthiness exception is relabeled with its real grounds (implicitness, and `python -O` eliding `assert`).
- The functional no-op `__str__` override is deleted: `float` defines no `__str__`, so all printing already lands on `__repr__` — now documented there, with the fallthrough guarded by the test's provenance pin.

## Attention points

- **`x.real is x` is now true** — identity is unobservable on a final immutable class, and returning `self` beats constructing an equal copy; a comment marks the divergence from the neighbors' re-wrap idiom.
- **`Decimal`/`Fraction` construction stays uncounted** through both constructors — their conversion has no FlopType (a stated gap, consistent with the model's floating-point-only scope), and the test pins that they still produce a `CountedFloat`.
- **The WARNING scope is deliberately minimal**: warn where leaving the counted world is a side effect (`as_integer_ratio`), never where it is the point (`float(x)`) or where no numeric value can re-enter (`hex`, formatting).

## Tests / Spikes

- 20 new test functions in `test_float_surface.py` (surface accounting, fake-member demonstration, behavior pins including both pickle routes across all protocols).
- **TEST:** full suite green on the 3.13 venv; `test_float_surface.py` additionally run on Python 3.14, where `from_number` exists and `dir(float)` has 60 members.
- **TEST:** the previously-silent defect reverses — `10.0 / x.real` now counts exactly one DIV regardless of the receiver's value.

## Changelog entry

Fixed:

```
- `conjugate()` and `.real` on a counted value now preserve countedness instead of silently dropping it
- `is_integer()` now counts the floor-and-compare a compiled port executes
- `from_number()` (Python 3.14) now counts the int-to-float conversion for integer sources, like the constructor
```

Added:

```
- `as_integer_ratio()` on a counted value is now reported at WARNING verbosity, since its integer parts can silently re-enter float math uncounted
```


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
