### PR TITLE
fix: declare from_number inside the class body

### DIFF
--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -759,29 +759,27 @@ class CountedFloat(float):
             count_pow_with_constant_base(other)
         return float.__new__(CountedFloat, result)
 
+    if hasattr(float, "from_number"):
+        # Python 3.14+ only. Declared conditionally, the way the math tables register
+        # version-gated functions: the member exists on CountedFloat exactly when it exists on
+        # float, so surface comparisons hold in both directions on every supported interpreter.
+        @classmethod
+        def from_number(cls, number: object) -> CountedFloat:
+            """Counted construction from a real number (float.from_number), I2F for int sources.
 
-if hasattr(float, "from_number"):
-    # Python 3.14+ only. Attached conditionally, the way the math tables register version-gated
-    # functions: the member exists on CountedFloat exactly when it exists on float, so surface
-    # comparisons hold in both directions on every supported interpreter.
-    def _from_number(cls: type[CountedFloat], number: object) -> CountedFloat:
-        """Counted construction from a real number (float.from_number), I2F for int sources.
-
-        CPython's from_number converts to a C double before handing the subclass constructor a
-        plain float, so without this override an int source converts unpaid where
-        CountedFloat(n) counts I2F -- the same source, two constructors, two answers. The
-        source matrix mirrors __new__: int (bool included) counts I2F; float sources cost
-        nothing; Decimal and Fraction convert uncounted, a stated gap; strings are rejected by
-        the underlying call.
-        """
-        # resolved dynamically: on 3.13-era typeshed the member does not exist to reference
-        from_number = getattr(float, "from_number")  # noqa: B009
-        result = from_number(number)  # compute first: a str or oversized source raises before counting
-        if isinstance(number, int):
-            try:
-                _TLS.flop_counts.I2F += 1
-            except AttributeError:  # first counted op on this thread
-                _create_thread_state().I2F += 1
-        return float.__new__(CountedFloat, result)
-
-    CountedFloat.from_number = classmethod(_from_number)  # ty: ignore[unresolved-attribute] -- version-gated member
+            CPython's from_number converts to a C double before handing the subclass constructor
+            a plain float, so without this override an int source converts unpaid where
+            CountedFloat(n) counts I2F -- the same source, two constructors, two answers. The
+            source matrix mirrors __new__: int (bool included) counts I2F; float sources cost
+            nothing; Decimal and Fraction convert uncounted, a stated gap; strings are rejected
+            by the underlying call.
+            """
+            # resolved dynamically: on 3.13-era typeshed the member does not exist to reference
+            float_from_number = getattr(float, "from_number")  # noqa: B009
+            result = float_from_number(number)  # compute first: a bad source raises before counting
+            if isinstance(number, int):
+                try:
+                    _TLS.flop_counts.I2F += 1
+                except AttributeError:  # first counted op on this thread
+                    _create_thread_state().I2F += 1
+            return float.__new__(CountedFloat, result)


### PR DESCRIPTION
**Problem**: `from_number` was attached after the class as `CountedFloat.from_number = classmethod(_from_number)`. The type checker rejects that: a callable whose first parameter is `type[CountedFloat]` is not assignable where `classmethod` expects a plain `type`. The `pre-commit` job (which runs `make lint`, and therefore `ty`) fails on `main` as a result — the push-to-main workflow runs tests and coverage only, so nothing surfaced it there.

**Solution**: declare the method **inside** the class body under the same `hasattr(float, "from_number")` guard. That removes the post-hoc assignment altogether — no `ty: ignore` needed — and the conditional now reads like the version-gated registrations used elsewhere in the counting modules. Behavior is unchanged: the member still exists exactly when `float.from_number` does, and still counts `I2F` for int sources.

- **TEST:** `make lint` clean; full suite green locally; the float-surface and fresh-thread tests re-run on Python 3.13 (member absent, tests skip) and 3.14 (member present, exercised).

**Changelog** (none): a type-annotation fix to code that has not shipped in a release yet — no user-facing behavior changes.


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
