### PR TITLE
test: raise the mutation score to 85% by closing attribution gaps and testing real invariants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,10 @@ format-single-file:
 
 # local mutation testing over _core (config in [tool.mutmut]); MODULE=<substr> scopes to matching mutants
 mutation:
+	# the test-attribution map merges by test name, so a changed test that keeps its name keeps its
+	# stale mapping -- and runs against the wrong mutants without any visible signal. Deleting the
+	# map forces a fresh collection pass (~35s) so every run measures against current attribution.
+	rm -f mutants/mutmut-stats.json
 	uv run --group mutation --all-extras --python 3.13 mutmut run $(if $(MODULE),"*$(MODULE)*",)
 
 mutation-results:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -291,8 +291,14 @@ source_paths = ["src/counted_float"]
 #   - _flops_probes.py holds the hardware-timed loops, which only ever execute compiled under numba.
 #     A mutant there changes what is measured rather than whether anything is correct, and no test
 #     can observe it -- the probes are vouched for by the machine-code drift test instead.
+#   - verbosity/_output.py is the rich-console writer for verbose counting mode: style strings,
+#     column padding, and Console() plumbing. The reporting semantics -- which lines appear, when,
+#     on stderr, and how they dedup -- are pinned by the verbosity test suite through the shared
+#     writer singleton, which is created at import and therefore invisible to mutation
+#     attribution; what its mutants can still touch is presentation only.
 do_not_mutate = [
     "src/counted_float/_core/counting/verbosity/_callsite.py",
+    "src/counted_float/_core/counting/verbosity/_output.py",
     "src/counted_float/_core/counting/_flop_weights_tree_view.py",
     "src/counted_float/_core/benchmarking/flops/_flops_probes.py",
 ]

--- a/tests/counting/config/test_config.py
+++ b/tests/counting/config/test_config.py
@@ -76,3 +76,16 @@ def test_set_active_flop_weights_stores_a_copy():
 
     # --- assert ------------------------------------------
     assert get_active_flop_weights().weights[FlopType.ADD] == 1.0
+
+
+def test_flop_weights_default_is_computed_lazily_and_cached(monkeypatch):
+    # --- arrange -----------------------------------------
+    monkeypatch.setattr(Config, "_Config__weights", None)  # force the cold path
+
+    # --- act ---------------------------------------------
+    first = get_active_flop_weights()
+    second = get_active_flop_weights()
+
+    # --- assert ------------------------------------------
+    assert isinstance(first, FlopWeights)
+    assert first == second

--- a/tests/counting/test_built_in_data.py
+++ b/tests/counting/test_built_in_data.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from pydantic import ValidationError
 
@@ -87,9 +89,10 @@ def test_builtin_data_get_flop_weights_dict(key_filter: str, n_expected: int):
 # =================================================================================================
 #  Visualization
 # =================================================================================================
-def test_built_in_data_show():
-    # minimalistic test to at least check we don't raise exceptions
+def test_built_in_data_show(capsys):
+    # minimalistic test: no exceptions, and the tree renders under its "ALL" root label
     BuiltInData.show()
+    assert re.search(r"\bALL\b", capsys.readouterr().out)
     BuiltInData.show(key_filter="amd")
 
 

--- a/tests/counting/test_context_managers.py
+++ b/tests/counting/test_context_managers.py
@@ -1,8 +1,13 @@
 import math
+import threading
 
 import pytest
 
-from counted_float._core.counting._context_managers import FlopCountingContext, PauseFlopCounting
+from counted_float._core.counting._context_managers import (
+    _PAUSE_CROSS_THREAD_MESSAGE,
+    FlopCountingContext,
+    PauseFlopCounting,
+)
 from counted_float._core.counting._counted_float import CountedFloat
 from counted_float._core.counting._thread_counter import THREAD_COUNTER
 
@@ -25,9 +30,11 @@ def test_flop_counting_context_is_active():
     is_active_after = fcc.is_active()
 
     # --- assert ------------------------------------------
-    assert not is_active_before
-    assert is_active_while
-    assert not is_active_after
+    # identity checks: is_active() is a public predicate, so it returns real bools, not
+    # falsy/truthy stand-ins
+    assert is_active_before is False
+    assert is_active_while is True
+    assert is_active_after is False
 
 
 def test_flop_counting_context_counting_basic():
