### PR TITLE
docs: state the overhead factor once, in the captured example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,16 +103,20 @@ counts.total_count()         # 2
 ## Performance overhead
 
 `CountedFloat` adds counting overhead in two forms — the price of Python-level
-operator dispatch and result wrapping. Measured on an Apple M3 Max (measure your
-own machine with `counted_float evaluate-overhead`):
+operator dispatch and result wrapping. How much slower your code runs depends
+almost entirely on its operation mix:
 
-- **native float ops** (`+`, `-`, `*`, `/`, comparisons): roughly **20–40×**
-  slower than plain `float` per operation, environment-dependent (~21× on the M3
-  Max bisection benchmark);
-- **patched `math.*` calls** (`math.sqrt`, `math.exp`, …): a roughly fixed
-  **~0.1 µs** of overhead per call — about **6–7×** for cheap functions like
-  `sqrt`, and a smaller multiple for costlier ones (the fixed overhead is a
-  smaller share of a slower call).
+- **native float ops** (`+`, `-`, `*`, `/`, comparisons): the expensive end of
+  the range — the fixed per-operation dispatch cost dwarfs the nanoseconds of
+  actual arithmetic;
+- **patched `math.*` calls** (`math.sqrt`, `math.lgamma`, …): a roughly fixed
+  surcharge per call, so the multiple shrinks as the function itself gets more
+  expensive.
+
+`counted_float evaluate-overhead` measures your own machine — a per-flop-type
+overhead table, the geomean across types, and a practical mixed workload; see
+the [captured example](https://counted-float.readthedocs.io/en/latest/benchmarking/#performance-impact)
+for representative figures.
 
 Three facts worth knowing:
 

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -396,12 +396,14 @@ missing silently, and the output says so up front.
 
 ## Performance overhead
 
-Counting adds overhead in two forms, measured on an Apple M3 Max (see the
-[Benchmarking page](benchmarking.md#performance-impact) for the CLI example):
-native float ops (`+`, `-`, `*`, `/`, comparisons) run roughly 20–40× slower
-than plain `float` per operation (environment-dependent), while a
-patched `math.*` call carries a roughly fixed ~0.1 µs of overhead — about 6–7×
-for cheap functions like `sqrt`, less for costlier ones. The overhead is inherent
+Counting adds overhead in two forms, and how much depends almost entirely on the
+operation mix: native float ops (`+`, `-`, `*`, `/`, comparisons) sit at the
+expensive end of the range, because the fixed Python-level dispatch cost dwarfs
+the underlying arithmetic, while a patched `math.*` call carries a roughly fixed
+surcharge per call, so the multiple shrinks as the function itself gets more
+expensive. The [Benchmarking page](benchmarking.md#performance-impact) carries a
+captured per-flop-type example; measure your own machine with
+`counted_float evaluate-overhead`. The overhead is inherent
 to Python-level instrumentation; `PauseFlopCounting` stops count registration but
 not the instrumented dispatch, so hot regions that need raw speed should convert
 back to plain `float`. Counts themselves are always exact — overhead affects wall


### PR DESCRIPTION
**Problem**: The overhead factor was published in three places — two of them with disagreeing hard numbers for what is described as the same run — and every figure predates the constant-folding work that moved them, with nothing regenerating any of them.

**Solution**: Prose stops carrying specific factors. The README and the counting page keep the qualitative range framing — native ops at the expensive end of the range, patched `math.*` calls at the cheap end — plus the pointer to measuring your own machine, while the benchmarking page's single machine-and-version-labeled capture becomes the only place with numbers.

- **Attention:** no drift mechanism on purpose — a timing capture cannot join the byte-exact drift-tested captures, and a tolerance check on a machine-dependent measurement would fail for environmental reasons; fewer copies removes the drift surface instead of policing it.
- **TEST:** swept README and docs for remaining hard overhead figures (stale ratios, the fixed per-call microsecond figure) — none left outside the benchmarking capture.

**Changelog** (none): documentation-only; the benchmark's new report format carries its changelog entry in #319.


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
