### PR TITLE
test: make every mutant attributable and gate releases on attribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,6 +272,11 @@ source_paths = ["src/counted_float"]
 # exclusion list rots the safe way instead: new code is in scope by default, and staying out costs
 # an entry with a reason next to it. The same rule governs the test selection further down.
 #
+# NOTE: mutmut attributes tests to a function only when it is called while a test runs, so code
+# executing only at import time (module-level registry construction) scores every mutant as
+# "no tests" = never killed. Keep registries behind plain functions that tests call directly;
+# release.py gates on the no-tests share so an attribution gap can never silently deflate the badge.
+#
 # Excluded from mutation -- every surviving mutant here is a false signal, not a real gap:
 #   - _callsite.py is pure call-stack introspection, and mutmut runs tests through a trampoline that
 #     becomes the reported call site, so no test can exercise it.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -39,9 +39,15 @@ PACKAGE_NAME = "counted-float"
 CATEGORIES = ["Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"]
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
 # ceiling on the mutation measurement, past which the run is treated as unable to produce a number.
-# A healthy full run finishes in a small fraction of this; the headroom is for a bad run, not for an
+# A healthy full run finishes in about a third of this; the headroom is for a bad run, not for an
 # unknown machine -- the release always runs on the maintainer's.
-MUTATION_TIMEOUT_SEC = 600
+MUTATION_TIMEOUT_SEC = 1200
+# ceiling on the share of mutants with no attributed tests. Such mutants run nothing and score as
+# not-killed, so a large share silently deflates the score below anything the suite actually
+# measures (mutmut attributes tests only to functions called *while a test runs*, so e.g.
+# import-time-only code gets none). A small residue is tolerated; past this share the measurement
+# is under-attributing and gates the release like any other broken measurement.
+MUTATION_NO_TESTS_MAX_SHARE = 0.02
 # provenance line above the badge block: rewritten in place each release, never appended to
 BADGE_STAMP_RE = re.compile(r"^<!-- badges below refreshed at release v[^>]*-->$", re.MULTILINE)
 
@@ -275,10 +281,11 @@ def _measure_mutation_score() -> int:
     Killed over *all* mutants: timeouts count toward the denominator but never the numerator, so a
     mutant that merely ran slowly is never scored as caught.
 
-    Two questions are kept apart. Whether a number could be produced at all gates the release: a
-    crashing suite, a missing or malformed stats file, an empty mutant set or a run past
-    MUTATION_TIMEOUT_SEC all mean the measurement is broken, and swallowing that compounds
-    silently across every later release -- the badge would keep claiming a figure nobody measured.
+    Two questions are kept apart. Whether a *meaningful* number could be produced at all gates the
+    release: a crashing suite, a missing or malformed stats file, an empty mutant set, a run past
+    MUTATION_TIMEOUT_SEC, or a no-tests share past MUTATION_NO_TESTS_MAX_SHARE all mean the
+    measurement is broken, and swallowing that compounds silently across every later release --
+    the badge would keep claiming a figure nobody measured.
     What the number *is* never gates: the score wobbles run to run from timeout nondeterminism, so
     a threshold would reject releases over measurement noise.
 
@@ -311,10 +318,17 @@ def _measure_mutation_score() -> int:
     try:
         stats = json.loads(MUTATION_STATS_FILE.read_text())
         killed, total = int(stats["killed"]), int(stats["total"])
+        no_tests = int(stats["no_tests"])
     except (OSError, ValueError, KeyError) as exc:
         fail_with_message(f"could not read the mutation stats ({exc}), so no mutation score could be measured")
     if total <= 0:
         fail_with_message("the mutation run produced no mutants, so no mutation score could be measured")
+    if no_tests / total > MUTATION_NO_TESTS_MAX_SHARE:
+        fail_with_message(
+            f"{no_tests}/{total} mutants have no attributed tests (> {MUTATION_NO_TESTS_MAX_SHARE:.0%}), so the "
+            f"score under-measures the suite instead of measuring it. The usual cause is code that runs only at "
+            f"import time (see MUTATION_NO_TESTS_MAX_SHARE); fix the attribution before releasing."
+        )
     return round(100 * killed / total)
 
 

