### PR TITLE
docs: state every countedness ending and re-point the author-decision claim

### DIFF
--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -32,9 +32,11 @@ actors, playing by two different rules.**
   port that calls libm's `pow` gets different last bits on glibc, Apple's libm and
   Microsoft's UCRT. What the author owes is **algorithmic faithfulness** — the same
   mathematical computation, written the way such code is really written. Every judgment
-  call the author is assumed to make is declared in the rules below, together with its
-  bound (for exponent chains, `|n| ≤ 16`): a stated, bounded persona — not a claim about
-  what all programmers everywhere would do.
+  call the author is assumed to make is declared — in the rules below or in the
+  [counting-model fold table](counting_flops.md#the-counting-model-what-gets-counted-and-why),
+  which owns the full enumeration — together with its bound (for exponent chains,
+  `|n| ≤ 16`): a stated, bounded persona — not a claim about what all programmers
+  everywhere would do.
 - **The compiler** then translates that C source into machine code, and its rule *is*
   mechanical bit-exactness: it may rewrite the source's arithmetic only when the rewrite
   provably never changes any computed value. Replacing `x / 8.0` by `x * 0.125` qualifies
@@ -69,14 +71,20 @@ Near-misses stay counted because they fail that test: `x * 0.0` is sign- and
 nan-dependent, `x + nan` carries a nan receiver's payload. Degeneracies outside the table
 stay conservatively counted as written.
 
-Countedness otherwise ends in exactly three places:
+Countedness otherwise ends in exactly four places:
 
-- the *value* leaves the float domain (`bool`, `int`, `str`), priced where the port pays
-  (e.g. F2I, COMP);
+- the *value* leaves the float domain (`bool`, `int`, `str`, `complex`), priced where the
+  port pays (e.g. F2I, COMP) — the `complex` exit (a negative counted base under a
+  fractional constant exponent) prices nothing, since a port of real-float code has no
+  complex counterpart;
 - the one documented exit, `float(x)` — safe because leaving the counted world is the
   explicit point of the call;
 - a WARNING-reported gap (see the
-  [`math` coverage table](math_patching.md#coverage-of-the-math-module)).
+  [`math` coverage table](math_patching.md#coverage-of-the-math-module) and the
+  [float surface](float_surface.md#reported-at-warning-verbosity));
+- the builtins `min`/`max` returning a winning plain constant — the one interpreter
+  mechanism the library cannot intercept; stated, with its re-wrap remedy, in
+  [known limitations](known_limitations.md#other-limitations).
 
 A *silent* plain-float return from a counted operand is none of those — it is a defect in
 the model, not a judgment call.

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -26,7 +26,8 @@ documented fallback) are stated in [Cost-model principles](cost_model.md).
 | `-x` | `MINUS` | operator | ISA | yes |
 | `+x` | *(nothing)* | operator | — | yes |
 | `abs(x)`, `math.fabs(x)` | `ABS` | operator / patch | ISA | yes |
-| `x == y`, `x < y`, …, `min`, `max` | `COMP` | operator | ISA | returns `bool` |
+| `x == y`, `x < y`, … | `COMP` | operator | ISA | returns `bool` |
+| `min(x, y, ...)`, `max(x, y, ...)` | `COMP` per comparison | operator | ISA | returns the winning operand — plain when a plain constant wins; re-wrap with `CountedFloat(...)` to keep counting |
 | `round(x, 0)` | `RND` | operator | ISA | yes (float) |
 | `round(x, n)`, `n != 0` | `MUL + RND + DIV` | operator (decomposed) | ISA | yes (float) |
 | `round(x)`, `int(x)`, `math.floor`/`ceil`/`trunc` | `F2I` | operator | ISA | returns `int` |
@@ -144,6 +145,10 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
   entirely, so a truthiness count would price interpreter bookkeeping and vary
   with interpreter flags — no port-faithful count does either. Write an
   algorithmic zero-test as `x != 0.0` to have it counted
+- **Note:** `min`/`max` return the winning operand *object*, not a `bool` —
+  with mixed counted/plain arguments the winner may be the plain constant,
+  which ends countedness; see
+  [known limitations](known_limitations.md#other-limitations)
 - **Weight measurement:** [the machine code behind the `COMP` weight](machine_code/comp.md)
 
 ## FlopType.RND (`round`) { #flop-rnd }
@@ -328,7 +333,10 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
   exponents/bases strength-reduce per the constant-folding convention (see the
   counting-model page): `x**0.5` -> SQRT, `x**-1` -> DIV, integer exponents
   2 <= |n| <= 16 -> their multiply chain, base 2/10 -> EXP2/EXP10
-- **Not counted:** `pow` on non-CountedFloat, `numpy.pow`
+- **Not counted:** `pow` on non-CountedFloat, `numpy.pow`; a negative counted
+  base under a fractional constant exponent, whose result is a plain `complex` —
+  it leaves the real-float domain the model prices, so nothing is counted and
+  contagion ends
 - **Weight measurement:** [the machine code behind the `POW` weight](machine_code/pow.md)
 
 ## FlopType.SIN (`sin(x)`) { #flop-sin }

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -120,6 +120,15 @@ up in that output.
   mutates only its own state. Note that the `benchmarking` extra requires **numba
   0.65 or newer** on a free-threaded build — earlier versions ship no
   free-threaded wheels
+- builtin `min`/`max` return the winning operand *object*, so with mixed
+  counted/plain arguments the result is a plain float whenever a plain constant
+  wins — countedness ends silently, and value-dependently: the same call site
+  keeps or drops it depending on the data. The comparisons themselves count
+  `COMP` correctly; only the result's type can revert, and no dunder exists
+  through which `CountedFloat` could intercept the returned object. When the
+  result feeds counted computation, re-wrap it — `CountedFloat(min(...))`
+  counts nothing (a float-source construction) and is correct whether or not
+  the wrap was needed
 - dict/set membership of `CountedFloat` keys inflates `COMP`: hash-bucket
   equality checks count as comparisons. This is consistent with the model
   (those comparisons really execute) but can surprise when a dict is used as


### PR DESCRIPTION
**Problem**: Three doc claims lagged the surface: builtin `min`/`max` can silently end countedness when a plain constant wins (uncataloged, and the coverage table filed them under "returns `bool`"), the countedness-termination enumeration missed the `complex` exit from `**`, and the author-persona claim promised declarations its rules don't carry.

**Solution**: `min`/`max` get their own coverage row, a known-limitations entry, and the zero-cost re-wrap idiom `CountedFloat(min(...))`. The termination enumeration grows to four stated endings and cites both WARNING surfaces, keeping the defect-guardrail sentence. The author-persona claim now points at the counting-model fold table — the single owner of the fold enumeration, so no duplicated table.

- **Attention:** the `min`/`max` hazard is inherent to the builtins — they return the winning operand object, and no dunder can intercept that — so documentation plus the re-wrap idiom is the deliberate remedy, not a stand-in for a code fix.

**Changelog** (docs): None: documentation-only.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
