### PR TITLE
chore: add a non-blocking CI leg on the next CPython, on an unpinned uv

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -3,9 +3,6 @@ author: bertpluymers
 description: Run counted_float benchmarks inside a github runner using uv.
 
 inputs:
-    uv_version:
-        required: true
-        description: "Version of UV to be used."
     python_version:
         required: false
         description: "Version of Python to be used.  If omitted will default to version in .python-version"
@@ -16,8 +13,6 @@ runs:
     steps:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          version: ${{ inputs.uv_version }}
 
       - name: Determine Python version
         shell: bash

--- a/.github/actions/pre_commit/action.yml
+++ b/.github/actions/pre_commit/action.yml
@@ -3,17 +3,12 @@ author: Bert Pluymers
 description: Set up uv and run the full pre-commit hook suite over all files, via `make lint`.
 
 inputs:
-    uv_version:
-        required: true
-        description: "Version of uv to be used."
-
 runs:
     using: composite
     steps:
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: ${{ inputs.uv_version }}
           enable-cache: true
 
       - name: Cache pre-commit hook environments

--- a/.github/actions/pre_commit/action.yml
+++ b/.github/actions/pre_commit/action.yml
@@ -2,7 +2,6 @@ name: Pre-commit
 author: Bert Pluymers
 description: Set up uv and run the full pre-commit hook suite over all files, via `make lint`.
 
-inputs:
 runs:
     using: composite
     steps:

--- a/.github/actions/unit_test/action.yml
+++ b/.github/actions/unit_test/action.yml
@@ -3,9 +3,6 @@ author: Bert Pluymers
 description: Run unit tests at a specific Python version, extras, and dependency resolution.
 
 inputs:
-    uv_version:
-        required: true
-        description: "Version of uv to be used."
     python_version:
         required: false
         description: "Python version. Empty string uses .python-version."
@@ -29,7 +26,6 @@ runs:
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: ${{ inputs.uv_version }}
           # Distinct cache key per combo so parallel legs don't race to save one shared key.
           cache-suffix: ${{ inputs.dependency_resolution }}-extras-${{ inputs.include_all_extra_deps }}
 

--- a/.github/workflows/_package_check.yml
+++ b/.github/workflows/_package_check.yml
@@ -23,8 +23,6 @@ jobs:
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          version: ${{ vars.UV_VERSION }}
 
       - name: Build sdist + wheel
         run: uv build
@@ -52,8 +50,6 @@ jobs:
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          version: ${{ vars.UV_VERSION }}
 
       - name: Download distribution artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -67,6 +67,11 @@ jobs:
     name: py3.15-pre / highest / extras-false / ubuntu-24.04-arm (never gates)
     runs-on: ubuntu-24.04-arm
     continue-on-error: true
+    env:
+      # pre-release interpreters reach uv through the manifest baked into each uv release, and the
+      # shared vars.UV_VERSION predates 3.15's first pre-release -- so this leg alone pins a uv
+      # that knows it. Fold back to vars.UV_VERSION once the shared pin catches up.
+      UV_VERSION_PYTHON_NEXT: "0.9.17"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -75,7 +80,7 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: ${{ vars.UV_VERSION }}
+          version: ${{ env.UV_VERSION_PYTHON_NEXT }}
       # a bare `--python 3.15` request never auto-downloads a pre-release interpreter; installing
       # it up front is what lets the shared unit-test action resolve 3.15 while the series is in
       # alpha/beta/rc (the bare install request does pick the latest pre-release)
@@ -83,7 +88,7 @@ jobs:
         run: uv python install 3.15
       - uses: ./.github/actions/unit_test
         with:
-          uv_version: ${{ vars.UV_VERSION }}
+          uv_version: ${{ env.UV_VERSION_PYTHON_NEXT }}
           python_version: "3.15"
           include_all_extra_deps: "false"
 

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -49,29 +49,23 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/unit_test
         with:
-          uv_version: ${{ vars.UV_VERSION }}
           python_version: ${{ matrix.python }}
           dependency_resolution: ${{ matrix.resolution }}
           include_all_extra_deps: ${{ matrix.all_extras }}
           coverage: "true"  # each combo uploads its data; the coverage job unions + gates
 
-  # Early warning on the next CPython, never gating: a base install on the upcoming minor, so an
+  # Early warning on the next CPython, non-blocking: a base install on the upcoming minor, so an
   # incompatible pre-release -- most acutely a new `math` function the patching partition would not
-  # classify -- fails loudly here months before that Python ships, instead of on users at release.
-  # Three things keep it from gating anything: continue-on-error stops a red run from failing the
-  # workflow, the coverage job does not depend on it, and it uploads no coverage data (the
+  # classify -- fails visibly here months before that Python ships, instead of on users at release.
+  # Three things keep it from blocking anything: the test step's continue-on-error keeps the job
+  # (and so the PR checks roll-up) green, with a failure surfacing as a warning annotation instead
+  # of a red cross; the coverage job does not depend on it; and it uploads no coverage data (the
   # cumulative floor unions supported versions only). Base install because numba wheels trail new
   # CPythons by months. Bump the version here when the next pre-release series opens; classifiers
   # and .python-versions stay untouched until the version is actually supported.
   python_next:
