### PR TITLE
docs: repair three fold rationales in the cost-model pages

### DIFF
--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -178,6 +178,13 @@ as a value-preserving [compiled port](glossary.md#compiled-port).**
       operation.
     - `fma` can carry that meaning because it is special in exactly one way: it has no
       operator spelling, so writing the call is unambiguous intent.
+    - The boundary runs both ways, and is pinned in favor of the explicit instruction the
+      author wrote: real compilers diverge on the bit-exact unfusings (`fma(x, 1.0, z)`
+      computes exactly `x + z` — at `-O2`, clang 22 rewrites it to a plain add while
+      gcc 16 keeps the fused instruction), and the model keeps it fused. This mirrors
+      `-ffp-contract=off`, which keeps written-unfused unfused: both pins price the
+      author's written arithmetic, so the priced stream is the same on every architecture
+      and toolchain.
 
 - **1.4** ***(consequence)*** — [strength reduction](glossary.md#strength-reduction) comes in
   both stages, and **the stage decides the test**.
@@ -203,7 +210,8 @@ as a value-preserving [compiled port](glossary.md#compiled-port).**
       generic POW price applies.
 
 - **1.6** ***(example)*** — **reciprocal multiplication for division**, only where it is exact.
-    - A power-of-two constant divisor with a finite reciprocal — there, and only there,
+    - A power-of-two constant divisor of either sign (`±2^k`) with a finite reciprocal —
+      there, and only there,
       `x * (1/c)` is bit-identical to `x / c`, and compilers apply the fold at plain
       `-O2` — so `x / c` counts MUL for exactly those divisors, and DIV for every other.
     - The one stronger fold: `x / 1.0` disappears entirely and counts nothing, like
@@ -220,7 +228,7 @@ as a value-preserving [compiled port](glossary.md#compiled-port).**
       counts SUB (it *is* `x + 0.0`), and `0.0 - x` counts SUB (`0.0 - 0.0` gives
       `+0.0`, where a sign flip would give `-0.0`).
     - Inside the decomposed operations the same folds apply to the division step — a
-      power-of-two constant divisor turns `x // c`'s and `x % c`'s DIV component into
+      power-of-two constant divisor (either sign) turns `x // c`'s and `x % c`'s DIV component into
       MUL, and `// 1.0` drops it entirely — and to the remainder's multiply step, whose
       constant factor is the divisor itself: `x % 1.0` drops the `c·⌊x/c⌋` multiply,
       `x % -1.0` turns it into MINUS.

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -84,7 +84,7 @@ patched `math` functions:
    | `x ** n`, integer 2 ≤ \|n\| ≤ 16 | square-and-multiply MULs (`x**3` → 2 MUL, `x**8` → 3 MUL); negative `n` adds one DIV |
    | `x ** -1` | DIV (reciprocal) |
    | `x / 1.0` | nothing (folds away; result stays `CountedFloat`) |
-   | `x / c`, power-of-two `c` | MUL — `x * (1/c)` is bit-identical exactly there, so a compiler folds it; any other constant divisor stays DIV |
+   | `x / c`, power-of-two `c` (either sign) | MUL — `x * (1/c)` is bit-identical exactly there, so a compiler folds it; any other constant divisor stays DIV |
    | `x ** 0.5` / `x ** -0.5` | SQRT / SQRT + DIV |
    | `x ** 1` | nothing (folds away to `x` itself; result stays `CountedFloat`) |
    | `x ** 0` | nothing — IEEE 754 and C99 define `pow(x, 0)` as `1.0` for *every* `x` (nan and infinities included), so the result is the port's compile-time constant and comes back as a **plain float** |
@@ -101,10 +101,13 @@ patched `math` functions:
 
    Reduction by *value* only earns its keep where the folded form is genuinely
    cheaper — a short chain of multiplies instead of a libm `pow` call is an
-   enormous saving. So it stops where that stops being true: `math.fma` gets no
-   value-based reduction, because every variant of it (`fma(x, 1.0, z)`,
-   `fma(x, 0.0, z)`, or any other) is the same single instruction and folding a
-   value would buy nothing. Its one fold is structural rather than value-based —
+   enormous saving. `math.fma` is the deliberate exception: it gets no
+   value-based reduction by decree, not by economics. Some variants do have
+   bit-exact cheaper respellings (`fma(x, 1.0, z)` is exactly `x + z`), but an
+   explicit `fma` is the author demanding one fused instruction with one
+   rounding, and the model's compiler never unfuses an author-written `fma` —
+   the mirror of the contraction pin that stops it fusing an author-written
+   `a*b + c`. Its one fold is structural rather than value-based —
    two constant multiplicands collapse to a single constant, leaving a compiled
    port with a bare add, so that counts ADD. That add then folds like any other
    add with a constant operand: a collapsed constant of exactly `-0.0` drops it

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -218,7 +218,7 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
     - **ARM:** `FDIV`
     - **x86:** `DIVSD`
 - **Counted Python operations:** `x / y` or `y / x` for `CountedFloat` —
-  except division by a power-of-two constant divisor with a finite reciprocal,
+  except division by a power-of-two constant divisor of either sign with a finite reciprocal,
   which counts `MUL`: for exactly those divisors `x * (1/c)` is bit-identical
   to `x / c`, so a compiled port applies the reciprocal fold. `x / 1.0` counts
   nothing at all (it folds away entirely, mirroring `x ** 1`)
@@ -237,8 +237,9 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
   their product folds at compile time, leaving a compiled port with a bare add,
   so that counts ADD rather than FMA — and a collapsed product of exactly
   `-0.0` folds the add away too (`z + (-0.0)` is `z` for every `z`), counting
-  nothing. No reduction is done by constant *value* —
-  every FMA variant is one instruction, so there is nothing to win (see
+  nothing. A surviving `fma` gets no reduction by constant *value*: the
+  explicit call stays fused by the author-boundary pin — written fused stays
+  fused, even where a bit-exact cheaper respelling exists (see
   [the counting model](counting_flops.md#the-counting-model-what-gets-counted-and-why))
 - **Not counted:** `math.fma` on plain floats only; `a*b + c` written with
   operators, which counts MUL + ADD because the interpreter cannot observe the
@@ -271,6 +272,12 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
 - **Counted Python operations:** `math.exp(x)` for `CountedFloat`
 - **Not counted:** `math.exp(x)` on non-CountedFloat, `numpy.exp`,
   `math.expm1`, `math.e ** x`
+- **Note:** `math.e ** x` counts POW, not EXP — `math.e` is not e (no float is;
+  e is irrational), so `pow(math.e, x)` and `exp(x)` compute different
+  functions, and neither the bit-exact compiler stage nor the same-computation
+  author stage of the [cost model](cost_model.md) admits the rewrite. Contrast
+  `math.log(x, math.e)`, whose fold rides a `1/log(base)` multiplier that
+  evaluates to exactly 1.0 (see [`FlopType.LOG`](#flop-log))
 - **Weight measurement:** [the machine code behind the `EXP` weight](machine_code/exp.md)
 
 ## FlopType.EXP2 (`2^x`) { #flop-exp2 }

--- a/src/counted_float/_core/counting/_counted_float.py
+++ b/src/counted_float/_core/counting/_counted_float.py
@@ -70,8 +70,8 @@ def count_div_with_constant_divisor(divisor: float) -> None:
 
     Constants are folded by value (an int and an equal-valued plain float compile identically):
     a divisor of 1 counts nothing (``x / 1.0`` folds away entirely — a compiled port emits no
-    instruction, mirroring ``x ** 1``), and any other power-of-two divisor with a finite
-    reciprocal counts MUL — for exactly those divisors ``x * (1/c)`` is bit-identical to
+    instruction, mirroring ``x ** 1``), and any other power-of-two divisor of either sign with a
+    finite reciprocal counts MUL — for exactly those divisors ``x * (1/c)`` is bit-identical to
     ``x / c``, so a standard-C compiler applies the reciprocal fold at plain ``-O2``. Every
     other divisor counts DIV.
     """
@@ -548,7 +548,8 @@ class CountedFloat(float):
 
         A constant (non-CountedFloat) divisor enables the folds a compiled port applies — see
         count_div_with_constant_divisor: a divisor of 1 counts nothing, any other power-of-two
-        constant divisor with a finite reciprocal counts MUL, everything else counts DIV.
+        constant divisor of either sign with a finite reciprocal counts MUL, everything else
+        counts DIV.
         """
         result = float.__truediv__(self, other)
         if result is NotImplemented:


### PR DESCRIPTION
**Problem**: Three stated rationales lagged the ruleset. The fma pages justified refusing value folds with "folding a value would buy nothing" — false, since `fma(x, 1.0, z)` is exactly `x + z` and ADD weighs less than FMA. The reciprocal-multiply fold reads as positive-only while the implementation folds divisors of either sign. And `math.e ** x` counting POW while `math.log(x, math.e)` folds to a bare LOG looked arbitrary, with the reason stated nowhere.

**Solution**: The fma refusal becomes a declared pin — written fused stays fused, in favor of the explicit instruction the author wrote, mirroring `-ffp-contract=off`; the divisor wording says "either sign" (`±2^k`) at every statement of the fold, docstrings included; the EXP entry explains that `math.e` is not e, so `pow(math.e, x)` and `exp(x)` compute different functions and no stage of the model admits the rewrite.

- **Attention:** counts are unchanged everywhere — this PR only makes the stated reasons match what the model actually does and why.
- **SPIKE:** Compiler Explorer (aarch64, `-O2`, no fast-math): clang 22.1.0 unfuses `fma(x, 1.0, z)` to a plain add while gcc 16.1.0 keeps the fused instruction — the divergence that makes the pin necessary; both keep `pow(2.718..., x)` as a `pow` call, corroborating the base-e stance. Versions are cited in the doc so the observation cannot rot.

**Changelog**: None: documentation only.


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>