### PR TITLE
fix: fold the collapsed fma add away for a -0.0 constant product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `math.fma` with two constant multiplicands no longer counts the add a compiled port folds away when the constant product is exactly `-0.0` (e.g. `math.fma(2.0, -0.0, x)`)
+
 ### Security
 
 ## 2.2.1 (2026-08-02)

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -106,7 +106,10 @@ patched `math` functions:
    `fma(x, 0.0, z)`, or any other) is the same single instruction and folding a
    value would buy nothing. Its one fold is structural rather than value-based —
    two constant multiplicands collapse to a single constant, leaving a compiled
-   port with a bare add, so that counts ADD.
+   port with a bare add, so that counts ADD. That add then folds like any other
+   add with a constant operand: a collapsed constant of exactly `-0.0` drops it
+   entirely (`z + (-0.0)` is `z` for every `z`), counting nothing, while a
+   `+0.0` product keeps the ADD (`(-0.0) + 0.0` is `+0.0`).
 
 The one place an `I2F` conversion *is* counted is explicit construction from an
 int — `CountedFloat(n)`. That is exactly how you opt a genuine runtime integer

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -33,7 +33,7 @@ documented fallback) are stated in [Cost-model principles](cost_model.md).
 | `round(x)`, `int(x)`, `math.floor`/`ceil`/`trunc` | `F2I` | operator | ISA | returns `int` |
 | `CountedFloat(int)` | `I2F` | constructor | ISA | yes |
 | `x ** y`, `math.pow(x, y)` | `POW` (or cheaper via constant strength reduction — MULs, SQRT, DIV, EXP2, EXP10) | operator / patch | benchmarked | yes |
-| `math.fma(x, y, z)` (3.13+) | `FMA` (or `ADD` when both multiplicands are constant) | patch | ISA | yes |
+| `math.fma(x, y, z)` (3.13+) | `FMA` (or `ADD` when both multiplicands are constant; nothing when their product is exactly `-0.0`) | patch | ISA | yes |
 | `math.sqrt(x)` | `SQRT` | patch | ISA | yes |
 | `math.cbrt(x)` | `CBRT` | patch | benchmarked | yes |
 | `math.exp(x)`, `math.exp2(x)`, `2 ** x` | `EXP`, `EXP2` | patch / operator | benchmarked | yes |
@@ -235,7 +235,9 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
   instruction with a single rounding
 - **Constant multiplicands decompose:** when *both* `x` and `y` are constants
   their product folds at compile time, leaving a compiled port with a bare add,
