### PR TITLE
test: close the mutation gaps in the counting sites

### DIFF
--- a/tests/counting/test_fresh_thread_first_op.py
+++ b/tests/counting/test_fresh_thread_first_op.py
@@ -19,6 +19,11 @@ Each case here spawns a pristine thread whose first action is exactly one op, an
 counts what the same op counts on the (warm) main thread -- so the ``except`` branch is checked
 against the ``try`` branch, per site.  The op list is the arithmetic/comparison/unary operators
 and the patch registry's own keys, so a newly instrumented op or patch is covered automatically.
+
+One half of the handler stays invisible even to that: since ``_create_thread_state()`` hands back
+a zeroed counter, ``<field> = 1`` there would behave exactly like ``<field> += 1``.  The last
+section makes the difference observable by handing the site a counter that already holds counts,
+which is the only way to check that the branch accumulates rather than overwrites.
 """
 
 import math
@@ -27,8 +32,8 @@ from collections.abc import Callable
 
 import pytest
 
-from counted_float import CountedFloat, FlopCountingContext
-from counted_float._core.counting import _math_patching
+from counted_float import CountedFloat, FlopCountingContext, FlopCounts
+from counted_float._core.counting import _counted_float, _math_patching
 from counted_float._core.counting._thread_counter import THREAD_COUNTER
 
 CF = CountedFloat
@@ -236,3 +241,73 @@ def test_math_patch_alternate_path_first_op_on_fresh_thread(case_id: str, call: 
     # --- assert -----------------------------
     assert reference, f"{case_id} counted nothing"
     assert fresh == reference
+
+
+# =================================================================================================
+#  The lazy-init handler accumulates onto the counter it is given
+# =================================================================================================
+# The handler's `except` branch reads `_create_thread_state().<field> += 1`, and in production that
+# helper returns a freshly zeroed counter -- which makes `+= 1` and a plain `= 1` produce the same
+# state, so no ordinary test can tell them apart (the branch also fires only once per thread, so
+# repeating the op cannot separate them either).  The distinction is real all the same: the site's
+# contract is to ACCUMULATE onto whatever counter the helper hands back, and an assignment there
+# would clobber existing counts the moment that helper returns anything but a zeroed counter.  The
+# cases below make the contract observable by handing the site a counter that already holds counts.
+_LAZY_INIT_MODULES = (_counted_float, _math_patching)
+_PRELOAD = 7
+
+
+def _lazy_init_counts_with_preloaded_state(call: Callable[[], object]) -> dict[str, int]:
+    """Run ``call`` as a pristine thread's first counted op, with a NON-fresh lazy-init counter.
+
+    Args:
+        call: The operation to run; it must be the thread's first counter access.
+
+    Returns:
+        The preloaded counter's fields after the call, so the caller can check each one grew by
+        the op's own count instead of being overwritten.
+    """
+    preloaded = FlopCounts()
+    for field in FlopCounts.field_names():
+        setattr(preloaded, field, _PRELOAD)
+    captured: dict[str, object] = {}
+
+    def target() -> None:
+        try:
+            call()
+        except BaseException as exc:  # noqa: BLE001 -- surfaced on the main thread below
+            captured["error"] = exc
+
+    # the helper is imported into each counting module's own namespace, so the replacement is
+    # installed per module -- both of them, since a patch may count through an operator (math.prod
+    # multiplies) and so reach the site in _counted_float rather than its own
+    originals = {m: m._create_thread_state for m in _LAZY_INIT_MODULES}
+    for m in _LAZY_INIT_MODULES:
+        m._create_thread_state = lambda: preloaded
+    try:
+        thread = threading.Thread(target=target)
+        thread.start()
+        thread.join()
+    finally:
+        for m, original in originals.items():
+            m._create_thread_state = original
+    if "error" in captured:
+        raise captured["error"]  # type: ignore[misc]
+    return {name: getattr(preloaded, name) for name in FlopCounts.field_names()}
+
+
+@pytest.mark.parametrize("fname", _PATCH_NAMES)
+def test_math_patch_lazy_init_accumulates_onto_a_preloaded_counter(fname: str) -> None:
+    def call() -> object:
+        return getattr(math, fname)(*_PATCH_ARGS[fname])
+
+    # --- arrange / act (a context installs the patch module-wide, so the pristine thread sees it) ---
+    with FlopCountingContext() as ctx:
+        call()  # reference on the warm main thread
+        reference = _counts_as_dict(ctx.flop_counts())
+        accumulated = _lazy_init_counts_with_preloaded_state(call)
+
+    # --- assert -----------------------------
+    assert reference, f"math.{fname} counted nothing -- its argument fixture may be wrong"
+    for field, per_call in reference.items():
+        assert accumulated[field] == _PRELOAD + per_call, f"math.{fname} overwrote {field} instead of adding to it"

--- a/tests/counting/test_math_patching_counting.py
+++ b/tests/counting/test_math_patching_counting.py
@@ -781,6 +781,10 @@ _ACCUMULATING_MATH_OPS = [
     ("fabs", lambda: math.fabs(CountedFloat(-2.0)), {"ABS": 1}),
     ("fmod", lambda: math.fmod(CountedFloat(5.0), CountedFloat(3.0)), {"FMOD": 1}),
     ("remainder", lambda: math.remainder(CountedFloat(5.0), CountedFloat(3.0)), {"REMAINDER": 1}),
+    ("isnan", lambda: math.isnan(CountedFloat(2.0)), {"COMP": 1}),
+    ("isinf", lambda: math.isinf(CountedFloat(2.0)), {"ABS": 1, "COMP": 1}),
+    ("isfinite", lambda: math.isfinite(CountedFloat(2.0)), {"ABS": 1, "COMP": 1}),
+    ("isclose", lambda: math.isclose(CountedFloat(2.0), 2.5), {"SUB": 1, "ABS": 3, "MUL": 1, "COMP": 3}),
     ("hypot_abs", lambda: math.hypot(CountedFloat(-3.0)), {"ABS": 1}),
     ("hypot2", lambda: math.hypot(CountedFloat(3.0), CountedFloat(4.0)), {"HYPOT": 1}),
     (

--- a/tests/counting/verbosity/test_info_counting.py
+++ b/tests/counting/verbosity/test_info_counting.py
@@ -62,6 +62,13 @@ def test_logged_lines_locate_the_user_expression_not_the_library(logged_lines):
         (lambda x: math.log(x, 10), "LOG10", "const base 10 -> log10"),
         (lambda x: math.log(x, 7.0), "LOG", "const base -> log(x) * 1/log(base)"),
         (lambda x: math.log(x, CountedFloat(7.0)), "LOG", "runtime base -> log(x)/log(base)"),
+        (lambda x: x**-0.5, "SQRT", "const exponent -0.5 -> sqrt + reciprocal"),
+        (lambda x: x**-3, "MUL", "const exponent -> square-and-multiply"),
+        (lambda x: x / -1.0, "MINUS", "constant divisor -1.0 -> sign flip"),
+        (lambda x: x / 4.0, "MUL", "power-of-two constant divisor -> reciprocal multiply"),
+        (lambda x: x * -1.0, "MINUS", "constant multiplier -1.0 -> sign flip"),
+        (lambda x: -0.0 - x, "MINUS", "constant minuend -0.0 -> sign flip"),
+        (lambda x: round(x, 2), "MUL", "nonzero ndigits -> scale, round, unscale"),
     ],
 )
 def test_strength_reductions_are_explained(logged_lines, expression, flop_type, rationale):


### PR DESCRIPTION
**TL;DR**: Kills 65 surviving mutants in the counting modules (89 → 24 survivors) by testing three things the suite could not previously observe.

- The lazy-init handler's `except` branch **accumulates rather than overwrites**.
- The float classifiers join the repeated-call registry that separates `+= 1` from `= 1`.
- Seven fold rationales logged at INFO verbosity gain assertions.

## Description

### Problem addressed

A mutation run over the counting modules left 89 survivors, and they fell into three groups — none of them noise:

- **The lazy-init `except` branch was untestable by construction.** Every counting site inlines `except AttributeError: _create_thread_state().<field> += 1`, and that helper returns a *zeroed* counter — so a mutant writing `= 1` produces identical state. The branch also fires exactly once per thread, so repeating the op cannot separate the two either.
- **The float classifiers had no repeated-call coverage.** `_ACCUMULATING_MATH_OPS` exists precisely to tell `+= 1` from `= 1` (its own comment says so), and `isnan`/`isinf`/`isfinite`/`isclose` were never added to it.
- **Seven fold rationales had no assertion.** The INFO-verbosity fold reasons are user-visible output, but only five of the twelve were asserted; the rest were covered solely by the docs-drift test, which mutation runs cannot execute.

### Implementation

- A new section in the fresh-thread module hands the counting site a **pre-loaded** counter by replacing `_create_thread_state` in both modules that resolve it — making the accumulate-don't-overwrite contract observable, and checking each field grew by the op's own count. The replacement is installed per module because a patch may count through an operator (`math.prod` multiplies) and so reach the site in the other module.
- The four classifiers join the accumulation registry with their per-call costs.
- Seven rationale rows join the existing strength-reduction parametrization: negative and fractional exponents, the two sign-flip folds, the reciprocal-multiply divisor, and the scaled `round`.

Everything reuses the existing registries, so a newly instrumented op stays covered automatically.

## Attention points

- **The pre-loaded counter is deliberately a state production never reaches.** That is the point: `+=` is written at those sites defensively, and the test makes the intent checkable rather than leaving it to be re-derived — if the helper ever returned a non-fresh counter, an assignment there would silently clobber real counts.
- **The replacement is restored under `try`/`finally`**, since it is a module global and a leak would poison later tests in the same worker.
- One lazy-init survivor remains, in a stub that is unreachable by construction.

## Tests / Spikes

- **SPIKE:** classified all 648 survivors by module and mutation shape to find which were genuinely killable — the three groups above — rather than guessing.
- **TEST:** mutation re-run over both counting modules confirms the kills: survivors **89 → 24**, lazy-init equivalents **36 → 1**.
- 62 new test cases (one per patched function, plus the seven rationale rows and four registry entries); full suite 2083 passing, lint clean.

## Changelog entry

None: test-only change, no user-facing behavior.


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
