### PR TITLE
fix: fold constant ±1.0 multiplies in decompositions and reprice 1-D dist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- the `%`/`divmod` decompositions and constant-base `math.log` no longer count the multiply a compiled port folds away for ±1.0 constants (e.g. `x % 1.0`, `math.log(x, math.e)`)
+- 1-D `math.dist` now counts the subtract-and-abs it executes instead of the 2-coordinate distance base cost
+
 ### Security
 
 ## 2.2.0 (2026-08-01)

--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -157,8 +157,10 @@ as a value-preserving [compiled port](glossary.md#compiled-port).**
   `x = -0.0` the result is `+0.0`, not `x`), `x - (-0.0)` counts SUB (it *is*
   `x + 0.0`), and `0.0 - x` counts SUB (`0.0 - 0.0` gives `+0.0`, where a sign flip
   would give `-0.0`). Inside the decomposed operations the same folds apply to the
-  division step: a power-of-two constant divisor turns `x // c`'s and `x % c`'s DIV
-  component into MUL, and `// 1.0` drops it entirely.
+  division step — a power-of-two constant divisor turns `x // c`'s and `x % c`'s DIV
+  component into MUL, and `// 1.0` drops it entirely — and to the remainder's multiply
+  step, whose constant factor is the divisor itself: `x % 1.0` drops the `c·⌊x/c⌋`
+  multiply, `x % -1.0` turns it into MINUS.
 
 **Rule 2 — operations that compile to a library call are priced as the call's real
 algorithm, contract included.**

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -92,7 +92,7 @@ patched `math` functions:
    | `1.0 ** x` | nothing — the same standards make `pow(1, y)` `1.0` for *every* `y`: the absorbing case on the other operand, likewise a **plain float** constant |
    | `2 ** x` / `10 ** x` | EXP2 / EXP10 (POW for other constant bases) |
    | `math.log(x, 2)` / `math.log(x, 10)` | LOG2 / LOG10 |
-   | `math.log(x, c)`, other values | LOG + MUL (`1/log(c)` folds to a constant multiplier) |
+   | `math.log(x, c)`, other values | LOG + MUL (`1/log(c)` folds to a constant multiplier, which itself identity-folds when it is exactly ±1.0 — base `math.e` counts a bare LOG) |
 
    Beyond \|n\| = 16 real compilers' powi expansion varies, so a generic POW
    is a fair stand-in. When the exponent, base, or log base is itself a

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -92,7 +92,7 @@ patched `math` functions:
    | `1.0 ** x` | nothing — the same standards make `pow(1, y)` `1.0` for *every* `y`: the absorbing case on the other operand, likewise a **plain float** constant |
    | `2 ** x` / `10 ** x` | EXP2 / EXP10 (POW for other constant bases) |
    | `math.log(x, 2)` / `math.log(x, 10)` | LOG2 / LOG10 |
-   | `math.log(x, c)`, other values | LOG + MUL (`1/log(c)` folds to a constant multiplier, which itself identity-folds when it is exactly ±1.0 — base `math.e` counts a bare LOG) |
+   | `math.log(x, c)`, other values | LOG + MUL (`1/log(c)` folds to a constant multiplier, which identity-folds when `log(c)` is exactly ±1.0 — base `math.e` counts a bare LOG) |
 
    Beyond \|n\| = 16 real compilers' powi expansion varies, so a generic POW
    is a fair stand-in. When the exponent, base, or log base is itself a

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -21,8 +21,8 @@ documented fallback) are stated in [Cost-model principles](cost_model.md).
 | `x + y`, `x - y`, `x * y` | `ADD`, `SUB`, `MUL` (sign-exact identity constants fold: `* 1.0` / `- 0.0` / `+ (-0.0)` → nothing, `* -1.0` / `(-0.0) - x` → `MINUS`) | operator | ISA | yes |
 | `x / y` | `DIV` (`MUL` for a power-of-two constant divisor — the exact reciprocal fold; `MINUS` for `x / -1.0`; nothing for `x / 1.0`) | operator | ISA | yes |
 | `x // y` | `DIV + RND` (the division step folds like `/` for constant divisors) | operator (decomposed) | ISA | yes |