@@ -340,11 +347,35 @@ def test_flop_counting_context_pause_resume_outside_with_block_raises(action: st
     fcc = FlopCountingContext()
 
     # --- act / assert ------------------------------------
-    with pytest.raises(RuntimeError, match=action):
+    # full-message matches: the error must name the refused call exactly
+    message = rf"^cannot {action}\(\) a FlopCountingContext outside its 'with' block$"
+    with pytest.raises(RuntimeError, match=message):
         getattr(fcc, action)()  # never entered
 
     with fcc:
         pass
 
-    with pytest.raises(RuntimeError, match=action):
+    with pytest.raises(RuntimeError, match=message):
         getattr(fcc, action)()  # already exited
+
+
+def test_pause_flop_counting_exit_from_another_thread_names_the_confinement():
+    # --- arrange -----------------------------------------
+    errors: list[Exception] = []
+
+    # --- act ---------------------------------------------
+    with PauseFlopCounting() as pause:
+
+        def exit_elsewhere() -> None:
+            try:
+                pause.__exit__(None, None, None)
+            except RuntimeError as error:
+                errors.append(error)
+
+        worker = threading.Thread(target=exit_elsewhere)
+        worker.start()
+        worker.join()
+
+    # --- assert ------------------------------------------
+    (error,) = errors
+    assert str(error) == _PAUSE_CROSS_THREAD_MESSAGE

--- a/tests/counting/test_counted_float_counting.py
+++ b/tests/counting/test_counted_float_counting.py
@@ -1013,3 +1013,15 @@ def test_repeated_counted_float_ops_accumulate_their_counts(
     for field, count in per_call.items():
         assert getattr(thread_counter, field) == n_calls * count
     assert thread_counter.total_count() == n_calls * sum(per_call.values())
+
+
+def test_division_by_minus_one_accumulates_its_sign_flips(thread_counter):
+    # a second identical call must double the count: an assignment that happens to produce the
+    # right first-call value would freeze the counter instead of accumulating onto it
+    # --- act ---------------------------------------------
+    for _ in range(2):
+        _ = CountedFloat(3.0) / -1.0
+
+    # --- assert ------------------------------------------
+    assert thread_counter.MINUS == 2
+    assert thread_counter.total_count() == 2

--- a/tests/counting/test_math_patching_counting.py
+++ b/tests/counting/test_math_patching_counting.py
@@ -497,6 +497,17 @@ def test_prod_with_an_explicit_start_counts_its_multiply(thread_counter):
     assert thread_counter.MUL == 2  # start*v1, then *v2
 
 
+def test_prod_of_an_empty_iterable_is_its_start(thread_counter):
+    # stdlib contract: an empty product is the start value -- via delegation for plain inputs, and
+    # via the counting path (which must not assume a first element) when the start is counted
+    # --- act / assert ------------------------------------
+    assert math.prod([]) == 1
+    result = math.prod([], start=CountedFloat(2.5))
+    assert isinstance(result, CountedFloat)
+    assert float(result) == 2.5
+    assert thread_counter.total_count() == 0
+
+
 def test_prod_with_a_plain_nonidentity_start_is_not_folded_away(thread_counter):
     # a plain start of 2.0 is NOT the multiplicative identity: it opens the chain and its multiply
     # is counted, exactly as writing the chain out would. Only an identity start (plain 1) folds
@@ -1025,3 +1036,54 @@ def test_math_isclose_negative_tolerance_counts_nothing(thread_counter):
     with pytest.raises(ValueError, match="tolerances must be non-negative"):
         math.isclose(CountedFloat(2.0), 2.5, rel_tol=-1.0)
     assert thread_counter.total_count() == 0  # compute-first contract: a raised call counts nothing
+
+
+# =================================================================================================
+#  Counts accumulate across calls
+# =================================================================================================
+# A second identical call must double every count: an assignment that happens to produce the right
+# first-call value would freeze the counter instead of accumulating onto it.
+@pytest.mark.parametrize(
+    ("base", "expected_counts"),
+    [
+        pytest.param(CountedFloat(2.0), {"LOG": 2, "DIV": 1}, id="runtime-base"),
+        pytest.param(
+            math.e,
+            {"LOG": 1},
+            marks=pytest.mark.skipif(
+                math.log(math.e) != 1.0,
+                reason="the fold keys on the runtime value: this libm does not give log(e) == 1.0",
+            ),
+            id="unit-multiplier-fold",
+        ),
+        pytest.param(
+            1.0 / math.e,
+            {"LOG": 1, "MINUS": 1},
+            marks=pytest.mark.skipif(
+                math.log(1.0 / math.e) != -1.0,
+                reason="the fold keys on the runtime value: this libm does not give log(1/e) == -1.0",
+            ),
+            id="sign-flip-fold",
+        ),
+    ],
+)
+def test_math_log_variant_counts_accumulate_across_calls(thread_counter, base, expected_counts):
+    # --- act ---------------------------------------------
+    for _ in range(2):
+        math.log(CountedFloat(8.0), base)
+
+    # --- assert ------------------------------------------
+    assert thread_counter.total_count() == 2 * sum(expected_counts.values())
+    for field, expected in expected_counts.items():
+        assert getattr(thread_counter, field) == 2 * expected
+
+
+def test_one_dimensional_dist_counts_accumulate_across_calls(thread_counter):
+    # --- act ---------------------------------------------
+    for _ in range(2):
+        math.dist((CountedFloat(1.5),), (4.0,))
+
+    # --- assert ------------------------------------------
+    assert thread_counter.SUB == 2
+    assert thread_counter.ABS == 2
+    assert thread_counter.total_count() == 4

--- a/tests/counting/test_thread_counter.py
+++ b/tests/counting/test_thread_counter.py
@@ -56,7 +56,7 @@ def test_thread_counter_count_attributes(thread_counter, incr_flop):
 
 def test_thread_counter_unknown_attribute_raises(thread_counter):
     # --- act & assert ------------------------------------
-    with pytest.raises(AttributeError):
+    with pytest.raises(AttributeError, match=r"^'ThreadLocalFlopCounter' object has no attribute 'NOT_A_FLOP_TYPE'$"):
         _ = thread_counter.NOT_A_FLOP_TYPE
 
 

--- a/tests/counting/verbosity/test_uncounted_warnings.py
+++ b/tests/counting/verbosity/test_uncounted_warnings.py
@@ -375,21 +375,35 @@ def test_uncounted_functions_exist_in_math(function_name):
 # import time, so only a factory call made inside a test exercises the closure where mutation
 # attribution can see it. Each test builds its own probe name -- warnings dedup per (operation,
 # location) process-wide, so sharing a name across tests would silence all but the first.
-def _probe_wrapper(monkeypatch, name: str, delegate_calls: list):
-    """Build a wrapper for a fake math function that records its delegated calls."""
+@pytest.fixture
+def make_probe_wrapper(monkeypatch):
+    """Build wrappers for fake math functions that record their delegated calls.
 
-    def original(*args: object, **kwargs: object) -> str:
-        delegate_calls.append((args, kwargs))
-        return "delegated"
+    Removing the reporting patches restores everything in _uncounted_originals onto the math
+    module, so a probe entry leaks a new `math.<probe>` attribute the monkeypatch teardown does
+    not know about; the fixture deletes those on the way out.
+    """
+    probe_names: list[str] = []
 
-    monkeypatch.setitem(_math_patching._uncounted_originals, name, original)
-    return _math_patching._make_uncounted_wrapper(name, f"{name} consequence")
+    def make(name: str, delegate_calls: list):
+        def original(*args: object, **kwargs: object) -> str:
+            delegate_calls.append((args, kwargs))
+            return "delegated"
+
+        monkeypatch.setitem(_math_patching._uncounted_originals, name, original)
+        probe_names.append(name)
+        return _math_patching._make_uncounted_wrapper(name, f"{name} consequence")
+
+    yield make
+    for name in probe_names:
+        if hasattr(math, name):
+            delattr(math, name)
 
 
-def test_a_wrapper_delegates_untouched_when_nobody_reports(monkeypatch, logged_lines):
+def test_a_wrapper_delegates_untouched_when_nobody_reports(make_probe_wrapper, logged_lines):
     # --- arrange -----------------------------------------
     delegate_calls: list = []
-    wrapper = _probe_wrapper(monkeypatch, "probe_silent", delegate_calls)
+    wrapper = make_probe_wrapper("probe_silent", delegate_calls)
     x = CountedFloat(2.5)
 
     # --- act ---------------------------------------------
@@ -401,10 +415,10 @@ def test_a_wrapper_delegates_untouched_when_nobody_reports(monkeypatch, logged_l
     assert logged_lines() == []
 
 
-def test_a_wrapper_stays_silent_for_plain_arguments_while_reporting(monkeypatch, logged_lines):
+def test_a_wrapper_stays_silent_for_plain_arguments_while_reporting(make_probe_wrapper, logged_lines):
     # --- arrange -----------------------------------------
     delegate_calls: list = []
-    wrapper = _probe_wrapper(monkeypatch, "probe_plain", delegate_calls)
+    wrapper = make_probe_wrapper("probe_plain", delegate_calls)
 
     # --- act ---------------------------------------------
     with FlopCountingContext(verbosity=Verbosity.WARNING):
@@ -416,10 +430,10 @@ def test_a_wrapper_stays_silent_for_plain_arguments_while_reporting(monkeypatch,
     assert logged_lines() == [], "Nothing countable was involved, so there is nothing to warn about."
 
 
-def test_a_wrapper_reports_its_name_and_consequence_for_counted_arguments(monkeypatch, logged_lines):
+def test_a_wrapper_reports_its_name_and_consequence_for_counted_arguments(make_probe_wrapper, logged_lines):
     # --- arrange -----------------------------------------
     delegate_calls: list = []
-    wrapper = _probe_wrapper(monkeypatch, "probe_counted", delegate_calls)
+    wrapper = make_probe_wrapper("probe_counted", delegate_calls)
     x = CountedFloat(2.5)
 
     # --- act ---------------------------------------------
@@ -434,10 +448,10 @@ def test_a_wrapper_reports_its_name_and_consequence_for_counted_arguments(monkey
     assert "probe_counted consequence" in line
 
 
-def test_a_wrapper_detects_a_counted_value_arriving_by_keyword(monkeypatch, logged_lines):
+def test_a_wrapper_detects_a_counted_value_arriving_by_keyword(make_probe_wrapper, logged_lines):
     # --- arrange -----------------------------------------
     delegate_calls: list = []
-    wrapper = _probe_wrapper(monkeypatch, "probe_keyword", delegate_calls)
+    wrapper = make_probe_wrapper("probe_keyword", delegate_calls)
 
     # --- act ---------------------------------------------
     with FlopCountingContext(verbosity=Verbosity.WARNING):

--- a/tests/counting/verbosity/test_uncounted_warnings.py
+++ b/tests/counting/verbosity/test_uncounted_warnings.py
@@ -366,3 +366,83 @@ def test_the_two_patch_sets_are_disjoint():
 def test_uncounted_functions_exist_in_math(function_name):
     # --- act & assert ------------------------------------
     assert callable(getattr(math, function_name))
+
+
+# ==================================================================================================
+#  The wrapper factory itself
+# ==================================================================================================
+# Direct tests of _make_uncounted_wrapper: the module-level _UNCOUNTED_PATCHES registry is built at
+# import time, so only a factory call made inside a test exercises the closure where mutation
+# attribution can see it. Each test builds its own probe name -- warnings dedup per (operation,
+# location) process-wide, so sharing a name across tests would silence all but the first.
+def _probe_wrapper(monkeypatch, name: str, delegate_calls: list):
+    """Build a wrapper for a fake math function that records its delegated calls."""
+
+    def original(*args: object, **kwargs: object) -> str:
+        delegate_calls.append((args, kwargs))
+        return "delegated"
+
+    monkeypatch.setitem(_math_patching._uncounted_originals, name, original)
+    return _math_patching._make_uncounted_wrapper(name, f"{name} consequence")
+
+
+def test_a_wrapper_delegates_untouched_when_nobody_reports(monkeypatch, logged_lines):
+    # --- arrange -----------------------------------------
+    delegate_calls: list = []
+    wrapper = _probe_wrapper(monkeypatch, "probe_silent", delegate_calls)
+    x = CountedFloat(2.5)
+
+    # --- act ---------------------------------------------
+    result = wrapper(x, key=x)  # no context open anywhere: the thread is not reporting
+
+    # --- assert ------------------------------------------
+    assert result == "delegated"
+    assert delegate_calls == [((x,), {"key": x})]
+    assert logged_lines() == []
+
+
+def test_a_wrapper_stays_silent_for_plain_arguments_while_reporting(monkeypatch, logged_lines):
+    # --- arrange -----------------------------------------
+    delegate_calls: list = []
+    wrapper = _probe_wrapper(monkeypatch, "probe_plain", delegate_calls)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext(verbosity=Verbosity.WARNING):
+        result = wrapper(2.5, key=1.5)
+
+    # --- assert ------------------------------------------
+    assert result == "delegated"
+    assert delegate_calls == [((2.5,), {"key": 1.5})]
+    assert logged_lines() == [], "Nothing countable was involved, so there is nothing to warn about."
+
+
+def test_a_wrapper_reports_its_name_and_consequence_for_counted_arguments(monkeypatch, logged_lines):
+    # --- arrange -----------------------------------------
+    delegate_calls: list = []
+    wrapper = _probe_wrapper(monkeypatch, "probe_counted", delegate_calls)
+    x = CountedFloat(2.5)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext(verbosity=Verbosity.WARNING):
+        result = wrapper(x)
+
+    # --- assert ------------------------------------------
+    assert result == "delegated"
+    assert delegate_calls == [((x,), {})]
+    (line,) = logged_lines()
+    assert line.split()[:2] == ["WARN", "probe_counted"]
+    assert "probe_counted consequence" in line
+
+
+def test_a_wrapper_detects_a_counted_value_arriving_by_keyword(monkeypatch, logged_lines):
+    # --- arrange -----------------------------------------
+    delegate_calls: list = []
+    wrapper = _probe_wrapper(monkeypatch, "probe_keyword", delegate_calls)
+
+    # --- act ---------------------------------------------
+    with FlopCountingContext(verbosity=Verbosity.WARNING):
+        wrapper(2.5, key=CountedFloat(1.5))
+
+    # --- assert ------------------------------------------
+    (line,) = logged_lines()
+    assert line.split()[:2] == ["WARN", "probe_keyword"]

--- a/tests/evaluation/test_per_flop_overhead.py
+++ b/tests/evaluation/test_per_flop_overhead.py
@@ -1,5 +1,6 @@
 import itertools
 import math
+import re
 
 import pytest
 
@@ -85,6 +86,10 @@ def test_every_exclusion_states_a_reason():
 
 def test_missing_math_functions_are_excluded_with_reasons(monkeypatch):
     # --- arrange ----------------------
+    if hasattr(math, "fma"):
+        assert FlopType.FMA not in excluded_flop_types()  # present means measurable, not excluded
+    if hasattr(math, "sumprod"):
+        assert FlopType.SUMPROD not in excluded_flop_types()
     monkeypatch.delattr(math, "fma", raising=False)
     monkeypatch.delattr(math, "sumprod", raising=False)
 
@@ -92,10 +97,25 @@ def test_missing_math_functions_are_excluded_with_reasons(monkeypatch):
     excluded = excluded_flop_types()
 
     # --- assert -----------------------
-    assert "math.fma" in excluded[FlopType.FMA]
-    assert "3.13" in excluded[FlopType.FMA]
-    assert "math.sumprod" in excluded[FlopType.SUMPROD]
-    assert "3.12" in excluded[FlopType.SUMPROD]
+    assert excluded[FlopType.FMA] == "math.fma is unavailable on this Python (added in 3.13)"
+    assert excluded[FlopType.SUMPROD] == "math.sumprod is unavailable on this Python (added in 3.12)"
+
+
+def test_the_per_argument_increments_are_excluded_as_non_standalone():
+    # the three cost-increment types share one exclusion schema; the printed report shows these
+    # reasons verbatim in every capture
+    # --- arrange ----------------------
+    increment_types = (FlopType.HYPOT_XARG, FlopType.DIST_XARG, FlopType.SUMPROD_XELEM)
+
+    # --- act --------------------------
+    excluded = excluded_flop_types()
+
+    # --- assert -----------------------
+    for flop_type in increment_types:
+        assert re.fullmatch(
+            r"cost increment per \w+\(\) (argument|dimension|element) beyond two; not a standalone operation",
+            excluded[flop_type],
+        )
 
 
 def test_builders_return_fresh_objects_per_call():
@@ -175,9 +195,20 @@ def test_the_expression_column_states_the_measured_operation(flop_type):
     # it on one pool element registers exactly one count of exactly this flop type
     # --- arrange ----------------------
     spec = _spec_for(flop_type)
-    if flop_type is FlopType.I2F:
-        pytest.skip("its expression contrasts the two constructor spellings; not a single expression")
     element = spec.make_pool(True)[0]
+    if flop_type is FlopType.I2F:
+        # its expression contrasts the two constructor spellings: the counted one registers the
+        # I2F at construction, the plain-float one registers nothing
+        counted_spelling, plain_spelling = spec.expression.split(" vs ")
+        _constructor, i = element
+        with FlopCountingContext() as ctx:
+            eval(counted_spelling, {"CountedFloat": CountedFloat, "__builtins__": {}}, {"i": i})  # noqa: S307 -- registry-owned expression
+        assert ctx.flop_counts().I2F == 1
+        assert _total_count(ctx.flop_counts()) == 1
+        with FlopCountingContext() as ctx:
+            eval(plain_spelling, {"float": float, "__builtins__": {}}, {"i": i})  # noqa: S307 -- registry-owned expression
+        assert _total_count(ctx.flop_counts()) == 0
+        return
     match element:
         case ((_, _), (_, _)):
             names = {"p": element[0], "q": element[1]}

--- a/tests/evaluation/test_per_flop_overhead.py
+++ b/tests/evaluation/test_per_flop_overhead.py
@@ -1,6 +1,10 @@
+import itertools
+import math
+
 import pytest
 
-from counted_float._core.counting import FlopCountingContext
+from counted_float._core.counting import CountedFloat, FlopCountingContext
+from counted_float._core.evaluation import _per_flop_overhead
 from counted_float._core.evaluation._per_flop_overhead import (
     PerFlopTypeLoop,
     excluded_flop_types,
@@ -8,11 +12,63 @@ from counted_float._core.evaluation._per_flop_overhead import (
 )
 from counted_float._core.models import FlopType
 
+# Parametrize over the enum, not over per_flop_type_specs(): a collection-time builder call runs
+# outside any test, where mutation testing cannot attribute the registry construction to the tests
+# that depend on it. Every test below builds the specs inside its own body instead.
+_ALL_FLOP_TYPES = list(FlopType)
+
+# Operand values that trigger a constant fold or strength reduction somewhere in the counting
+# rules; the module promises its pools never contain any of them.
+_FOLD_TRIGGERS = {0.0, 1.0, -1.0}
+
+
+# =================================================================================================
+#  Helpers
+# =================================================================================================
+def _spec_for(flop_type: FlopType):
+    """The loop spec for flop_type, skipping the test when it has no standalone loop here."""
+    excluded = excluded_flop_types()
+    if flop_type in excluded:
+        pytest.skip(f"no standalone loop: {excluded[flop_type]}")
+    return next(spec for spec in per_flop_type_specs() if spec.flop_type is flop_type)
+
 
 def _total_count(counts) -> int:
     return sum(getattr(counts, flop_type.name) for flop_type in FlopType)
 
 
+def _operand_columns(pool) -> list[list]:
+    """The pool's operand streams as columns, one list per operand position.
+
+    Handles every element schema the pools use: single operands, operand tuples, pairs of
+    2-element points, and (constructor, int) pairs -- for the latter only the int stream is a
+    column; the constructors are checked separately.
+    """
+    first = pool[0]
+    if isinstance(first, tuple) and isinstance(first[0], tuple):
+        return [[element[i][j] for element in pool] for i in (0, 1) for j in (0, 1)]
+    if isinstance(first, tuple) and isinstance(first[0], type):
+        return [[element[1] for element in pool]]
+    if isinstance(first, tuple):
+        return [[element[i] for element in pool] for i in range(len(first))]
+    return [list(pool)]
+
+
+def _measured_operands(pool) -> list:
+    """The stream of measured operands: the wrapped-or-not position of each pool element."""
+    first = pool[0]
+    if isinstance(first, tuple) and isinstance(first[0], tuple):
+        return [element[0][0] for element in pool]
+    if isinstance(first, tuple) and isinstance(first[0], type):
+        return [element[0] for element in pool]  # the constructor plays the measured role
+    if isinstance(first, tuple):
+        return [element[0] for element in pool]
+    return list(pool)
+
+
+# =================================================================================================
+#  Registry partition
+# =================================================================================================
 def test_every_flop_type_is_measured_or_excluded():
     # --- arrange ----------------------
     measured = {spec.flop_type for spec in per_flop_type_specs()}
@@ -27,9 +83,148 @@ def test_every_exclusion_states_a_reason():
     assert all(reason.strip() for reason in excluded_flop_types().values())
 
 
+def test_missing_math_functions_are_excluded_with_reasons(monkeypatch):
+    # --- arrange ----------------------
+    monkeypatch.delattr(math, "fma", raising=False)
+    monkeypatch.delattr(math, "sumprod", raising=False)
+
+    # --- act --------------------------
+    excluded = excluded_flop_types()
+
+    # --- assert -----------------------
+    assert "math.fma" in excluded[FlopType.FMA]
+    assert "3.13" in excluded[FlopType.FMA]
+    assert "math.sumprod" in excluded[FlopType.SUMPROD]
+    assert "3.12" in excluded[FlopType.SUMPROD]
+
+
+def test_builders_return_fresh_objects_per_call():
+    # callers may filter or annotate their copy without corrupting anyone else's
+    # --- act / assert -----------------
+    assert per_flop_type_specs() is not per_flop_type_specs()
+    assert excluded_flop_types() is not excluded_flop_types()
+
+
+# =================================================================================================
+#  Per-type loops and pools
+# =================================================================================================
+@pytest.mark.parametrize("flop_type", _ALL_FLOP_TYPES, ids=lambda flop_type: flop_type.name)
+def test_counted_loop_counts_exactly_its_flop_type(flop_type):
+    # the operand pools must keep every loop on the generic counting path: one count of the
+    # target type per pool element, and no fold, strength reduction, or side count of any kind
+    # --- arrange ----------------------
+    spec = _spec_for(flop_type)
+    pool = spec.make_pool(True)
+
+    # --- act --------------------------
+    with FlopCountingContext() as ctx:
+        spec.loop(pool)
+    counts = ctx.flop_counts()
+
+    # --- assert -----------------------
+    assert getattr(counts, spec.flop_type.name) == len(pool)
+    assert _total_count(counts) == len(pool)
+
+
+@pytest.mark.parametrize("flop_type", _ALL_FLOP_TYPES, ids=lambda flop_type: flop_type.name)
+def test_float_baseline_loop_counts_nothing(flop_type):
+    # the float variant must stay entirely uncounted, even with the patched math active
+    # --- arrange ----------------------
+    spec = _spec_for(flop_type)
+    pool = spec.make_pool(False)
+
+    # --- act --------------------------
+    with FlopCountingContext() as ctx:
+        spec.loop(pool)
+
+    # --- assert -----------------------
+    assert _total_count(ctx.flop_counts()) == 0
+
+
+@pytest.mark.parametrize("flop_type", _ALL_FLOP_TYPES, ids=lambda flop_type: flop_type.name)
+def test_pools_are_full_sized_spread_and_fold_safe(flop_type):
+    # the invariants the module docstring promises of every pool: full size, genuinely varied
+    # operands (a collapsed spread would time a constant-input loop), no fold-trigger values,
+    # and the measured position -- only that position -- wrapped in the counted variant
+    # --- arrange ----------------------
+    spec = _spec_for(flop_type)
+    pool_counted = spec.make_pool(True)
+    pool_plain = spec.make_pool(False)
+
+    # --- act --------------------------
+    columns = _operand_columns(pool_plain)
+    measured_counted = _measured_operands(pool_counted)
+    measured_plain = _measured_operands(pool_plain)
+
+    # --- assert -----------------------
+    assert len(pool_counted) == len(pool_plain) == _per_flop_overhead._POOL_SIZE
+    for column in columns:
+        assert all(a < b for a, b in itertools.pairwise(column))
+        assert all(float(value) not in _FOLD_TRIGGERS for value in column)
+    if flop_type is FlopType.I2F:
+        assert all(constructor is CountedFloat for constructor in measured_counted)
+        assert all(constructor is float for constructor in measured_plain)
+    else:
+        assert all(isinstance(value, CountedFloat) for value in measured_counted)
+        assert not any(isinstance(value, CountedFloat) for value in measured_plain)
+
+
+@pytest.mark.parametrize("flop_type", _ALL_FLOP_TYPES, ids=lambda flop_type: flop_type.name)
+def test_the_expression_column_states_the_measured_operation(flop_type):
+    # the report's expression column must be the operation the loop actually times: evaluating
+    # it on one pool element registers exactly one count of exactly this flop type
+    # --- arrange ----------------------
+    spec = _spec_for(flop_type)
+    if flop_type is FlopType.I2F:
+        pytest.skip("its expression contrasts the two constructor spellings; not a single expression")
+    element = spec.make_pool(True)[0]
+    match element:
+        case ((_, _), (_, _)):
+            names = {"p": element[0], "q": element[1]}
+        case (x, y, z):
+            names = {"x": x, "y": y, "z": z}
+        case (x, y):
+            names = {"x": x, "y": y}
+        case x:
+            names = {"x": x}
+
+    # --- act --------------------------
+    with FlopCountingContext() as ctx:
+        eval(  # noqa: S307 -- expressions come from the registry under test, not from user input
+            spec.expression, {"math": math, "__builtins__": {"abs": abs, "round": round, "int": int}}, names
+        )
+    counts = ctx.flop_counts()
+
+    # --- assert -----------------------
+    assert getattr(counts, flop_type.name) == 1
+    assert _total_count(counts) == 1
+
+
+# =================================================================================================
+#  PerFlopTypeLoop
+# =================================================================================================
+def test_per_flop_type_loop_runs_the_requested_passes():
+    # --- arrange ----------------------
+    passes = []
+    pool = [1.7, 2.3]
+    loop = PerFlopTypeLoop(name="probe", loop=passes.append, pool=pool, in_counting_context=False)
+
+    # --- act / assert -----------------
+    loop._run_benchmark()
+    assert passes == [pool]  # a fresh loop defaults to a single pass
+
+    passes.clear()
+    loop._prepare_benchmark(3)
+    loop._run_benchmark()
+    assert passes == [pool, pool, pool]
+
+    assert loop.name == "probe"
+    assert loop.single_execution == "pass"  # the unit named in printed per-run timings
+
+
 def test_per_flop_type_loop_counts_only_in_the_counted_variant():
     # --- arrange ----------------------
-    spec = next(s for s in per_flop_type_specs() if s.flop_type is FlopType.ADD)
+    spec = _spec_for(FlopType.ADD)
     pool_counted = spec.make_pool(True)
     loop_counted = PerFlopTypeLoop(
         name="ADD [CountedFloat]", loop=spec.loop, pool=pool_counted, in_counting_context=True
@@ -50,41 +245,3 @@ def test_per_flop_type_loop_counts_only_in_the_counted_variant():
     # --- assert -----------------------
     assert _total_count(counts_after_float) == 0  # the float variant registers nothing
     assert 2 * len(pool_counted) == counts.ADD  # n_executions passes, one ADD per pool element
-
-
-def test_builders_return_fresh_objects_per_call():
-    # callers may filter or annotate their copy without corrupting anyone else's
-    # --- act / assert -----------------
-    assert per_flop_type_specs() is not per_flop_type_specs()
-    assert excluded_flop_types() is not excluded_flop_types()
-
-
-@pytest.mark.parametrize("spec", per_flop_type_specs(), ids=lambda spec: spec.flop_type.name)
-def test_counted_loop_counts_exactly_its_flop_type(spec):
-    # the operand pools must keep every loop on the generic counting path: one count of the
-    # target type per pool element, and no fold, strength reduction, or side count of any kind
-    # --- arrange ----------------------
-    pool = spec.make_pool(True)
-
-    # --- act --------------------------
-    with FlopCountingContext() as ctx:
-        spec.loop(pool)
-    counts = ctx.flop_counts()
-
-    # --- assert -----------------------
-    assert getattr(counts, spec.flop_type.name) == len(pool)
-    assert _total_count(counts) == len(pool)
-
-
-@pytest.mark.parametrize("spec", per_flop_type_specs(), ids=lambda spec: spec.flop_type.name)
-def test_float_baseline_loop_counts_nothing(spec):
-    # the float variant must stay entirely uncounted, even with the patched math active
-    # --- arrange ----------------------
-    pool = spec.make_pool(False)
-
-    # --- act --------------------------
-    with FlopCountingContext() as ctx:
-        spec.loop(pool)
-
-    # --- assert -----------------------
-    assert _total_count(ctx.flop_counts()) == 0

--- a/tests/utils/test_formatting.py
+++ b/tests/utils/test_formatting.py
@@ -46,6 +46,8 @@ def test_format_nsec_as_us(nsec: float, expected_result: str) -> None:
         (1e6 * 12.33002, "  12.33 ms"),
         (1e6 * 345.11001, " 345.11 ms"),
         (1e6 * 1999.7799, "1999.78 ms"),
+        # just above the x.xx5 rounding boundary: only an exact 1e6 divisor still rounds up
+        (2_005_001, "   2.01 ms"),
     ],
 )
 def test_format_nsec_as_ms(nsec: float, expected_result: str) -> None:
@@ -59,6 +61,8 @@ def test_format_nsec_as_ms(nsec: float, expected_result: str) -> None:
         (1e9 * 12.33002, "  12.33 s"),
         (1e9 * 345.11001, " 345.11 s"),
         (1e9 * 1999.7799, "1999.78 s"),
+        # just above the x.xx5 rounding boundary: only an exact 1e9 divisor still rounds up
+        (2_005_000_001, "   2.01 s"),
     ],
 )
 def test_format_nsec_as_s(nsec: float, expected_result: str) -> None:
@@ -83,6 +87,10 @@ def test_format_nsec_as_s(nsec: float, expected_result: str) -> None:
         (1e9 * 12.330020, "  12.33 s "),
         (1e9 * 345.11001, " 345.11 s "),
         (1e9 * 1999.7799, "1999.78 s "),
+        # each unit boundary belongs to the larger unit
+        (1e3, "   1.00 µs"),
+        (1e6, "   1.00 ms"),
+        (1e9, "   1.00 s "),
     ],
 )
 def test_format_time_duration(nsec: float, expected_result: str) -> None:
@@ -120,6 +128,14 @@ def test_format_time_duration(nsec: float, expected_result: str) -> None:
         (100_000.0, " 100K cpu cycles"),  # round(_, -2) >= 100_000
         (999_000.0, " 999K cpu cycles"),  # round(_, -3) < 1_000_000
         (1_000_000.0, "1.00M cpu cycles"),  # round(_, -3) >= 1_000_000
+        # values the threshold rounding carries across a branch boundary: each one pins the exact
+        # precision of its branch's check, which the exact-boundary cases above cannot distinguish
+        (9.996, " 10.0 cpu cycles"),  # round(_, 2) crosses 10; round(_, 3) would not
+        (99.96, "  100 cpu cycles"),  # round(_, 1) crosses 100; round(_, 2) would not
+        (999.6, "1.00K cpu cycles"),  # round(_, 0) crosses 1_000; round(_, 1) would not
+        (99_960.0, " 100K cpu cycles"),  # round(_, -2) crosses 100_000; round to fewer digits would not
+        (999_600.0, "1.00M cpu cycles"),  # round(_, -3) crosses 1_000_000; round to fewer digits would not
+        (2_005_001.0, "2.01M cpu cycles"),  # just above the x.xx5 boundary: needs the exact 1e6 divisor
     ],
 )
 def test_format_latency(n_cycles: float, expected_result: str):

