### PR TITLE
docs: backfill the Zenodo concept DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,6 +9,12 @@ authors:
   - family-names: Pluymers
     given-names: Bert
 license: Apache-2.0
+identifiers:
+  # the concept DOI, resolving to the latest archived version -- stable across releases, unlike
+  # the per-version DOIs Zenodo mints alongside it
+  - type: doi
+    value: 10.5281/zenodo.21780137
+    description: "The concept DOI of this software; resolves to the latest archived version."
 repository-code: "https://github.com/bertpl/counted-float"
 version: 2.3.1
 date-released: 2026-08-03

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Mutation](https://img.shields.io/badge/mutmut-85%25-brightgreen)](https://pypi.org/project/mutmut/)
 [![Docs](https://img.shields.io/readthedocs/counted-float)](https://counted-float.readthedocs.io/)
 [![PyPI](https://img.shields.io/pypi/v/counted-float.svg)](https://pypi.org/project/counted-float/)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21780137.svg)](https://doi.org/10.5281/zenodo.21780137)
 [![Python](https://img.shields.io/pypi/pyversions/counted-float.svg)](https://pypi.org/project/counted-float/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/bertpl/counted-float/blob/main/LICENSE)
 [![code style: ruff](https://img.shields.io/badge/code%20style-ruff-261230)](https://github.com/astral-sh/ruff)


### PR DESCRIPTION
**Problem**: The citation metadata shipped without a DOI — the concept DOI did not exist until Zenodo archived the first release (v2.3.1, deposit 10.5281/zenodo.21780138).

**Solution**: CITATION.cff carries the concept DOI (10.5281/zenodo.21780137) under `identifiers:`, and the README badge row links it. The concept DOI resolves to the latest archived version, so neither spot needs a per-release refresh — only the version and date fields do, which the release flow already stamps.

**Changelog** (none): None: the citation-metadata entry already shipped with 2.3.1; this completes it with the identifier that could only exist after that release.


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