-| `x % y` | `DIV + RND + MUL + SUB` (the division step folds like `/` for constant divisors) | operator (decomposed) | ISA | yes |
-| `divmod(x, y)` | `DIV + RND + MUL + SUB` (the division step folds like `/` for constant divisors) | operator (decomposed) | ISA | yes (both) |
+| `x % y` | `DIV + RND + MUL + SUB` (the division step folds like `/` for constant divisors; a `±1.0` divisor folds the multiply step too — away for `1.0`, to `MINUS` for `-1.0`) | operator (decomposed) | ISA | yes |
+| `divmod(x, y)` | `DIV + RND + MUL + SUB` (folds like `%`, division step and multiply step alike) | operator (decomposed) | ISA | yes (both) |
 | `-x` | `MINUS` | operator | ISA | yes |
 | `+x` | *(nothing)* | operator | — | yes |
 | `abs(x)`, `math.fabs(x)` | `ABS` | operator / patch | ISA | yes |
@@ -49,7 +49,7 @@ documented fallback) are stated in [Cost-model principles](cost_model.md).
 | `math.erf`/`erfc(x)` | `ERF`, `ERFC` | patch | benchmarked | yes |
 | `math.copysign(x, y)` | `COPYSIGN` | patch | benchmarked | yes |
 | `math.degrees(x)`, `math.radians(x)` | `MUL` *(decomposed)* | patch | — | yes |
-| `math.dist(p, q)` | `DIST` + (n−2) `DIST_XARG` | patch | benchmarked | yes |
+| `math.dist(p, q)` | `DIST` + (n−2) `DIST_XARG` (1-D → `SUB + ABS`) | patch | benchmarked | yes |
 | `math.prod(xs)` | one `MUL` per chained multiply *(decomposed)* | patch | — | yes |
 | `math.fsum(xs)` | (n−1) `ADD` *(decomposed; compensation machinery not modeled)* | patch | — | yes |
 | `math.sumprod(p, q)` (3.12+) | `SUMPROD` + (n−2) `SUMPROD_XELEM` | patch | benchmarked | yes |
@@ -74,6 +74,10 @@ float→float round (`RND`), not an `F2I`:
 - `x % y` → `DIV + RND + MUL + SUB` — the floored remainder `r = x − y·⌊x/y⌋`.
 - `divmod(x, y)` → `DIV + RND + MUL + SUB` — quotient and remainder share the
   `DIV + RND`, so it costs the same as a lone `%`.
+
+For a constant divisor the division step folds like a bare `/`, and a `±1.0` divisor also
+folds the `y·⌊x/y⌋` multiply — the divisor is that multiply's constant factor, so the
+identity folds apply to it: away for `1.0`, `MINUS` for `-1.0`.
 
 `round(x, n)` with a nonzero digit count decomposes the same way:
 
@@ -289,7 +293,9 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
 - **Counted Python operations:** `math.log(x)` for `CountedFloat`;
   `math.log(x, base)` for `CountedFloat` decomposes per the constant-folding
   convention (constant base 2/10 -> LOG2/LOG10; other constant base ->
-  LOG+MUL; CountedFloat base -> LOG per counted operand + DIV)
+  LOG+MUL, where the multiply itself identity-folds when `1/log(base)` is
+  exactly ±1.0 — e.g. base `math.e`; CountedFloat base -> LOG per counted
+  operand + DIV)
 - **Not counted:** `numpy.log`, log on non-CountedFloat
 - **Weight measurement:** [the machine code behind the `LOG` weight](machine_code/log.md)
 
@@ -421,7 +427,9 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
     - **x86:** (software)
 - **Counted Python operations:** `math.dist(p, q)` for `CountedFloat` — counted
   once per call when *any* coordinate is a `CountedFloat`; coordinates beyond