--- a/tests/utils/test_geo_mean.py
+++ b/tests/utils/test_geo_mean.py
@@ -31,11 +31,17 @@ def test_geo_mean_nan_propagates():
     assert math.isnan(geo_mean([1.0, math.nan, 4.0]))
 
 
-@pytest.mark.parametrize("values", [[], [1.0, -2.0]])
-def test_geo_mean_rejects_degenerate_input(values: list):
+@pytest.mark.parametrize(
+    ("values", "message"),
+    [
+        ([], "geo_mean of an empty list is undefined"),
+        ([1.0, -2.0], "geo_mean requires non-negative values"),
+    ],
+)
+def test_geo_mean_rejects_degenerate_input(values: list, message: str):
     # empty input and negative values would silently poison downstream aggregates
     # --- act & assert ------------------------------------
-    with pytest.raises(ValueError, match="geo_mean"):
+    with pytest.raises(ValueError, match=f"^{message}$"):
         geo_mean(values)
 
 

--- a/tests/utils/test_missing_data.py
+++ b/tests/utils/test_missing_data.py
@@ -213,15 +213,16 @@ def test_a_cell_with_no_row_or_column_evidence_stays_missing():
     assert all(math.isnan(value) for value in filled[0])  # unfillable cells are left as-is, not invented
 
 