--- a/src/counted_float/_core/evaluation/_per_flop_overhead.py
+++ b/src/counted_float/_core/evaluation/_per_flop_overhead.py
@@ -12,8 +12,8 @@ Operand pools keep every loop on the generic counting path: values sit strictly 
 operation's domain and never hit a constant fold or strength reduction (no +-0.0 addends, +-1.0
 multipliers, power-of-two divisors, or special exponents). The one exception is EXP10, whose only
 counted spelling *is* the constant-base fold `10.0 ** x` -- its expression column states exactly
-that. Types with no reliably measurable standalone loop are listed in EXCLUDED_FLOP_TYPES with the
-reason, so the printed report shows the exemptions rather than silently omitting rows.
+that. Types with no reliably measurable standalone loop are listed by excluded_flop_types() with
+the reason, so the printed report shows the exemptions rather than silently omitting rows.
 """
 
 from __future__ import annotations
@@ -473,19 +473,33 @@ def _runtime_unavailable() -> dict[FlopType, str]:
     return unavailable
 
 
-# Exclusion rule: a type is excluded only when its standalone measurement is unreliable or
-# impossible, never because its result would be unflattering -- every entry states its reason,
-# and the printed report shows this dict so exemptions are visible in every capture.
-EXCLUDED_FLOP_TYPES: dict[FlopType, str] = {
-    FlopType.HYPOT_XARG: "cost increment per hypot() argument beyond two; not a standalone operation",
-    FlopType.DIST_XARG: "cost increment per dist() dimension beyond two; not a standalone operation",
-    FlopType.SUMPROD_XELEM: "cost increment per sumprod() element beyond two; not a standalone operation",
-    **_runtime_unavailable(),
-}
+def excluded_flop_types() -> dict[FlopType, str]:
+    """The flop types without a per-type overhead row, each mapped to its measurement reason.
 