-  so that counts ADD rather than FMA. No reduction is done by constant *value* —
+  so that counts ADD rather than FMA — and a collapsed product of exactly
+  `-0.0` folds the add away too (`z + (-0.0)` is `z` for every `z`), counting
+  nothing. No reduction is done by constant *value* —
   every FMA variant is one instruction, so there is nothing to win (see
   [the counting model](counting_flops.md#the-counting-model-what-gets-counted-and-why))
 - **Not counted:** `math.fma` on plain floats only; `a*b + c` written with

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -57,6 +57,7 @@ from __future__ import annotations
 
 import math
 import threading
+from math import copysign as _copysign  # the raw builtin: math.copysign is patched inside contexts
 from typing import TYPE_CHECKING
 
 from ._counted_float import CountedFloat, count_pow_with_constant_base, count_pow_with_constant_exponent
@@ -335,10 +336,13 @@ def math_fma(x: float, y: float, z: float) -> float | CountedFloat:
     Flop classification follows the constant-folding convention, treating any non-CountedFloat
     operand as a compile-time constant:
       - two constant multiplicands -> their product folds, leaving a compiled port with a bare
-                                      add on the remaining runtime value -> ADD
+                                      add on the remaining runtime value -> ADD; a product of
+                                      exactly -0.0 folds the add away too (z + (-0.0) is z for
+                                      every z -- cost-model rule 1.7) and counts nothing, where
+                                      a +0.0 product keeps the ADD ((-0.0) + 0.0 is +0.0)
       - any other counted operand  -> the port emits one fused instruction -> FMA
-    Constant *values* are never inspected: unlike POW, no FMA variant is cheaper than another --
-    every one is a single instruction -- so there is nothing to strength-reduce.
+    Once an fma survives, constant *values* are never inspected: the explicit call is the author
+    asking for the fused instruction, and it stays fused.
     """
     if isinstance(x, CountedFloat) or isinstance(y, CountedFloat) or isinstance(z, CountedFloat):
         # computed first: math.fma raises ValueError on invalid operand combinations
@@ -350,6 +354,11 @@ def math_fma(x: float, y: float, z: float) -> float | CountedFloat:
             except AttributeError:  # first counted op on this thread
                 _create_thread_state().FMA += 1
         else:
+            product = x * y  # the constant a compiled port folds at compile time (both multiplicands are plain)
+            if product == 0.0 and _copysign(1.0, product) < 0.0:
+                # a -0.0 product leaves z + (-0.0), which is z for every z, so the port emits
+                # nothing -- the same sign-exact identity fold as a written -0.0 addend
+                return float.__new__(CountedFloat, result)
             try:
                 _TLS.flop_counts.ADD += 1  # x*y is a constant product; only the add survives folding
             except AttributeError:  # first counted op on this thread

--- a/tests/counting/test_math_patching_counting.py
+++ b/tests/counting/test_math_patching_counting.py
@@ -707,6 +707,56 @@ def test_math_fma_with_constant_multiplicands_counts_add(thread_counter):
 
 
 @requires_fma
+@pytest.mark.parametrize(
+    ("x", "y"),
+    [
+        (2.0, -0.0),
+        (-0.0, 2.0),
+        (-2.0, 0.0),
+        (1e-200, -1e-200),
+    ],
+    ids=["negzero_y", "negzero_x", "negative_x_zero_y", "underflow_to_negzero"],
+)
+def test_math_fma_with_negzero_constant_product_counts_nothing(thread_counter, x: float, y: float):
+    """A collapsed product of exactly -0.0 folds the surviving add away: z + (-0.0) is z for every z."""
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(4.0)
+
+    # --- act ---------------------------------------------
+    result = math.fma(x, y, cf)
+
+    # --- assert ------------------------------------------
+    assert thread_counter.total_count() == 0
+    assert result == 4.0
+    assert isinstance(result, CountedFloat)
+
+
+@requires_fma
+@pytest.mark.parametrize(
+    ("x", "y"),
+    [
+        (2.0, 0.0),
+        (0.0, 0.0),
+        (-0.0, -0.0),
+    ],
+    ids=["poszero_y", "both_poszero", "negzeros_cancel"],
+)
+def test_math_fma_with_poszero_constant_product_counts_add(thread_counter, x: float, y: float):
+    """A +0.0 product is the sign-exactness near-miss: (-0.0) + 0.0 is +0.0, so the add stays counted."""
+    # --- arrange -----------------------------------------
+    cf = CountedFloat(4.0)
+
+    # --- act ---------------------------------------------
+    result = math.fma(x, y, cf)
+
+    # --- assert ------------------------------------------
+    assert thread_counter.total_count() == 1
+    assert thread_counter.ADD == 1
+    assert result == 4.0
+    assert isinstance(result, CountedFloat)
+
+
+@requires_fma
 def test_math_fma_without_counted_operands_counts_nothing(thread_counter):
     """Every operand constant: the expression folds entirely and contagion does not start."""
     # --- act ---------------------------------------------


### PR DESCRIPTION
**Problem**: With both multiplicands plain constants, `math.fma` collapses to a bare add and counts ADD unconditionally — even when the collapsed constant is exactly `-0.0`, where `z + (-0.0)` is `z` for every `z` and a compiled port emits nothing.

**Solution**: The constant-multiplicand branch now inspects the folded product: exactly `-0.0` counts nothing (the result still stays `CountedFloat`); anything else keeps the ADD. This is the same sign-exact identity fold the operators already apply to a written `-0.0` addend.

- **Attention:** the `+0.0` product deliberately stays a counted ADD — `(-0.0) + 0.0` is `+0.0`, so dropping that add would be value-changing.
- **Attention:** products that *underflow* to `-0.0` (e.g. `1e-200 * -1e-200`) fold too — the fold keys on the runtime value, like every constant fold.
- **SPIKE:** verified on Compiler Explorer (aarch64, `-O2`, no fast-math) that clang 22.1.0 and gcc 16.1.0 both fold `z + (2.0 * -0.0)` away entirely, corroborating the zero count.
- **TEST:** 7 parametrized unit tests added: 4 `-0.0`-product cases fold to a zero count, 3 `+0.0` near-miss cases keep the ADD.

**Changelog** (Fixed):
```
- `math.fma` with two constant multiplicands no longer counts the add a compiled port folds away when the constant product is exactly `-0.0` (e.g. `math.fma(2.0, -0.0, x)`)
```


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>