### PR TITLE
docs: add the float-surface page with its generated coverage table

### DIFF
--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -130,6 +130,10 @@ is active. Operator-based contagion (`+`, `*`, `**`, ...) works everywhere,
 but counts are meant to be read through a context — so the practical rule is
 simply: run your measured algorithm inside one.
 
+The account of `float`'s *own* attribute surface — which methods count, which
+are reported, which are deliberately uncounted, and the presentation and
+pickling contracts — is on [The float surface](float_surface.md).
+
 ### What the library will and will not instrument
 
 The library's side of the contract counts what a compiled port would execute —

--- a/docs/float_surface.md
+++ b/docs/float_surface.md
@@ -1,0 +1,97 @@
+# The float surface
+
+`CountedFloat` inherits from `float`, so every attribute `float` exposes is part of the
+counting model's surface — not just the arithmetic operators. This page is the account of
+that surface, the sibling of the
+[`math` coverage table](math_patching.md#coverage-of-the-math-module): every member of
+`dir(float)` participates in exactly one way — **counted** through an override, **reported**
+at WARNING verbosity, or **deliberately uncounted** with the reason stated below — and a test
+holds the surface to that partition on every supported interpreter, so an attribute a future
+CPython adds fails a test instead of becoming a silently uncounted hole.
+
+## Counted members
+
+The arithmetic and comparison operators are covered per operation in the
+[FLOP types reference](flop_types.md). Beyond those, these members count or preserve
+countedness:
+
+| Member | Counts | Result |
+|---|---|---|
+| `x.real`, `x.conjugate()` | *(nothing — they return the receiver's own bits, like `+x`)* | `CountedFloat`, bit-identical |
+| `x.is_integer()` | `RND + COMP` — CPython computes `floor(x) == x` in doubles, the price of the counted spelling `x // 1.0 == x` (RND, not F2I: no int materializes) | `bool` |
+| `CountedFloat(n)`, int source | `I2F` — the port's int→double conversion instruction | `CountedFloat` |
+| `CountedFloat.from_number(n)` (Python 3.14+), int source | `I2F` — the same answer as the constructor, for the same source | `CountedFloat` |
+
+The complex-protocol trio gets two answers on purpose: `real` and `conjugate()` are
+receiver-*dependent* (they hand back the receiver's own bits, so dropping the type would
+silently stop downstream counting), while `imag` is receiver-*independent* — `+0.0` for every
+possible receiver, signs and nan payloads included — which makes it a compile-time constant
+of the port; see its row below.
+
+## Reported at WARNING verbosity
+
+`x.as_integer_ratio()` is uncounted — the port's extraction is a bit-field read plus an
+integer shift, work outside the floating-point domain the model prices — but its result is
+the one on this surface that can silently re-enter float arithmetic: `n, d =
+x.as_integer_ratio(); n / d` resumes uncounted at zero flops. It is therefore reported
+through the same once-per-call-site WARNING channel as the uncounted `math` helpers — see
+[watching what gets counted](counting_flops.md#watching-what-gets-counted).
+
+`float(x)` is *not* reported, deliberately: it is the documented exit from the counting
+model, and what makes it safe is that leaving the counted world is the explicit point of the
+call — unlike a representation query whose parts happen to re-enter.
+
+## Deliberately uncounted members
+
+Everything `CountedFloat` inherits unchanged, with the reason it needs no override:
+
+<!-- BEGIN generated: float-surface-table -->
+| Member | Why it needs no override |
+|---|---|
+| `__bool__` | truthiness is deliberately uncounted bookkeeping: the interpreter inserts it implicitly at every if/while/and/or/not/assert with no opt-out, and python -O elides assert entirely, so a count here would vary with interpreter flags; the algorithmic spelling x != 0.0 counts COMP |
+| `__float__` | the documented escape hatch: an explicit, uncounted exit from the counting model -- double->double identity, no instruction in the port. Safe because it is explicit at the call site, which is exactly what the implicit property access real lacks |
+| `__format__` | formatting produces a str that leaves the algorithm; correctly-rounded decimal conversion is the machinery round(x, n) declares unmodeled -- except the '%' presentation type, which scales by 100 in binary64 first: one MUL, a labeled uncounted exception (unobservable from Python, and the result cannot re-enter the algorithm) |
+| `__getformat__` | structurally not a float operation: binds to the type and reads no value (its return string is endianness-dependent, so only existence is pinned) |
+| `__getnewargs__` | pickling (protocol 2+) and copy/deepcopy: hands __new__ a plain-float 1-tuple, so round-trips rebuild a CountedFloat at zero count -- deserialization is not the algorithm converting an integer |
+| `fromhex` | preserves countedness: CPython wraps the parsed double through the subclass constructor, so the result is a CountedFloat; the strtod-shaped parse itself has no FlopType -- a stated gap (CountedFloat(3) costs I2F where fromhex('0x1.8p+1') costs nothing) |
+| `hex` | produces a str that leaves the algorithm; the hex digits are the mantissa's own nibbles, so the port emits no floating-point instruction -- the remaining work is integer/bit manipulation, which this library counts nowhere |
+| `imag` | plain +0.0 for every receiver, signs and nan payloads included: a compile-time constant of the port, per the cost model's constant-result convention (the receiver-dependent real / conjugate preserve countedness instead) |
+| `__class__` *(object plumbing)* | object plumbing: computes no float value |
+| `__delattr__` *(object plumbing)* | refuses attribute mutation (empty __slots__), matching plain float |
+| `__dir__` *(object plumbing)* | object plumbing: computes no float value |
+| `__getattribute__` *(object plumbing)* | object plumbing: computes no float value |
+| `__getstate__` *(object plumbing)* | pickling: returns None because __slots__ is empty -- no instance state exists to serialize; pinned because it guards the __slots__ decision |
+| `__init__` *(object plumbing)* | object.__init__ no-op: the narrowed __new__ is the sole arity gate, so CountedFloat(1.0, 2.0) fails in __new__ before this ever runs |
+| `__reduce__` *(object plumbing)* | pickling: delegates through copyreg and rebuilds a CountedFloat at zero count; reachable only by direct call (pickle routes through __reduce_ex__) |
+| `__reduce_ex__` *(object plumbing)* | pickling (protocols 0-1): routes through copyreg and float(), rebuilding a CountedFloat at zero count with no CountedFloat override participating -- pinned because that route is pure CPython machinery |
+| `__setattr__` *(object plumbing)* | refuses attribute mutation (empty __slots__), matching plain float |
+| `__sizeof__` *(object plumbing)* | reports memory, computes no float value (the byte count is build-dependent -- 3.14t differs -- so only existence is pinned) |
+| `__str__` *(object plumbing)* | presentation: float defines no __str__ of its own, so str(x) falls through object.__str__ to the loud CountedFloat.__repr__ -- the single presentation mechanism; provenance is pinned because a future float-defined __str__ would silently change what str(x) prints |
+| `__subclasshook__` *(object plumbing)* | object plumbing: computes no float value |
+<!-- END generated: float-surface-table -->
+
+## The presentation contract
+
+`__repr__` is the single presentation mechanism, and it is deliberately loud:
+`repr(x)`, `str(x)`, `print(x)`, `f"{x}"` and `format(x, "")` all render
+`CountedFloat(1.5)` — `float` defines no `__str__` of its own, so every empty-spec spelling
+falls through to the repr. Whether a value silently fell out of the counting system is this
+library's central hazard, and the repr is the zero-cost place it shows.
+
+Any **non-empty** format spec formats the plain value instead — `f"{x:.2f}"` gives `1.50`,
+and even a bare alignment (`f"{x:>10}"`) flips to plain rendering — so reports and tables
+keep their layout. The loud/quiet boundary is exactly `spec == ""`.
+
+One formatting subtlety is a labeled exception rather than a derivation: the `%`
+presentation type multiplies by 100 in binary64 before converting (`f"{x:.1%}"`), and that
+one MUL is uncounted — it is unobservable from Python, and the resulting `str` cannot
+re-enter the algorithm.
+
+## Pickling and copying
+
+Pickling, `copy.copy` and `copy.deepcopy` round-trip a `CountedFloat` to a `CountedFloat` at
+zero count, on both mechanisms pickle uses: protocols 2+ rebuild through `__getnewargs__`
+and the class's own constructor, protocols 0–1 through `copyreg` and plain CPython
+machinery. The zero count is correct — deserialization is not the algorithm converting an
+integer — and bit-exactness holds from protocol 1 up (protocol 0 stores floats as repr text,
+which loses nan payloads; plain-float behavior, not a `CountedFloat` difference).

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -60,13 +60,13 @@ up in that output.
 
 ## Other limitations
 
-- the only uncounted Python built-in math operations are the
-  float-representation helpers (`frexp`, `ldexp`, `modf`, `nextafter`,
-  `ulp`), which manipulate rather than compute; see the
-  [`math` coverage table](math_patching.md#coverage-of-the-math-module) for
-  the full per-function status and the
-  [FLOP types reference](flop_types.md) for per-operation counting rules. A
-  counting context can be asked to report such calls as it meets them, so a
+- the uncounted built-in operations are cataloged per surface: the `math`
+  module's not-instrumented set (`frexp`, `ldexp`, `modf`, `nextafter`,
+  `ulp` — the port emits no floating-point instruction for them; see the
+  [`math` coverage table](math_patching.md#coverage-of-the-math-module)) and
+  `float`'s own uncounted members (`hex()`, `as_integer_ratio()`, formatting,
+  truthiness — see [the float surface](float_surface.md)). A counting context
+  can be asked to report the contagion-relevant ones as it meets them, so a
   count that is quietly missing them says so — see
   [watching what gets counted](counting_flops.md#watching-what-gets-counted)
 - operator-level fused multiply-add is not modeled: `a*b + c` counts as separate

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
   - Home: index.md
   - Counting FLOPs: counting_flops.md
   - Math patching semantics: math_patching.md
+  - The float surface: float_surface.md
   - FLOP weights: flop_weights.md
   - Benchmarking: benchmarking.md
   - CLI reference: cli.md

--- a/scripts/generate_docs_content.py
+++ b/scripts/generate_docs_content.py
@@ -63,6 +63,7 @@ from flop_weight_chart import THEMES as CHART_THEMES
 from flop_weight_chart import build_svg as build_chart_svg
 
 from counted_float import BuiltInData
+from counted_float._core.counting._float_surface import _FLOAT_DEFINED_UNPATCHED, _OBJECT_DEFINED_UNPATCHED
 from counted_float._core.counting._math_patching import (
     _MATH_NOT_PATCHED,
     _NOT_PATCHED_DUNDER,
@@ -353,6 +354,17 @@ def generate_math_coverage_table() -> str:
     return "\n".join(["| Coverage | Functions |", "|---|---|", *(f"| {left} | {right} |" for left, right in rows)])
 
 
+def generate_float_surface_table() -> str:
+    """The float-surface classification table, derived from the classification tables."""
+    rows = ["| Member | Why it needs no override |", "|---|---|"]
+    rows += [f"| `{name}` | {_FLOAT_DEFINED_UNPATCHED[name]} |" for name in sorted(_FLOAT_DEFINED_UNPATCHED)]
+    rows += [
+        f"| `{name}` *(object plumbing)* | {_OBJECT_DEFINED_UNPATCHED[name]} |"
+        for name in sorted(_OBJECT_DEFINED_UNPATCHED)
+    ]
+    return "\n".join(rows)
+
+
 def _snippet_source(name: str) -> str:
     """The committed snippet's source, as the docs' input code block."""
     return f"```python\n{(SNIPPETS_DIR / name).read_text(encoding='utf-8').rstrip()}\n```"
@@ -386,6 +398,7 @@ MARKED_BLOCKS: dict[str, MarkedBlock] = {
     "cli-show-data-slice": MarkedBlock(REPO_ROOT / "docs" / "cli.md", generate_cli_show_data_slice),
     "builtin-data-table": MarkedBlock(REPO_ROOT / "docs" / "builtin_data.md", generate_builtin_data_table),
     "math-coverage-table": MarkedBlock(REPO_ROOT / "docs" / "math_patching.md", generate_math_coverage_table),
+    "float-surface-table": MarkedBlock(REPO_ROOT / "docs" / "float_surface.md", generate_float_surface_table),
     "snippet-verbosity-info": MarkedBlock(REPO_ROOT / "docs" / "counting_flops.md", generate_snippet_verbosity_info),
     "snippet-verbosity-warning": MarkedBlock(
         REPO_ROOT / "docs" / "counting_flops.md", generate_snippet_verbosity_warning

--- a/tests/counting/test_float_surface.py
+++ b/tests/counting/test_float_surface.py
@@ -347,6 +347,37 @@ def test_pickle_round_trip_preserves_countedness_at_zero_count(thread_counter, v
         assert restored == value or (math.isnan(restored) and math.isnan(value))
 
 
+@pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+def test_each_protocol_takes_its_documented_route(protocol):
+    """The route itself, not only its outcome: both would pass if one of them vanished.
+
+    Protocols 0-1 route through `copyreg._reconstructor`, which the pickle stream names
+    outright; protocols 2+ use `__getnewargs__` and the class's own `__new__`, and name no
+    reconstructor at all.
+    """
+    # --- act -----------------------------------
+    stream = pickle.dumps(CountedFloat(1.5), protocol=protocol)
+
+    # --- assert --------------------------------
+    assert (b"_reconstructor" in stream) is (protocol <= 1)
+
+
+def test_protocol_0_loses_the_nan_payload_that_later_protocols_keep():
+    """The stated exception to bit-exactness, pinned so it stays a known limit of protocol 0."""
+    # --- arrange -------------------------------
+    payload_nan = CountedFloat(struct.unpack(">d", bytes.fromhex("7ff8deadbeef0000"))[0])
+
+    # --- act -----------------------------------
+    restored = {p: pickle.loads(pickle.dumps(payload_nan, protocol=p)) for p in (0, 1, 2)}  # noqa: S301
+
+    # --- assert --------------------------------
+    # protocol 0 stores floats as repr text, so the payload cannot survive the round trip
+    assert _bits(restored[0]) != _bits(payload_nan)
+    assert math.isnan(restored[0])  # still a nan, just not the same one
+    for protocol in (1, 2):
+        assert _bits(restored[protocol]) == _bits(payload_nan)
+
+
 @pytest.mark.parametrize("copier", [copy.copy, copy.deepcopy], ids=["copy", "deepcopy"])
 def test_copy_preserves_countedness_at_zero_count(thread_counter, copier):
     # --- act -----------------------------------


### PR DESCRIPTION
**Problem**: The float surface is now classified and tested, but nothing in the rendered docs shows it — and `known_limitations.md` still claimed the float-representation helpers were the only uncounted built-in operations, which the new classification disproves.

**Solution**: A new docs page, sibling of the math coverage page: the counted members, the WARNING-reported `as_integer_ratio`, the deliberately-uncounted table (generated from the same source-of-truth tables the surface test enforces, so docs and code cannot drift), the presentation contract (`__repr__` loud, the `spec == ""` boundary, the `%` exception), and the pickling contract. `known_limitations.md` now points at both coverage tables; `counting_flops.md` cross-links.

- **TEST:** full suite green, including the docs-drift test over the new generated block; site nav gains the page.

**Changelog** (none): documentation only — the behavior it describes carries its entries on the implementing changes.


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