-  the second each add a [`DIST_XARG`](#flop-dist-xarg)
+  the second each add a [`DIST_XARG`](#flop-dist-xarg), and a 1-D call counts
+  `SUB + ABS` instead: the coordinate difference through the same
+  single-coordinate shortcut as 1-argument `hypot`
 - **Not counted:** `dist` on plain floats only, numpy norms/distances
 - **Note:** the 2-D base price of the overflow-safe algorithm `math.dist`
   executes; it sits above `HYPOT` by the per-coordinate subtraction work its
@@ -435,7 +443,8 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
     - **x86:** (software)
 - **Counted Python operations:** one per dimension beyond the second of a
   `math.dist` call: an n-dimensional call counts `DIST` + (n−2) `DIST_XARG`
-- **Not counted:** 1- and 2-dimensional calls (they cost the base `DIST` alone)
+- **Not counted:** 2-dimensional calls (they cost the base `DIST` alone) and
+  1-dimensional calls (`SUB + ABS`)
 - **Weight measurement:** [the machine code behind the `DIST_XARG` weight](machine_code/dist_xarg.md)
 
 ## FlopType.SUMPROD (`sumprod(p,q)`) { #flop-sumprod }

--- a/docs/math_patching.md
+++ b/docs/math_patching.md
@@ -54,7 +54,9 @@ strength reduction and never adds an I2F conversion:
 - `math.log(x, base)` classifies per log variant: base omitted → LOG;
   constant base 2 / 10 → LOG2 / LOG10 (a compiled port calls `log2`/`log10`
   directly); other constant base → LOG + MUL (a port computes `log(x) * C`
-  with `C = 1/log(base)` folded at compile time); `CountedFloat` base →
+  with `C = 1/log(base)` folded at compile time — and `C` being a constant,
+  the identity folds apply to the multiply itself: exactly `1.0`, e.g. base
+  `math.e`, drops it, exactly `-1.0` counts MINUS); `CountedFloat` base →
   genuinely runtime, a port computes `log(x)/log(base)`: LOG per counted
   operand + DIV.
 
@@ -69,7 +71,7 @@ Every commonly used `math` function, and how it participates in counting:
 | Coverage | Functions |
 |---|---|
 | **Instrumented** (patched, counts its FlopType) | `sqrt`, `cbrt`, `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `pow`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `hypot` (+ `HYPOT_XARG` per coordinate beyond the second), `dist` (+ `DIST_XARG` likewise), `fmod`, `remainder`, `gamma`, `lgamma`, `erf`, `erfc`, `fabs`, `copysign`, `isnan` (COMP — the self-compare a port emits), `isinf` (ABS + COMP), `isfinite` (ABS + COMP), `isclose` (SUB + 3 ABS + MUL + 3 COMP — the transcription of its documented formula; the guards, short-circuit savings and the implementation's respelling are a stated gap), `fma` (Python 3.13+), `sumprod` (Python 3.12+; + `SUMPROD_XELEM` per element beyond the second — counted inputs are unboxed so the extended-precision algorithm runs) |
-| **Instrumented, counted as a decomposition** (patched, counts the flops a compiled port would execute) | `degrees` / `radians` → MUL; `prod` → one MUL per chained multiply; `fsum` → (n−1) ADD; 1-argument `hypot` → ABS |
+| **Instrumented, counted as a decomposition** (patched, counts the flops a compiled port would execute) | `degrees` / `radians` → MUL; `prod` → one MUL per chained multiply; `fsum` → (n−1) ADD; 1-argument `hypot` → ABS; 1-D `dist` → SUB + ABS |
 | **Counted via dunder** (no patch needed — do not expect these in the patch list) | `math.floor` / `math.ceil` / `math.trunc` → F2I through `__floor__`/`__ceil__`/`__trunc__`; the builtins `abs()` → ABS and `round()` → RND/F2I likewise count through their dunders |
 | **Not instrumented** (returns a plain, uncounted `float`) | exactly the float-representation helpers — `frexp`, `ldexp`, `modf`, `nextafter`, `ulp` |
 <!-- END generated: math-coverage-table -->

--- a/scripts/generate_docs_content.py
+++ b/scripts/generate_docs_content.py
@@ -303,10 +303,12 @@ _MATH_INSTRUMENTED_NOTES = {
     ),
 }
 # patched, but presented by the decomposition each one counts rather than by a FlopType of its own.
-# 1-argument `hypot` also belongs to this row's prose; `hypot` itself is presented above.
+# 1-argument `hypot` and 1-D `dist` also belong to this row's prose; both functions themselves are
+# presented above.
 _MATH_DECOMPOSED = ["degrees", "radians", "prod", "fsum"]
 _MATH_DECOMPOSED_CELL = (
-    "`degrees` / `radians` → MUL; `prod` → one MUL per chained multiply; `fsum` → (n−1) ADD; 1-argument `hypot` → ABS"
+    "`degrees` / `radians` → MUL; `prod` → one MUL per chained multiply; `fsum` → (n−1) ADD; "
+    "1-argument `hypot` → ABS; 1-D `dist` → SUB + ABS"
 )
 # registered conditionally by the patch table, so they are absent from it on an older interpreter
 # while still belonging in the committed table -- the note on each says from which version

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -618,8 +618,10 @@ class CountedFloat(float):
         Python's % is the floored remainder r = x - y*floor(x/y), which a compiled port emits as
         DIV + RND (the floor) + MUL + SUB. Distinct from math.fmod, the truncated C remainder.
         A constant divisor routes the division step through the same folds as a bare `/`
-        (count_div_with_constant_divisor; cost-model rule 1.7); the y*floor(...) multiply stays
-        MUL regardless — its other factor is the freshly computed floor, never a constant.
+        (count_div_with_constant_divisor; cost-model rule 1.7) — and it is also the constant
+        factor of the y*floor(...) multiply, so the identity folds apply there too: a divisor
+        of 1.0 drops that multiply, -1.0 makes it a bare sign flip (MINUS). Any other constant
+        keeps it a genuine MUL: the floor factor is freshly computed, never foldable.
         """
         result = float.__mod__(self, other)
         if result is NotImplemented:
@@ -630,10 +632,14 @@ class CountedFloat(float):
             cnt: CountsTarget = _create_thread_state()
         if type(other) is CountedFloat:
             cnt.DIV += 1
+            cnt.MUL += 1
         else:
             count_div_with_constant_divisor(other)
+            if other == 1.0 or other == -1.0:
+                count_mul_with_identity_multiplier(other)
+            else:
+                cnt.MUL += 1
         cnt.RND += 1
-        cnt.MUL += 1
         cnt.SUB += 1
         return float.__new__(CountedFloat, result)
 
@@ -658,7 +664,8 @@ class CountedFloat(float):
         Quotient and remainder share the DIV + RND (the floor); the remainder adds MUL + SUB, so
         divmod counts DIV + RND + MUL + SUB — the same as a lone %, since the // part is shared.
         A constant divisor routes the shared division step through the same folds as a bare `/`
-        (count_div_with_constant_divisor; cost-model rule 1.7).
+        (count_div_with_constant_divisor; cost-model rule 1.7), and folds the remainder's
+        y*floor(...) multiply for a ±1.0 divisor the way % does.
         """
         result = float.__divmod__(self, other)
         if result is NotImplemented:
@@ -669,10 +676,14 @@ class CountedFloat(float):
             cnt: CountsTarget = _create_thread_state()
         if type(other) is CountedFloat:
             cnt.DIV += 1
+            cnt.MUL += 1
         else:
             count_div_with_constant_divisor(other)
+            if other == 1.0 or other == -1.0:
+                count_mul_with_identity_multiplier(other)
+            else:
+                cnt.MUL += 1
         cnt.RND += 1
-        cnt.MUL += 1
         cnt.SUB += 1
         quotient, remainder = result
         return float.__new__(CountedFloat, quotient), float.__new__(CountedFloat, remainder)

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -190,7 +190,10 @@ def math_log(  # noqa: C901 -- branches mirror the per-log-variant counting rule
       - base omitted           -> LOG
       - constant base 2 / 10   -> LOG2 / LOG10 (a compiled port calls log2/log10 directly)
       - other constant base    -> LOG + MUL (a port computes log(x) * C, with C = 1/log(base)
-                                  folded at compile time)
+                                  folded at compile time); C is itself a constant, so the
+                                  identity folds apply to the multiply: C = 1.0 (base e on a
+                                  libm that rounds log(e) to exactly 1.0) drops it, C = -1.0
+                                  makes it a bare sign flip (MINUS)
       - CountedFloat base      -> genuinely runtime: a port computes log(x)/log(base), so
                                   LOG per CountedFloat operand + DIV
     As everywhere in the counting model, only operations touching CountedFloat values are counted:
@@ -232,9 +235,20 @@ def math_log(  # noqa: C901 -- branches mirror the per-log-variant counting rule
             cnt.LOG10 += 1
     else:
         if isinstance(x, CountedFloat):
-            cnt.note("const base -> log(x) * 1/log(base)")
-            cnt.LOG += 1
-            cnt.MUL += 1
+            # the multiplier C = 1/log(base) is a compile-time constant, so it identity-folds at
+            # exactly +/-1.0 -- keyed on the runtime value of log(base), like every fold by value
+            log_of_base = original_math_log(float(base))
+            if log_of_base == 1.0:
+                cnt.note("const base -> log(x); the 1/log(base) multiplier is 1.0 and folds away")
+                cnt.LOG += 1
+            elif log_of_base == -1.0:
+                cnt.note("const base -> log(x) * -1.0 -> sign flip")
+                cnt.LOG += 1
+                cnt.MINUS += 1
+            else:
+                cnt.note("const base -> log(x) * 1/log(base)")
+                cnt.LOG += 1
+                cnt.MUL += 1
     # the guard above already established that at least one operand is counted
     return float.__new__(CountedFloat, result)
 
@@ -641,7 +655,9 @@ def math_dist(p: Iterable[float], q: Iterable[float]) -> float | CountedFloat:
 
     Counted as DIST + (n-2) DIST_XARG for n-dimensional inputs: the benchmarked 2-D base cost
     (which carries the per-coordinate subtractions in its offset) plus the measured
-    per-extra-coordinate slope. 1-D inputs count the base cost alone. Iterator inputs are
+    per-extra-coordinate slope. 1-D inputs count SUB + ABS instead: the call computes
+    |p0 - q0| through the same single-coordinate shortcut 1-argument hypot takes, so the
+    port pays the subtract and the fabs, not the scaled 2-D machinery. Iterator inputs are
     materialized up front (the stdlib accepts them too), so the coordinates can be inspected
     after computing the result.
     """
@@ -656,9 +672,13 @@ def math_dist(p: Iterable[float], q: Iterable[float]) -> float | CountedFloat:
         cnt: CountsTarget = _TLS.flop_counts
     except AttributeError:  # first counted op on this thread
         cnt: CountsTarget = _create_thread_state()
-    cnt.DIST += 1
-    if n > 2:
-        cnt.DIST_XARG += n - 2
+    if n == 1:
+        cnt.SUB += 1
+        cnt.ABS += 1
+    else:
+        cnt.DIST += 1
+        if n > 2:
+            cnt.DIST_XARG += n - 2
     return float.__new__(CountedFloat, result)
 
 

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -235,8 +235,9 @@ def math_log(  # noqa: C901 -- branches mirror the per-log-variant counting rule
             cnt.LOG10 += 1
     else:
         if isinstance(x, CountedFloat):
-            # the multiplier C = 1/log(base) is a compile-time constant, so it identity-folds at
-            # exactly +/-1.0 -- keyed on the runtime value of log(base), like every fold by value
+            # the port precomputes C = 1/log(base) and multiplies by it; a C of exactly +/-1.0
+            # identity-folds like any constant multiplier. Computing log(base) here mirrors that
+            # compile-time evaluation -- as for every fold, the observed value decides
             log_of_base = original_math_log(float(base))
             if log_of_base == 1.0:
                 cnt.note("const base -> log(x); the 1/log(base) multiplier is 1.0 and folds away")

--- a/tests/counting/test_counted_float_counting.py
+++ b/tests/counting/test_counted_float_counting.py
@@ -452,6 +452,12 @@ def test_counted_float_counts_div_by_constant(thread_counter, divisor, expected_
         (lambda cf: cf % 3.0, {"DIV": 1, "RND": 1, "MUL": 1, "SUB": 1}),
         (lambda cf: divmod(cf, 4.0), {"RND": 1, "MUL": 2, "SUB": 1}),
         (lambda cf: divmod(cf, 3.0), {"DIV": 1, "RND": 1, "MUL": 1, "SUB": 1}),
+        # --- ... and a ±1.0 divisor folds the remainder's y*floor(x/y) multiply too ---
+        (lambda cf: cf % 1.0, {"RND": 1, "SUB": 1}),
+        (lambda cf: cf % 1, {"RND": 1, "SUB": 1}),  # int 1 compiles as 1.0
+        (lambda cf: cf % -1.0, {"MINUS": 2, "RND": 1, "SUB": 1}),  # division step and multiply are both sign flips
+        (lambda cf: divmod(cf, 1.0), {"RND": 1, "SUB": 1}),
+        (lambda cf: divmod(cf, -1.0), {"MINUS": 2, "RND": 1, "SUB": 1}),
     ],
 )
 def test_counted_float_identity_folds(thread_counter, case, expected_counts: dict[str, int]):
@@ -477,6 +483,8 @@ def test_counted_float_identity_folds(thread_counter, case, expected_counts: dic
         (lambda cf: cf / CountedFloat(-1.0), {"DIV": 1}),
         (lambda cf: cf // CountedFloat(8.0), {"DIV": 1, "RND": 1}),
         (lambda cf: cf % CountedFloat(8.0), {"DIV": 1, "RND": 1, "MUL": 1, "SUB": 1}),
+        (lambda cf: cf % CountedFloat(1.0), {"DIV": 1, "RND": 1, "MUL": 1, "SUB": 1}),
+        (lambda cf: divmod(cf, CountedFloat(-1.0)), {"DIV": 1, "RND": 1, "MUL": 1, "SUB": 1}),
     ],
 )
 def test_counted_float_identity_folds_key_on_constants_only(thread_counter, case, expected_counts):

--- a/tests/counting/test_math_patching_counting.py
+++ b/tests/counting/test_math_patching_counting.py
@@ -177,6 +177,45 @@ def test_math_log_constant_float_base_folds_like_int(thread_counter):
     assert isinstance(result, CountedFloat)
 
 
+@pytest.mark.parametrize(
+    ("base", "expected_counts"),
+    [
+        pytest.param(
+            math.e,
+            {"LOG": 1},
+            marks=pytest.mark.skipif(
+                math.log(math.e) != 1.0,
+                reason="the fold keys on the runtime value: this libm does not give log(e) == 1.0",
+            ),
+            id="unit-multiplier-folds-away",
+        ),
+        pytest.param(
+            1.0 / math.e,
+            {"LOG": 1, "MINUS": 1},
+            marks=pytest.mark.skipif(
+                math.log(1.0 / math.e) != -1.0,
+                reason="the fold keys on the runtime value: this libm does not give log(1/e) == -1.0",
+            ),
+            id="negative-unit-multiplier-is-a-sign-flip",
+        ),
+    ],
+)
+def test_math_log_constant_base_with_unit_reciprocal_folds_multiply(thread_counter, base, expected_counts):
+    # the port's multiplier C = 1/log(base) is itself a compile-time constant, so the identity
+    # folds apply to it: C = 1.0 drops the multiply, C = -1.0 is a bare sign flip
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(8.0)
+
+    # --- act ---------------------------------------------
+    result = math.log(cf, base)
+
+    # --- assert ------------------------------------------
+    assert isinstance(result, CountedFloat)
+    assert thread_counter.total_count() == sum(expected_counts.values())
+    for field, expected in expected_counts.items():
+        assert getattr(thread_counter, field) == expected
+
+
 def test_math_log_counted_base_counts_runtime_division(thread_counter):
     # a CountedFloat base is genuinely runtime: a port computes log(x)/log(base)
     # --- arrange -----------------------------------------
@@ -396,9 +435,16 @@ def test_dist_counts_the_arity_scaled_types(thread_counter, n_dims):
 
     # --- assert ------------------------------------------
     assert isinstance(result, CountedFloat)
-    assert thread_counter.DIST == 1
-    assert max(0, n_dims - 2) == thread_counter.DIST_XARG
-    assert thread_counter.total_count() == 1 + max(0, n_dims - 2)
+    if n_dims == 1:
+        # one dimension takes the same single-coordinate shortcut as 1-argument hypot: the call
+        # computes |p0 - q0|, so the port pays the subtract and the fabs, not the 2-D base
+        assert thread_counter.SUB == 1
+        assert thread_counter.ABS == 1
+        assert thread_counter.total_count() == 2
+    else:
+        assert thread_counter.DIST == 1
+        assert max(0, n_dims - 2) == thread_counter.DIST_XARG
+        assert thread_counter.total_count() == 1 + max(0, n_dims - 2)
 
 
 def test_dist_accepts_iterator_inputs_and_mismatched_lengths_raise(thread_counter):


### PR DESCRIPTION
**TL;DR**: Two degenerate-input counting fixes, aligning the counts with the cost model's own admission rules.

- **±1.0 constant multiplies** inside `%`/`divmod` and constant-base `math.log` now identity-fold instead of counting MUL.
- **1-D `math.dist`** now prices the subtract-and-abs it executes, not the 2-coordinate base weight.

## Description

### Problem addressed

- **The identity folds stopped one step short.** The cost model folds `x * 1.0` away and prices `x * -1.0` as a bare sign flip, but inside the decomposed operations only the *division* step folded: `x % 1.0` still counted the `1.0 · ⌊x⌋` multiply a compiled port eliminates, and `math.log(x, base)` counted LOG + MUL even when the folded multiplier `1/log(base)` is exactly ±1.0 (e.g. base `math.e`).
- **Sibling asymmetry in dist.** A 1-D `math.dist` call charged the DIST base — a weight measured on the 2-coordinate scaled algorithm — although CPython computes `|p0 − q0|` through the same single-coordinate shortcut that already prices 1-argument `hypot` as ABS.

### Implementation

- **`%` / `divmod`**: the multiply's constant factor *is* the divisor, so the constant path now routes ±1.0 through the existing identity-multiplier helper (1.0 → nothing, −1.0 → MINUS). Runtime (`CountedFloat`) divisors are untouched, and `//` has no multiply step.
- **`math.log`**: the constant-base branch computes `log(base)` and keys the fold on that runtime value — fold-by-value, so a libm that does not round `log(e)` to exactly 1.0 legitimately does not fold.
- **`math.dist`**: the patch gains a one-dimension branch counting SUB + ABS, mirroring the hypot 1-argument branch.
- **Docs move with the counts**: the cost model's decomposition-fold sentence, the FLOP-types rows and sections, the math-patching classification prose, and the generated coverage table's decomposition row all state the new folds.

## Attention points

- **`x % -1.0` counts MINUS twice** — division step and multiply step are each a genuine sign flip in the port.
- **The log fold is platform-honest**: whether base `e` folds depends on the libm rounding `log(e)` to exactly 1.0; the tests guard with value-keyed skips so an exotic libm skips rather than fails.
- **Verbosity rationale ordering preserved**: fold notes are emitted before the increments they explain, so INFO lines keep carrying their explanation.

## Tests / Spikes

- **TEST:** full suite green locally (2092 passed) plus lint.
- 7 new parametrized cases pin the `%`/`divmod` folds — both fold directions, the int-1 spelling, and counted-divisor near-misses that must not fold.
- 2 new parametrized cases pin the log unit-reciprocal folds (base `e` and its reciprocal), each value-guarded per platform.
- The dist arity test now pins the 1-D SUB + ABS shape alongside the existing 2-D/3-D/5-D expectations.

## Changelog entry

Both under **Fixed**:

```
- the `%`/`divmod` decompositions and constant-base `math.log` no longer count the multiply a compiled port folds away for ±1.0 constants (e.g. `x % 1.0`, `math.log(x, math.e)`)
- 1-D `math.dist` now counts the subtract-and-abs it executes instead of the 2-coordinate distance base cost
```

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