-    name: py3.15-pre / highest / extras-false / ubuntu-24.04-arm (never gates)
+    name: py3.15-pre / highest / extras-false / ubuntu-24.04-arm (non-blocking)
     runs-on: ubuntu-24.04-arm
-    continue-on-error: true
-    env:
-      # pre-release interpreters reach uv through the manifest baked into each uv release, and the
-      # shared vars.UV_VERSION predates 3.15's first pre-release -- so this leg alone pins a uv
-      # that knows it. Fold back to vars.UV_VERSION once the shared pin catches up.
-      UV_VERSION_PYTHON_NEXT: "0.9.17"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -79,18 +73,20 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          version: ${{ env.UV_VERSION_PYTHON_NEXT }}
       # a bare `--python 3.15` request never auto-downloads a pre-release interpreter; installing
       # it up front is what lets the shared unit-test action resolve 3.15 while the series is in
       # alpha/beta/rc (the bare install request does pick the latest pre-release)
       - name: Install the next Python's pre-release interpreter
         run: uv python install 3.15
       - uses: ./.github/actions/unit_test
+        id: tests
+        continue-on-error: true
         with:
-          uv_version: ${{ env.UV_VERSION_PYTHON_NEXT }}
           python_version: "3.15"
           include_all_extra_deps: "false"
+      - name: Surface a test failure as a warning annotation
+        if: steps.tests.outcome == 'failure'
+        run: echo "::warning title=py3.15-pre leg failed::the next CPython's pre-release broke the suite -- early warning only, nothing is blocked"
 
   coverage:
     name: coverage
@@ -114,8 +110,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          version: ${{ vars.UV_VERSION }}
       - name: Download coverage data from all matrix combos
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -73,6 +73,14 @@ jobs:
           # full history + tags: hatch-vcs derives the package version via git describe
           fetch-depth: 0
           persist-credentials: false
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: ${{ vars.UV_VERSION }}
+      # a bare `--python 3.15` request never auto-downloads a pre-release interpreter; installing
+      # it up front is what lets the shared unit-test action resolve 3.15 while the series is in
+      # alpha/beta/rc (the bare install request does pick the latest pre-release)
+      - name: Install the next Python's pre-release interpreter
+        run: uv python install 3.15
       - uses: ./.github/actions/unit_test
         with:
           uv_version: ${{ vars.UV_VERSION }}

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -55,6 +55,30 @@ jobs:
           include_all_extra_deps: ${{ matrix.all_extras }}
           coverage: "true"  # each combo uploads its data; the coverage job unions + gates
 
+  # Early warning on the next CPython, never gating: a base install on the upcoming minor, so an
+  # incompatible pre-release -- most acutely a new `math` function the patching partition would not
+  # classify -- fails loudly here months before that Python ships, instead of on users at release.
+  # Three things keep it from gating anything: continue-on-error stops a red run from failing the
+  # workflow, the coverage job does not depend on it, and it uploads no coverage data (the
+  # cumulative floor unions supported versions only). Base install because numba wheels trail new
+  # CPythons by months. Bump the version here when the next pre-release series opens; classifiers
+  # and .python-versions stay untouched until the version is actually supported.
+  python_next:
+    name: py3.15-pre / highest / extras-false / ubuntu-24.04-arm (never gates)
+    runs-on: ubuntu-24.04-arm
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # full history + tags: hatch-vcs derives the package version via git describe
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: ./.github/actions/unit_test
+        with:
+          uv_version: ${{ vars.UV_VERSION }}
+          python_version: "3.15"
+          include_all_extra_deps: "false"
+
   coverage:
     name: coverage
     # Cumulative gate: combine every combo's data into one picture before

--- a/.github/workflows/benchmark_linux_arm.yml
+++ b/.github/workflows/benchmark_linux_arm.yml
@@ -17,5 +17,3 @@ jobs:
           persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark
-        with:
-          uv_version: ${{ vars.UV_VERSION }}

--- a/.github/workflows/benchmark_linux_x86.yml
+++ b/.github/workflows/benchmark_linux_x86.yml
@@ -19,5 +19,3 @@ jobs:
           persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark
-        with:
-          uv_version: ${{ vars.UV_VERSION }}

--- a/.github/workflows/benchmark_macos_arm.yml
+++ b/.github/workflows/benchmark_macos_arm.yml
@@ -17,5 +17,3 @@ jobs:
           persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark
-        with:
-          uv_version: ${{ vars.UV_VERSION }}

--- a/.github/workflows/benchmark_macos_x86.yml
+++ b/.github/workflows/benchmark_macos_x86.yml
@@ -17,5 +17,3 @@ jobs:
           persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark
-        with:
-          uv_version: ${{ vars.UV_VERSION }}

--- a/.github/workflows/benchmark_windows_x86.yml
+++ b/.github/workflows/benchmark_windows_x86.yml
@@ -17,5 +17,3 @@ jobs:
           persist-credentials: false
       - name: Run counted_float benchmark
         uses: ./.github/actions/benchmark
-        with:
-          uv_version: ${{ vars.UV_VERSION }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -77,8 +77,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/pre_commit
-        with:
-          uv_version: ${{ vars.UV_VERSION }}
 
   test:
     needs: [preflight]
@@ -117,8 +115,6 @@ jobs:
           persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          version: ${{ vars.UV_VERSION }}
       - name: Export the locked runtime dependencies
         run: uv export --frozen --no-emit-project --no-dev --no-hashes --format requirements-txt -o requirements.txt
       - uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266 # v1.1.0

--- a/.github/workflows/push_to_branch.yml
+++ b/.github/workflows/push_to_branch.yml
@@ -42,8 +42,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/pre_commit
-        with:
-          uv_version: ${{ vars.UV_VERSION }}
 
   test:  # latest-only here; the full matrix runs on PR / push-to-main / release
     needs: [check-open-pr]
@@ -56,5 +54,3 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/unit_test
-        with:
-          uv_version: ${{ vars.UV_VERSION }}

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: ${{ vars.UV_VERSION }}
           enable-cache: false
 
       - name: Validate tag and version match
@@ -115,7 +114,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: ${{ vars.UV_VERSION }}
           enable-cache: false
       - name: Download the provenance bundle from the publish job
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- the rich dependency floor rises to 13.4, the oldest release whose forced-color rendering produces the styling the weight tree view relies on
+- the minimum rich version is bumped to 13.4; older releases did not render the weight tree view's styling correctly
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- the rich dependency floor rises to 13.4, the oldest release whose forced-color rendering produces the styling the weight tree view relies on
+
 ### Deprecated
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ dependencies = [
     "pydantic>=2.7; python_version < '3.13'",
     "pydantic>=2.9; python_version == '3.13'",
     "pydantic>=2.12; python_version >= '3.14'",
-    "rich>=13.0.0",
+    # 13.4 floor: the weight tree view relies on FORCE_COLOR producing ANSI styling in captured
+    # (non-tty) output, which older rich does not honor
+    "rich>=13.4.0",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/uv.lock
+++ b/uv.lock
@@ -288,7 +288,7 @@ requires-dist = [
     { name = "pydantic", marker = "python_full_version < '3.13'", specifier = ">=2.7" },
     { name = "pydantic", marker = "python_full_version == '3.13.*'", specifier = ">=2.9" },
     { name = "pydantic", marker = "python_full_version >= '3.14'", specifier = ">=2.12" },
-    { name = "rich", specifier = ">=13.0.0" },
+    { name = "rich", specifier = ">=13.4.0" },
 ]
 provides-extras = ["benchmarking", "cli", "numba"]
 


### PR DESCRIPTION
**Problem**: The test matrix tops out at released Pythons, so a 3.15 incompatibility — most acutely a new `math` function that the patching partition (`_PATCHES` / `_UNCOUNTED_MATH` / `_MATH_NOT_PATCHED`) would not classify — surfaces only when 3.15 ships and users hit it.

**Solution**: A `python_next` job beside the test matrix: base install (numba wheels trail new CPythons by months) on `3.15` pre-releases via uv, ubuntu-arm. Non-blocking by construction: the test step's `continue-on-error` keeps the job — and with it the PR checks roll-up — green, with a failure surfacing as a warning annotation; the coverage gate does not depend on it; and it uploads no coverage data, so the cumulative floor unions supported versions only. Classifiers and `.python-versions` stay untouched until 3.15 is actually supported.

- **Attention:** review follow-up broadened the scope: every `setup-uv` call site now floats to the latest uv — the out-of-tree pinned variable had rotted silently, which is exactly what hid 3.15's pre-releases. The SHA-pinned, dependabot-bumped action remains the security anchor; the now-unused `UV_VERSION` repository variable can be deleted in Settings.
- **Attention:** floating uv immediately exposed a latent defect: the declared `rich>=13.0.0` floor was never exercised (the previously pinned uv resolved lowest-direct to rich 14.x), and rich 13.3 ignores `FORCE_COLOR` in captured output, breaking the weight tree view's styling. The floor rises to 13.4.0 — bisected as the oldest release that renders correctly — and the lockfile is regenerated.
- **TEST:** the leg runs a real interpreter today (3.15.0a2), and its suite failure — five new `math` callables not yet classified — appears as the designed warning annotation while every check stays green.

**Changelog** (Changed):
```
- the minimum rich version is bumped to 13.4; older releases did not render the weight tree view's styling correctly
```


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
