### PR TITLE
docs: make the countedness-endings enumeration exact

### DIFF
--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -94,12 +94,21 @@ stay conservatively counted as written.
 
 #### Where countedness ends
 
-Countedness otherwise ends in exactly four places:
+The enumeration below holds inside an active `FlopCountingContext` — the model's operative
+regime. Outside one, `math.*` is unpatched, so type preservation ends at every such call on
+a counted value (see [Math patching semantics](math_patching.md)); the operators preserve
+countedness everywhere.
+
+Countedness otherwise ends in exactly five places:
 
 - the *value* leaves the float domain (`bool`, `int`, `str`, `complex`), priced where the
-  port pays (e.g. F2I, COMP) — the `complex` exit (a negative counted base under a
-  fractional constant exponent) prices nothing, since a port of real-float code has no
-  complex counterpart;
+  port pays (e.g. F2I, COMP) — with three exits priced at nothing: the `complex` exit
+  (a negative base under a fractional exponent, either operand counted), since a port of
+  real-float code has no complex counterpart; truthiness (`bool(x)`, `if x:`), the
+  deliberate interpreter-bookkeeping exception documented with the
+  [`COMP` type](flop_types.md#flop-comp); and the `%` presentation type's `str` exit,
+  whose scale-by-100 MUL is the labeled exception on
+  [the float surface](float_surface.md#the-presentation-contract);
 - the one documented exit, `float(x)` — safe because leaving the counted world is the
   explicit point of the call;
 - a WARNING-reported gap (see the
@@ -107,7 +116,12 @@ Countedness otherwise ends in exactly four places:
   [float surface](float_surface.md#reported-at-warning-verbosity));
 - the builtins `min`/`max` returning a winning plain constant — the one interpreter
   mechanism the library cannot intercept; stated, with its re-wrap remedy, in
-  [known limitations](known_limitations.md#other-limitations).
+  [known limitations](known_limitations.md#other-limitations);
+- a non-float numeric operand (a `Fraction`) winning the delegation: the reflected
+  operation returns a correct but plain — and uncounted — `float`, outside the model
+  because non-float numeric towers have no compiled-port counterpart (see
+  [What the model prices](#what-the-model-prices)); stated, with its non-goal rationale,
+  in [known limitations](known_limitations.md#other-limitations).
 
 A *silent* plain-float return from a counted operand is none of those — it is a defect in
 the model, not a judgment call.

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -335,10 +335,10 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
   exponents/bases strength-reduce per the constant-folding convention (see the
   counting-model page): `x**0.5` -> SQRT, `x**-1` -> DIV, integer exponents
   2 <= |n| <= 16 -> their multiply chain, base 2/10 -> EXP2/EXP10
-- **Not counted:** `pow` on non-CountedFloat, `numpy.pow`; a negative counted
-  base under a fractional constant exponent, whose result is a plain `complex` —
-  it leaves the real-float domain the model prices, so nothing is counted and
-  contagion ends
+- **Not counted:** `pow` on non-CountedFloat, `numpy.pow`; a negative base
+  under a fractional exponent with either operand counted, whose result is a
+  plain `complex` — it leaves the real-float domain the model prices, so
+  nothing is counted and contagion ends
 - **Weight measurement:** [the machine code behind the `POW` weight](machine_code/pow.md)
 
 ## FlopType.SIN (`sin(x)`) { #flop-sin }


### PR DESCRIPTION
**Problem**: The cost model's "where countedness ends" enumeration claimed exactly four places, but held only inside a counting context, missed the mixed-numeric ending (`cf * Fraction(...)` silently returns a plain float), described the complex exit by one operand pattern of three, and named only one of its three priced-nothing exits.

**Solution**: One coherent rewrite of the section: a scoping clause (inside an active context; outside one every unpatched `math.*` call ends type preservation), a fifth bullet for the non-float numeric ending, the complex exit restated by its trigger (negative base, fractional exponent, either operand counted), and all three priced-nothing exits named with pointers (complex, truthiness, `%`-format). The flop_types POW entry gets the matching complex-exit wording.

- **Attention:** every listed behavior was already documented and tested elsewhere (known limitations, math patching semantics, the float surface) — this PR changes no counts, only makes the completeness claim true as stated.

**Changelog**: None: documentation only.


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>