-PER_FLOP_TYPE_SPECS: list[FlopTypeLoopSpec] = [
-    spec for spec in _all_loop_specs() if spec.flop_type not in EXCLUDED_FLOP_TYPES
-]
+    Exclusion rule: a type is excluded only when its standalone measurement is unreliable or
+    impossible, never because its result would be unflattering -- every entry states its reason,
+    and the printed report shows this mapping so exemptions are visible in every capture.
+
+    Returns a fresh dict per call: construction is trivial, and callers never share a mutable.
+    """
+    return {
+        FlopType.HYPOT_XARG: "cost increment per hypot() argument beyond two; not a standalone operation",
+        FlopType.DIST_XARG: "cost increment per dist() dimension beyond two; not a standalone operation",
+        FlopType.SUMPROD_XELEM: "cost increment per sumprod() element beyond two; not a standalone operation",
+        **_runtime_unavailable(),
+    }
+
+
+def per_flop_type_specs() -> list[FlopTypeLoopSpec]:
+    """Every measurable flop type's loop spec, in FlopType declaration order.
+
+    A plain function rather than a module-level constant -- like excluded_flop_types(), and
+    returning a fresh list per call for the same reason -- so the registry builders execute inside
+    the tests that pin them: mutation testing attributes tests to a function only when it runs
+    during one, and import-time construction is invisible to that attribution.
+    """
+    excluded = excluded_flop_types()
+    return [spec for spec in _all_loop_specs() if spec.flop_type not in excluded]
 
 
 # =================================================================================================

--- a/src/counted_float/_core/evaluation/_runner.py
+++ b/src/counted_float/_core/evaluation/_runner.py
@@ -8,7 +8,7 @@ suite, which is why it lives here and not beside it.
 from counted_float._core.micro_benchmarking import console, output_quiet
 from counted_float._core.models import FlopType
 
-from ._per_flop_overhead import EXCLUDED_FLOP_TYPES, PER_FLOP_TYPE_SPECS, PerFlopTypeLoop
+from ._per_flop_overhead import PerFlopTypeLoop, excluded_flop_types, per_flop_type_specs
 from ._practical_workload import PRACTICAL_WORKLOAD_LABEL, CountedFloatBisection, FloatBisection
 from ._results import CountingOverheadResults, ExcludedFlopType, PerFlopTypeOverhead
 
@@ -31,8 +31,9 @@ def evaluate_counting_overhead(t_target_sec: float = 0.1, verbose: bool = True) 
         console.print()
 
         # --- per-flop-type loops --------------------
+        excluded = excluded_flop_types()
         per_flop_type: list[PerFlopTypeOverhead] = []
-        for spec in PER_FLOP_TYPE_SPECS:
+        for spec in per_flop_type_specs():
             pool_float = spec.make_pool(False)
             pool_counted = spec.make_pool(True)
             result_float = PerFlopTypeLoop(
@@ -74,9 +75,9 @@ def evaluate_counting_overhead(t_target_sec: float = 0.1, verbose: bool = True) 
     return CountingOverheadResults(
         per_flop_type=per_flop_type,
         excluded_flop_types=[
-            ExcludedFlopType(flop_type=flop_type, reason=EXCLUDED_FLOP_TYPES[flop_type])
+            ExcludedFlopType(flop_type=flop_type, reason=excluded[flop_type])
             for flop_type in FlopType
-            if flop_type in EXCLUDED_FLOP_TYPES
+            if flop_type in excluded
         ],
         practical_workload_label=PRACTICAL_WORKLOAD_LABEL,
         float_time_nsec=result_float_bisection.summary_stats_nsecs_per_exec().q50,

--- a/tests/evaluation/test_counting_overhead.py
+++ b/tests/evaluation/test_counting_overhead.py
@@ -3,15 +3,103 @@ import warnings
 import pytest
 
 from counted_float._core.counting import CountedFloat, FlopCountingContext
-from counted_float._core.evaluation import CountingOverheadResults, PerFlopTypeOverhead, evaluate_counting_overhead
+from counted_float._core.evaluation import (
+    CountedFloatBisection,
+    CountingOverheadResults,
+    ExcludedFlopType,
+    FloatBisection,
+    PerFlopTypeOverhead,
+    evaluate_counting_overhead,
+)
 from counted_float._core.evaluation._practical_workload import _zero_function
 from counted_float._core.models import FlopType
+
+# golden output for the show() test below; module-level so the wide table rows stay unindented
+_EXPECTED_SHOW_OUTPUT = """\
+Counting overhead per flop type (CountedFloat vs float, generic counting path):
+  FlopType.ADD            [x+y]             x + y                       :     10.00 ns ->     40.00 ns  =     4.0x
+  FlopType.GAMMA          [gamma(x)]        math.gamma(x)               :     32.00 ns ->    144.00 ns  =     4.5x
+
+Not measured:
+  FlopType.DIST_XARG      [dist(+arg)]      cost increment, not standalone
+
+Geomean overhead across measured flop types: 4.2x
+
+Practical workload: test workload
+  float        :    1.00 µs / execution
+  CountedFloat :    9.30 µs / execution
+
+CountedFloat is 9.3x slower than float on this workload
+"""
 
 
 def test_evaluate_counting_overhead():
     # Rudimentary test to check the benchmark runs without errors
     result = evaluate_counting_overhead(t_target_sec=0.001)
     result.show()
+
+
+def test_counted_bisection_registers_the_expected_operation_mix():
+    # one bisection over [2, 100] runs N halvings; per zero-function call (N+2: fa, fb, then one
+    # per iteration) it counts LGAMMA + SUB, per midpoint ADD + MUL, per while-check SUB + COMP
+    # (N+1 checks), and per sign test COMP (N) -- so the relations below hold for any N, and the
+    # N-range pins that the bracket/tolerance produce a real bisection rather than a degenerate one
+    # --- arrange ----------------------
+    benchmark = CountedFloatBisection()
+    benchmark._prepare_benchmark(1)
+
+    # --- act --------------------------
+    with FlopCountingContext() as ctx:
+        benchmark._run_benchmark()
+    counts = ctx.flop_counts()
+    n_iterations = counts.ADD
+
+    # --- assert -----------------------
+    assert 40 <= n_iterations <= 60
+    assert n_iterations == counts.MUL
+    assert n_iterations + 2 == counts.LGAMMA
+    assert 2 * n_iterations + 3 == counts.SUB
+    assert 2 * n_iterations + 1 == counts.COMP
+
+
+def test_float_bisection_registers_nothing():
+    # --- arrange ----------------------
+    benchmark = FloatBisection()
+    benchmark._prepare_benchmark(1)
+
+    # --- act --------------------------
+    with FlopCountingContext() as ctx:
+        benchmark._run_benchmark()
+
+    # --- assert -----------------------
+    assert sum(getattr(ctx.flop_counts(), flop_type.name) for flop_type in FlopType) == 0
+
+
+def test_show_prints_the_full_report(capsys):
+    # --- arrange ----------------------
+    results = CountingOverheadResults(
+        per_flop_type=[
+            PerFlopTypeOverhead(
+                flop_type=FlopType.ADD, expression="x + y", float_time_nsec=10.0, counted_float_time_nsec=40.0
+            ),
+            PerFlopTypeOverhead(
+                flop_type=FlopType.GAMMA,
+                expression="math.gamma(x)",
+                float_time_nsec=32.0,
+                counted_float_time_nsec=144.0,
+            ),
+        ],
+        excluded_flop_types=[ExcludedFlopType(flop_type=FlopType.DIST_XARG, reason="cost increment, not standalone")],
+        practical_workload_label="test workload",
+        float_time_nsec=1000.0,
+        counted_float_time_nsec=9300.0,
+    )
+
+    # --- act --------------------------
+    results.show()
+
+    # --- assert -----------------------
+    assert capsys.readouterr().out == _EXPECTED_SHOW_OUTPUT
 
 
 def test_practical_zero_function_mixes_lgamma_and_operator_work():

--- a/tests/evaluation/test_per_flop_overhead.py
+++ b/tests/evaluation/test_per_flop_overhead.py
@@ -2,8 +2,9 @@ import pytest
 
 from counted_float._core.counting import FlopCountingContext
 from counted_float._core.evaluation._per_flop_overhead import (
-    EXCLUDED_FLOP_TYPES,
-    PER_FLOP_TYPE_SPECS,
+    PerFlopTypeLoop,
+    excluded_flop_types,
+    per_flop_type_specs,
 )
 from counted_float._core.models import FlopType
 
@@ -14,8 +15,8 @@ def _total_count(counts) -> int:
 
 def test_every_flop_type_is_measured_or_excluded():
     # --- arrange ----------------------
-    measured = {spec.flop_type for spec in PER_FLOP_TYPE_SPECS}
-    excluded = set(EXCLUDED_FLOP_TYPES)
+    measured = {spec.flop_type for spec in per_flop_type_specs()}
+    excluded = set(excluded_flop_types())
 
     # --- assert -----------------------
     assert measured | excluded == set(FlopType)
@@ -23,10 +24,42 @@ def test_every_flop_type_is_measured_or_excluded():
 
 
 def test_every_exclusion_states_a_reason():
-    assert all(reason.strip() for reason in EXCLUDED_FLOP_TYPES.values())
+    assert all(reason.strip() for reason in excluded_flop_types().values())
 
 
-@pytest.mark.parametrize("spec", PER_FLOP_TYPE_SPECS, ids=lambda spec: spec.flop_type.name)
+def test_per_flop_type_loop_counts_only_in_the_counted_variant():
+    # --- arrange ----------------------
+    spec = next(s for s in per_flop_type_specs() if s.flop_type is FlopType.ADD)
+    pool_counted = spec.make_pool(True)
+    loop_counted = PerFlopTypeLoop(
+        name="ADD [CountedFloat]", loop=spec.loop, pool=pool_counted, in_counting_context=True
+    )
+    loop_float = PerFlopTypeLoop(
+        name="ADD [float]", loop=spec.loop, pool=spec.make_pool(False), in_counting_context=False
+    )
+    loop_counted._prepare_benchmark(2)
+    loop_float._prepare_benchmark(2)
+
+    # --- act --------------------------
+    with FlopCountingContext() as ctx:  # outer context: the counted variant's own context nests inside it
+        loop_float._run_benchmark()
+        counts_after_float = ctx.flop_counts()
+        loop_counted._run_benchmark()
+    counts = ctx.flop_counts()
+
+    # --- assert -----------------------
+    assert _total_count(counts_after_float) == 0  # the float variant registers nothing
+    assert 2 * len(pool_counted) == counts.ADD  # n_executions passes, one ADD per pool element
+
+
+def test_builders_return_fresh_objects_per_call():
+    # callers may filter or annotate their copy without corrupting anyone else's
+    # --- act / assert -----------------
+    assert per_flop_type_specs() is not per_flop_type_specs()
+    assert excluded_flop_types() is not excluded_flop_types()
+
+
+@pytest.mark.parametrize("spec", per_flop_type_specs(), ids=lambda spec: spec.flop_type.name)
 def test_counted_loop_counts_exactly_its_flop_type(spec):
     # the operand pools must keep every loop on the generic counting path: one count of the
     # target type per pool element, and no fold, strength reduction, or side count of any kind
@@ -43,7 +76,7 @@ def test_counted_loop_counts_exactly_its_flop_type(spec):
     assert _total_count(counts) == len(pool)
 
 
-@pytest.mark.parametrize("spec", PER_FLOP_TYPE_SPECS, ids=lambda spec: spec.flop_type.name)
+@pytest.mark.parametrize("spec", per_flop_type_specs(), ids=lambda spec: spec.flop_type.name)
 def test_float_baseline_loop_counts_nothing(spec):
     # the float variant must stay entirely uncounted, even with the patched math active
     # --- arrange ----------------------


### PR DESCRIPTION
**TL;DR**: The mutation badge's 80% → 67% drop was a measurement artifact, not a test-quality regression: 703 mutants in the new evaluation modules were never attributed to any test. This PR makes every mutant attributable, and gates future releases on attribution health.

## Description

### Problem addressed

mutmut runs, per mutant, only the tests its stats pass mapped to the mutated function — and that mapping records a function only when it is called *while a test is running*. The per-flop overhead registry (`PER_FLOP_TYPE_SPECS`) and its pool factories executed at module import, and a few benchmark methods only deep inside the one slow smoke test, so 703 of 3963 mutants got an empty test list and scored "no tests" — unkillable by construction, all in code whose counting behavior the suite pins exactly. Nothing in the release flow flagged that a fifth of the denominator was unmeasurable.

### Implementation

- **The registry and exclusion table become plain builder functions** (`per_flop_type_specs()`, `excluded_flop_types()`), returning fresh objects per call — the more testable structure on its own merits: the builders now execute inside the tests that pin them, so attribution works naturally.
- **Direct tests for the remaining unattributed code**: the two bisection benchmarks (exact operation-mix relations, derived in a comment), the float baseline (registers nothing), `show()` (golden output), and the per-type timed-loop class (counts only in its counted variant).
- **release.py gates on attribution**: the release now fails when the no-tests share of mutants exceeds 2% — the same principle already stated in its docstring (a broken measurement gates; a merely-low score never does), extended to attribution gaps.
- **The mutation timeout rises to 1200 s**: with ~700 more mutants actually running their tests, a healthy full run measures ~6.3 min; the old 600 s ceiling left too little headroom.
- The mutmut config comment documents the import-time attribution trap so the next registry doesn't reintroduce it.

## Attention points

- **The honest score is now visible and lower than the badge**: a full run measures 73.9% killed with zero unattributed mutants — the previously invisible mutants are now measured, and ~430 of them genuinely survive (display strings, pool constants). Raising the kill rate is deliberately out of scope here: this PR fixes the measurement; the survivor triage is its own change.
- **Mutants of the workload's bracket/target constants survive by design-tradeoff**: the bisection's operation-mix relations hold for any bracket, and the root value is not observable from outside the timed loop. They fall to the triage change.

## Tests / Spikes

- **SPIKE:** scoped mutation runs before/after the conversion: evaluation-module "no tests" went 703 → 16 (the timed-loop class, exercised only late in the smoke test — confirming the attribution cutoff also bites long tests) → 0 after its direct test.
- **TEST:** full mutation run from scratch: 3972 mutants, 0 with no attributed tests, 6m19s wall.
- 5 tests added (bisection mix, float-baseline silence, golden `show()`, timed-loop variant behavior, fresh-objects-per-call); 4 updated to call the builders inside test bodies.

## Changelog entry

None: test infrastructure and release tooling only; no user-facing behavior changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