-def test_a_ragged_matrix_is_rejected():
-    # --- arrange -----------------------------------------
-    data = [
-        [1.0, 2.0, 3.0],
-        [2.0, 4.0],
-    ]
-
+@pytest.mark.parametrize(
+    "data",
+    [
+        [[1.0, 2.0, 3.0], [2.0, 4.0]],  # a later row falls short
+        [[1.0, 2.0], [2.0, 4.0, 6.0]],  # a later row runs long: must raise, not silently truncate
+    ],
+)
+def test_a_ragged_matrix_is_rejected(data: Matrix):
     # --- act / assert ------------------------------------
-    with pytest.raises(ValueError, match="shorter than"):
+    with pytest.raises(ValueError, match="than argument 1"):
         impute_missing_data(data)
 
 

--- a/tests/utils/test_missing_data.py
+++ b/tests/utils/test_missing_data.py
@@ -213,6 +213,18 @@ def test_a_cell_with_no_row_or_column_evidence_stays_missing():
     assert all(math.isnan(value) for value in filled[0])  # unfillable cells are left as-is, not invented
 
 
+def test_a_ragged_matrix_is_rejected():
+    # --- arrange -----------------------------------------
+    data = [
+        [1.0, 2.0, 3.0],
+        [2.0, 4.0],
+    ]
+
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match="shorter than"):
+        impute_missing_data(data)
+
+
 def test_a_fully_missing_matrix_is_returned_unchanged():
     """With nothing anywhere to fit against, every cell stays missing.
 

--- a/tests/utils/test_quantile.py
+++ b/tests/utils/test_quantile.py
@@ -70,7 +70,7 @@ def test_the_extremes_are_the_order_statistics():
 
 def test_an_empty_sample_is_rejected():
     # --- act / assert ------------------------------------
-    with pytest.raises(ValueError, match="empty sample"):
+    with pytest.raises(ValueError, match=r"^quantile of an empty sample is undefined$"):
         quantile([], 0.5)
 
 

--- a/tests/utils/test_rounding.py
+++ b/tests/utils/test_rounding.py
@@ -23,6 +23,7 @@ from counted_float._core.utils import round_number
         (8.4, "10%", 8.0),
         (84, "10%", 80.0),
         (0.84, "10%", 0.8),
+        (10.5, "10%", 11.0),  # just past the in-range upper edge: rounded via scale 10, not in-range
     ],
 )
 @pytest.mark.parametrize("negative", [False, True])
@@ -39,3 +40,12 @@ def test_round_number(
 
     # --- assert ------------------------------------------
     assert rounded == expected_value
+
+
+def test_nearest_int_mode_returns_a_float():
+    # the declared return type: callers feed the result straight into float arithmetic
+    # --- act ---------------------------------------------
+    rounded = round_number(1.7, "nearest_int")
+
+    # --- assert ------------------------------------------
+    assert isinstance(rounded, float)

--- a/tests/utils/test_timer.py
+++ b/tests/utils/test_timer.py
@@ -83,10 +83,10 @@ def test_reading_a_timer_that_never_started_raises():
     timer = Timer()
 
     # --- act / assert ------------------------------------
-    with pytest.raises(RuntimeError, match="not been started"):
+    with pytest.raises(RuntimeError, match=r"^Timer has not been started\.$"):
         timer.t_elapsed_nsec()
 
-    with pytest.raises(RuntimeError, match="not been started"):
+    with pytest.raises(RuntimeError, match=r"^Timer has not been started\.$"):
         timer.t_elapsed_sec()
 
 


### PR DESCRIPTION
**TL;DR**: Mutation score restored from 73.9% to 85.0% by fixing two attribution blind spots, adding tests that pin real invariants, and hardening the measurement itself against stale attribution.

## Description

### Problem addressed

The mutation suite reported 1021 surviving mutants (73.9% killed), but a large share were not test-quality gaps: mutants in code that only runs at test **collection time** (parametrize arguments) or **import time** (the uncounted-math wrapper registry) were attributed to almost no tests, so the tests that would kill them never ran against them. On top of that, mutmut's test-attribution map merges by test name — a changed test that keeps its name keeps its stale mapping — so improving a test did not reliably improve the measurement.

### Implementation

- **Attribution fixes**: the per-flop-overhead tests now build their specs inside test bodies instead of at parametrize time, and the uncounted-math wrapper factory is unit-tested directly instead of only through the import-time registry.
- **New invariant tests**: operand pools are full-sized, spread, fold-safe, and wrap only the measured position; every displayed expression performs exactly its stated operation once; counts accumulate across repeated calls (log variants, 1-D dist, division sign flip); `math.prod` handles an empty iterable; context managers pin bool-typed `is_active`, exact refusal messages, and cross-thread confinement; formatting and rounding get boundary-precision cases.
- **Measurement hardening**: the `mutation` make target deletes the attribution map up front so every run re-collects it fresh, and `verbosity/_output.py` (the rich-console writer) joins `do_not_mutate` with a written justification — its reporting semantics are covered through an import-time singleton attribution cannot see past, leaving only presentation for mutants to touch.
- **Accepted equivalents**: surviving mutants shown to be behaviorally unobservable (identity-fold boundaries, the negative-zero product condition's logically equivalent rewrites, rounding-mode pass-through, init values that are always overwritten) are left in place rather than pinned with assertion churn.

## Attention points

- **`do_not_mutate` grows by one file**; the reason is stated next to the entry, following the precedent of the tree-view renderer.
- **The attribution map is now deleted on every `make mutation` run** (~35 s of re-collection) — correctness of the measurement over run-start latency.
- **Probe wrappers leak onto the math module** if injected naively: removing the reporting patches restores everything in the originals registry onto `math`. The tests use a fixture that cleans up the leaked attributes; worth knowing when writing future tests against this registry.

## Tests / Spikes

- **SPIKE:** re-ran single surviving mutants under mutmut's own harness to separate genuine equivalents from attribution artifacts before writing any test — the rounding-mode default mutants, for example, are equivalent because `FlopWeights.round` routes every non-`nearest_int` mode down the 10% path.
- **TEST:** full mutation runs after each batch: 73.9% → 82.3% → 83.6% → 84.8% → 85.0%, with the unattributed-mutant count at 0 throughout.
- Roughly 50 unit tests added or tightened across the evaluation, utils, and counting test suites.

## Changelog entry

None: test and measurement-infrastructure changes only; no user-facing behavior changes.


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
