### PR TITLE
docs: add citation metadata kept fresh by the release flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- citation metadata (CITATION.cff), with releases archived on Zenodo under a DOI
+
 ### Changed
 
 - the minimum rich version is bumped to 13.4; older releases did not render the weight tree view's styling correctly

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+# The version and date-released fields are refreshed by scripts/release.py at every release,
+# so this file always cites the latest published version.
+cff-version: 1.2.0
+message: "If you use this software, please cite it using the metadata from this file."
+type: software
+title: "counted-float"
+abstract: "Count floating-point operations in Python code & benchmark relative flop costs."
+authors:
+  - family-names: Pluymers
+    given-names: Bert
+license: Apache-2.0
+repository-code: "https://github.com/bertpl/counted-float"
+version: 2.3.0
+date-released: 2026-08-02

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -30,6 +30,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 CHANGELOG = REPO_ROOT / "CHANGELOG.md"
 README = REPO_ROOT / "README.md"
+CITATION = REPO_ROOT / "CITATION.cff"
 PYTHON_VERSIONS_FILE = REPO_ROOT / ".python-versions"
 SPLASH_SCRIPT = REPO_ROOT / ".github" / "scripts" / "create_splash.sh"
 SPLASH_WEBP = REPO_ROOT / "images" / "splash_with_version.webp"
@@ -435,6 +436,22 @@ def refresh_readme_badges(version: str, badges: BadgeMetrics) -> None:
     README.write_text(_stamp_badge_provenance(text, version))
 
 
+def refresh_citation(version: str) -> None:
+    """Stamp the release version and date into CITATION.cff.
+
+    Refreshed at release time like the badges, so the committed citation metadata always names
+    the latest published version instead of going stale.
+    """
+    text = CITATION.read_text()
+    text, n_version = re.subn(r"^version: .*$", f"version: {version}", text, flags=re.MULTILINE)
+    text, n_date = re.subn(
+        r"^date-released: .*$", f"date-released: {date.today().isoformat()}", text, flags=re.MULTILINE
+    )
+    if n_version != 1 or n_date != 1:
+        fail_with_message("CITATION.cff is missing its 'version:' or 'date-released:' field")
+    CITATION.write_text(text)
+
+
 def stamp_splash(version: str) -> None:
     """Stamp the release version onto the committed splash webp (needs ImageMagick).
 
@@ -448,11 +465,12 @@ def stamp_splash(version: str) -> None:
 
 
 def step_10_commit_release(version: str, badges: BadgeMetrics) -> None:
-    """Refresh README badges, stamp the splash, then create the release commit."""
-    print_step(10, f"refresh README badges + stamp splash + commit 'release: {version}'")
+    """Refresh README badges and CITATION.cff, stamp the splash, then create the release commit."""
+    print_step(10, f"refresh README badges + CITATION.cff + stamp splash + commit 'release: {version}'")
     refresh_readme_badges(version, badges)
+    refresh_citation(version)
     stamp_splash(version)
-    run_command(["git", "add", "CHANGELOG.md", "README.md", str(SPLASH_WEBP)])
+    run_command(["git", "add", "CHANGELOG.md", "README.md", "CITATION.cff", str(SPLASH_WEBP)])
     run_command(["git", "commit", "-m", f"release: {version}"])
 
 

--- a/tests/docs/test_citation_drift.py
+++ b/tests/docs/test_citation_drift.py
@@ -1,0 +1,35 @@
+"""CITATION.cff must cite the latest released version, exactly as the changelog records it.
+
+Both files are stamped by the release flow in the same commit; this pins that they cannot drift
+apart between releases (e.g. through a hand edit to either file).
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CITATION = REPO_ROOT / "CITATION.cff"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+
+def _citation_field(name: str) -> str:
+    """The value of a top-level `name:` field in CITATION.cff."""
+    match = re.search(rf"^{name}: (.+)$", CITATION.read_text(), re.MULTILINE)
+    assert match, f"CITATION.cff has no '{name}:' field"
+    return match.group(1).strip()
+
+
+def _latest_changelog_release() -> tuple[str, str]:
+    """The (version, date) of the newest dated version section in CHANGELOG.md."""
+    match = re.search(r"^## (\d+\.\d+\.\d+) \((\d{4}-\d{2}-\d{2})\)$", CHANGELOG.read_text(), re.MULTILINE)
+    assert match, "CHANGELOG.md has no dated version section"
+    return match.group(1), match.group(2)
+
+
+def test_citation_cites_the_latest_released_version():
+    # --- arrange / act -------------------------
+    version, released = _latest_changelog_release()
+
+    # --- assert --------------------------------
+    assert _citation_field("version") == version
+    assert _citation_field("date-released") == released


### PR DESCRIPTION
**Problem**: The package is research-facing but provides no citation metadata: GitHub shows no "Cite this repository", and there is no stable identifier for a paper to point at.

**Solution**: CITATION.cff carries the citation fields (authors, license, repository, version, release date). release.py stamps the version and release date at every release, alongside the badges, so the file cannot go stale; a drift test pins it to the changelog's newest release section. Zenodo archiving of releases (minting a DOI) rides on this file — its GitHub integration reads CITATION.cff for deposit metadata, so no `.zenodo.json` is needed.

- **Attention:** the file ships without a DOI — the concept DOI does not exist until Zenodo archives the first release, and gets backfilled (badge + `identifiers:`) in a follow-up docs change right after.
- **Attention:** enabling the Zenodo–GitHub integration is a manual maintainer action, required before the next release so that release becomes the first archived deposit.
- **SPIKE:** confirmed via Zenodo's help center that the GitHub integration reads CITATION.cff for release metadata, with `.zenodo.json` only as an explicit override.
- **TEST:** exercised the release-flow refresh against a copy of the file (version and date both stamped correctly); one drift test added.

**Changelog** (Added):
```
- citation metadata (CITATION.cff), with releases archived on Zenodo under a DOI
```


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
