### PR TITLE
feat: count the five math callables Python 3.15 adds

### DIFF
--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -57,12 +57,13 @@ jobs:
   # Early warning on the next CPython, non-blocking: a base install on the upcoming minor, so an
   # incompatible pre-release -- most acutely a new `math` function the patching partition would not
   # classify -- fails visibly here months before that Python ships, instead of on users at release.
-  # Three things keep it from blocking anything: the test step's continue-on-error keeps the job
-  # (and so the PR checks roll-up) green, with a failure surfacing as a warning annotation instead
-  # of a red cross; the coverage job does not depend on it; and it uploads no coverage data (the
-  # cumulative floor unions supported versions only). Base install because numba wheels trail new
-  # CPythons by months. Bump the version here when the next pre-release series opens; classifiers
-  # and .python-versions stay untouched until the version is actually supported.
+  # What keeps it from blocking is the test step's continue-on-error, which holds the job (and so
+  # the PR checks roll-up) green, a failure surfacing as a warning annotation instead of a red
+  # cross. It does feed the coverage combine: version-gated code whose only home is this
+  # interpreter has no other leg to be covered from, and the cumulative floor admits no exceptions.
+  # Base install because numba wheels trail new CPythons by months. Bump the version here when the
+  # next pre-release series opens; classifiers and .python-versions stay untouched until the
+  # version is actually supported.
   python_next:
     name: py3.15-pre / highest / extras-false / ubuntu-24.04-arm (non-blocking)
     runs-on: ubuntu-24.04-arm
@@ -84,6 +85,7 @@ jobs:
         with:
           python_version: "3.15"
           include_all_extra_deps: "false"
+          coverage: "true"
       - name: Surface a test failure as a warning annotation
         if: steps.tests.outcome == 'failure'
         run: echo "::warning title=py3.15-pre leg failed::the next CPython's pre-release broke the suite -- early warning only, nothing is blocked"
@@ -93,7 +95,9 @@ jobs:
     # Cumulative gate: combine every combo's data into one picture before
     # checking the floor, so version-/dependency-divergent code paths (only hit
     # on some combos) don't read as uncovered.
-    needs: [core]
+    # python_next only sequences the download behind that leg's upload; whether it *succeeded* is
+    # not gated here, since it is the one leg allowed to fail.
+    needs: [core, python_next]
     # always() so a cancelled/failed combo makes this job FAIL explicitly rather
     # than skip — GitHub doesn't reliably propagate a cancelled leg through needs.
     if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- on Python 3.15, the new `math` callables are counted: `fmax`/`fmin` (COMP each), `isnormal`/`issubnormal` (ABS + 2 COMP each) and `signbit` (COMP)
+
 ### Changed
 
 ### Deprecated

--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -138,6 +138,12 @@ text) and `as_integer_ratio()` (a bit-field read plus an integer shift) count no
 it — carries a benchmarked weight: the boundary is the *domain of the operation*, not
 whether its machine code looks like manipulation or computation.
 
+Within the domain, the same boundary cuts once more: priced is the work the operation does,
+never machinery a float-only *spelling* of it would need. `math.signbit` counts the single
+test its question is (COMP), not the `copysign(1.0, x) < 0.0` contortion that smuggles
+`-0.0`'s sign into comparable form — a spelling the [author](#convention-2-two-actors-build-the-port)
+would never write, having C's `signbit` to hand.
+
 The same precondition places Python's other numeric types outside the model:
 `decimal.Decimal` and `fractions.Fraction` are software towers a compiled port has no
 counterpart for, so nothing about them is priced. Converting one into the counting model
@@ -260,6 +266,10 @@ operation's documented defining formula instead.**
 - **3.1** ***(procedure)*** — the formula is **transcribed symbol by symbol** into FlopTypes, each
   occurrence priced exactly once: `|·|` → ABS, `max`/`min` → COMP (the model's price for
   them everywhere), arithmetic and comparisons → their types.
+    - The price is shared, the operation is not: `math.fmax` / `math.fmin` are a different
+      value function from the builtins — they return the non-NaN operand where `max`/`min`
+      propagate the NaN — and are priced COMP as the compare-and-select a port emits, not
+      as a spelling of the builtins.
     - A formula contains no guards, no short-circuits and no adaptive machinery, so none
       are priced — the transcription is fixed per call *by construction*, charged
       whatever branch the implementation actually takes, and unconditioned on argument
@@ -376,6 +386,17 @@ table). Most follow rule 1 at the operation level; `math.fsum`, `round(x, n)` an
   equality and infinity guards, the short-circuit savings, and the implementation's
   weak-test respelling (which multiplies twice where the formula's max-then-multiply does
   once).
+- **The float classifiers**, each priced as the FP-canonical form of the question it asks:
+  `math.isnan` → COMP (`x != x`), `math.isinf` → ABS + COMP (`|x| = ∞`), `math.isfinite` →
+  ABS + COMP (`|x| < ∞`), `math.isnormal` → ABS + 2 COMP (`DBL_MIN ≤ |x| ≤ DBL_MAX`),
+  `math.issubnormal` → ABS + 2 COMP (`0 < |x| < DBL_MIN`), `math.signbit` → COMP (no FP form
+  to transcribe — see [What the model prices](#what-the-model-prices) — so only the exit
+  every classifier pays for its `bool`). The canonical form is priced whatever integer-domain
+  lowering a compiler picks, as everywhere in the domain: `math.isfinite` compiles to pure
+  integer tests on both priced architectures and counts ABS + COMP all the same. Stated gap
+  for the two range predicates: the price is fixed per call because the port is branchless,
+  so it exceeds what the equivalent Python spelling counts on the inputs where a chained
+  comparison short-circuits (zeros, subnormals, NaN).
 
 `math.dist` and n-ary `math.hypot` are *not* decompositions: they count the dedicated
 `DIST` + (n−2) `DIST_XARG` and `HYPOT` + (n−2) `HYPOT_XARG` types, measured on the real

--- a/docs/cost_model.md
+++ b/docs/cost_model.md
@@ -138,12 +138,6 @@ text) and `as_integer_ratio()` (a bit-field read plus an integer shift) count no
 it — carries a benchmarked weight: the boundary is the *domain of the operation*, not
 whether its machine code looks like manipulation or computation.
 
-Within the domain, the same boundary cuts once more: priced is the work the operation does,
-never machinery a float-only *spelling* of it would need. `math.signbit` counts the single
-test its question is (COMP), not the `copysign(1.0, x) < 0.0` contortion that smuggles
-`-0.0`'s sign into comparable form — a spelling the [author](#convention-2-two-actors-build-the-port)
-would never write, having C's `signbit` to hand.
-
 The same precondition places Python's other numeric types outside the model:
 `decimal.Decimal` and `fractions.Fraction` are software towers a compiled port has no
 counterpart for, so nothing about them is priced. Converting one into the counting model
@@ -266,10 +260,6 @@ operation's documented defining formula instead.**
 - **3.1** ***(procedure)*** — the formula is **transcribed symbol by symbol** into FlopTypes, each
   occurrence priced exactly once: `|·|` → ABS, `max`/`min` → COMP (the model's price for
   them everywhere), arithmetic and comparisons → their types.
-    - The price is shared, the operation is not: `math.fmax` / `math.fmin` are a different
-      value function from the builtins — they return the non-NaN operand where `max`/`min`
-      propagate the NaN — and are priced COMP as the compare-and-select a port emits, not
-      as a spelling of the builtins.
     - A formula contains no guards, no short-circuits and no adaptive machinery, so none
       are priced — the transcription is fixed per call *by construction*, charged
       whatever branch the implementation actually takes, and unconditioned on argument
@@ -324,7 +314,7 @@ rule that governs it, and — for grey-zone cases — why the choice is what it 
 | [`ATAN2`](machine_code/atan2.md) | `f_add_atan2` − `f_add` | 2, 4 |  |
 | [`ATANH`](machine_code/atanh.md) | `f_add_halfsin_atanh` − `f_add_halfsin` | 2 |  |
 | [`CBRT`](machine_code/cbrt.md) | `f_add_cbrt` − `f_add` | 2 | numba's `np.cbrt` wraps the libm call in NaN/sign handling CPython's `math.cbrt` never executes, so the probe calls libm through a ctypes binding -- the bare call CPython executes |
-| [`COMP`](machine_code/comp.md) | `f_lte_addsub` − `f_add` | 1 | the subtrahend is the ADD/SUB average, and the branchy source compiles branchless -- the weight prices compare-and-select machinery, matching what float comparisons cost in optimized code |
+| [`COMP`](machine_code/comp.md) | `f_lte_addsub` − `f_add` | 1 | the subtrahend is the ADD/SUB average, and the branchy source compiles branchless -- the weight prices compare-and-select machinery, matching what float comparisons cost in optimized code. `math.fmax`/`fmin` reuse this weight: their port -- the IEEE max/min instruction (ARM's `fmaxnm`/`fminnm`) -- is one instruction of the same compare-select class, the same reuse as `math.fabs` -> ABS. They stay a different value function from the builtin `min`/`max` (NaN-quieting selection vs a comparison chain returning whichever operand survives, order-dependent under NaN): shared machinery, and so a shared price, not shared semantics |
 | [`COPYSIGN`](machine_code/copysign.md) | `f_add_copysign` − `f_add` | 1 |  |
 | [`COS`](machine_code/cos.md) | `f_add_cos` − `f_add` | 2, 4 |  |
 | [`COSH`](machine_code/cosh.md) | `f_add_acosh_cosh` − `f_add_acosh` | 2, 4 |  |
@@ -389,9 +379,10 @@ table). Most follow rule 1 at the operation level; `math.fsum`, `round(x, n)` an
 - **The float classifiers**, each priced as the FP-canonical form of the question it asks:
   `math.isnan` → COMP (`x != x`), `math.isinf` → ABS + COMP (`|x| = ∞`), `math.isfinite` →
   ABS + COMP (`|x| < ∞`), `math.isnormal` → ABS + 2 COMP (`DBL_MIN ≤ |x| ≤ DBL_MAX`),
-  `math.issubnormal` → ABS + 2 COMP (`0 < |x| < DBL_MIN`), `math.signbit` → COMP (no FP form
-  to transcribe — see [What the model prices](#what-the-model-prices) — so only the exit
-  every classifier pays for its `bool`). The canonical form is priced whatever integer-domain
+  `math.issubnormal` → ABS + 2 COMP (`0 < |x| < DBL_MIN`), `math.signbit` → COMP — its only
+  faithful float spelling, `copysign(1.0, x) < 0.0`, needs the copysign solely to make
+  `-0.0`'s sign visible to a comparison; that is machinery of the *spelling*, not work the
+  operation does, so only the bool-exit compare is priced. The canonical form is priced whatever integer-domain
   lowering a compiler picks, as everywhere in the domain: `math.isfinite` compiles to pure
   integer tests on both priced architectures and counts ABS + COMP all the same. Stated gap
   for the two range predicates: the price is fixed per call because the port is branchless,

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -124,7 +124,7 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
       isolate the sign of `y`, merge)
 - **Counted Python operations:** `math.copysign(x, y)` where `x` or `y` is a `CountedFloat`
   (and only there — `math.signbit`, which reads the same bit, counts COMP instead: see
-  [what the model prices](cost_model.md#what-the-model-prices))
+  [the decomposed operations](cost_model.md#decomposed-operations))
 - **Not counted:** copysign on non-CountedFloat, numpy copysign
 - **Note:** same sign-bit instruction class as ABS and MINUS, but 1–3 ops depending on
   architecture — which is why it is measured as its own benchmarked flop type rather than

--- a/docs/flop_types.md
+++ b/docs/flop_types.md
@@ -49,6 +49,7 @@ documented fallback) are stated in [Cost-model principles](cost_model.md).
 | `math.gamma`/`lgamma(x)` | `GAMMA`, `LGAMMA` | patch | benchmarked | yes |
 | `math.erf`/`erfc(x)` | `ERF`, `ERFC` | patch | benchmarked | yes |
 | `math.copysign(x, y)` | `COPYSIGN` | patch | benchmarked | yes |
+| `math.fmax(x, y)`, `math.fmin(x, y)` (3.15+) | `COMP` (the NaN-quieting guard is unpriced) | patch | ISA | yes — unlike the builtins, whichever operand wins |
 | `math.degrees(x)`, `math.radians(x)` | `MUL` *(decomposed)* | patch | — | yes |
 | `math.dist(p, q)` | `DIST` + (n−2) `DIST_XARG` (1-D → `SUB + ABS`) | patch | benchmarked | yes |
 | `math.prod(xs)` | one `MUL` per chained multiply *(decomposed)* | patch | — | yes |
@@ -100,8 +101,9 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
     - **x86:** `ANDPD`
 - **Counted Python operations:** `abs(x)` and `math.fabs(x)` where `x` is a
   `CountedFloat` (both map to the same `FABS`/`ANDPD` instruction); one ABS
-  inside `math.isinf` / `math.isfinite` (the classifier's `fabs`-then-compare)
-  and three inside `math.isclose`'s core
+  inside `math.isinf` / `math.isfinite` (the classifier's `fabs`-then-compare),
+  one inside `math.isnormal` / `math.issubnormal` (the magnitude their range
+  test takes once) and three inside `math.isclose`'s core
 - **Not counted:** `numpy.abs`, `numpy.fabs`, complex abs, abs on non-CountedFloat
 - **Weight measurement:** [the machine code behind the `ABS` weight](machine_code/abs.md)
 
@@ -121,6 +123,8 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
     - **x86:** `ANDPD` + `ANDPD` + `ORPD` (no dedicated instruction: clear the sign of `x`,
       isolate the sign of `y`, merge)
 - **Counted Python operations:** `math.copysign(x, y)` where `x` or `y` is a `CountedFloat`
+  (and only there — `math.signbit`, which reads the same bit, counts COMP instead: see
+  [what the model prices](cost_model.md#what-the-model-prices))
 - **Not counted:** copysign on non-CountedFloat, numpy copysign
 - **Note:** same sign-bit instruction class as ABS and MINUS, but 1–3 ops depending on
   architecture — which is why it is measured as its own benchmarked flop type rather than
@@ -134,9 +138,12 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
     - **ARM:** `FCMP`
     - **x86:** `(U)COMISD`
 - **Counted Python operations:** `x == y`, `x != y`, `x <= y`, ... and
-  `min(x,y)`, `max(x,y)` for `CountedFloat`; the float classifiers —
+  `min(x,y)`, `max(x,y)` for `CountedFloat`; the selections `math.fmax(x,y)` /
+  `math.fmin(x,y)` (the compare-and-select a port emits); the float classifiers —
   `math.isnan` (the self-compare a port emits), one COMP inside `math.isinf` /
-  `math.isfinite`, three inside `math.isclose`'s core, and `is_integer()`'s
+  `math.isfinite`, two inside `math.isnormal` / `math.issubnormal` (their two
+  range bounds), one for `math.signbit` (the sole charge: its question has no FP
+  form to decompose), three inside `math.isclose`'s core, and `is_integer()`'s
   compare
 - **Not counted:** Comparisons on non-CountedFloat, numpy comparisons, and
   truthiness (`bool(x)`, `if x:`, `assert x`) — a deliberate, labeled exception.
@@ -145,10 +152,12 @@ decomposes for bases other than 2/10 — see `FlopType.LOG` below.
   entirely, so a truthiness count would price interpreter bookkeeping and vary
   with interpreter flags — no port-faithful count does either. Write an
   algorithmic zero-test as `x != 0.0` to have it counted
-- **Note:** `min`/`max` return the winning operand *object*, not a `bool` —
-  with mixed counted/plain arguments the winner may be the plain constant,
-  which ends countedness; see
-  [known limitations](known_limitations.md#other-limitations)
+- **Note:** the *builtin* `min`/`max` return the winning operand *object*, not a
+  `bool` — with mixed counted/plain arguments the winner may be the plain
+  constant, which ends countedness; see
+  [known limitations](known_limitations.md#other-limitations). `math.fmax` /
+  `math.fmin` are not affected: they build a fresh result, which the patch wraps,
+  so countedness survives whichever operand wins
 - **Weight measurement:** [the machine code behind the `COMP` weight](machine_code/comp.md)
 
 ## FlopType.RND (`round`) { #flop-rnd }

--- a/docs/math_patching.md
+++ b/docs/math_patching.md
@@ -70,7 +70,7 @@ Every commonly used `math` function, and how it participates in counting:
 <!-- BEGIN generated: math-coverage-table -->
 | Coverage | Functions |
 |---|---|
-| **Instrumented** (patched, counts its FlopType) | `sqrt`, `cbrt`, `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `pow`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `hypot` (+ `HYPOT_XARG` per coordinate beyond the second), `dist` (+ `DIST_XARG` likewise), `fmod`, `remainder`, `gamma`, `lgamma`, `erf`, `erfc`, `fabs`, `copysign`, `isnan` (COMP — the self-compare a port emits), `isinf` (ABS + COMP), `isfinite` (ABS + COMP), `isclose` (SUB + 3 ABS + MUL + 3 COMP — the transcription of its documented formula; the guards, short-circuit savings and the implementation's respelling are a stated gap), `fma` (Python 3.13+), `sumprod` (Python 3.12+; + `SUMPROD_XELEM` per element beyond the second — counted inputs are unboxed so the extended-precision algorithm runs) |
+| **Instrumented** (patched, counts its FlopType) | `sqrt`, `cbrt`, `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `pow`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `hypot` (+ `HYPOT_XARG` per coordinate beyond the second), `dist` (+ `DIST_XARG` likewise), `fmod`, `remainder`, `gamma`, `lgamma`, `erf`, `erfc`, `fabs`, `copysign`, `fmax` (Python 3.15+; COMP — the compare-and-select a port emits), `fmin` (Python 3.15+; COMP likewise), `isnan` (COMP — the self-compare a port emits), `isinf` (ABS + COMP), `isfinite` (ABS + COMP), `isnormal` (Python 3.15+; ABS + 2 COMP — the FP-canonical `DBL_MIN ≤ |x| ≤ DBL_MAX`; the Python spelling's short-circuit on zeros, subnormals and NaN is a stated gap), `issubnormal` (Python 3.15+; ABS + 2 COMP — likewise, for `0 < |x| < DBL_MIN`), `signbit` (Python 3.15+; COMP — the float-domain exit alone: the copysign its faithful float spelling needs is machinery of the spelling, not work the operation does), `isclose` (SUB + 3 ABS + MUL + 3 COMP — the transcription of its documented formula; the guards, short-circuit savings and the implementation's respelling are a stated gap), `fma` (Python 3.13+), `sumprod` (Python 3.12+; + `SUMPROD_XELEM` per element beyond the second — counted inputs are unboxed so the extended-precision algorithm runs) |
 | **Instrumented, counted as a decomposition** (patched, counts the flops a compiled port would execute) | `degrees` / `radians` → MUL; `prod` → one MUL per chained multiply; `fsum` → (n−1) ADD; 1-argument `hypot` → ABS; 1-D `dist` → SUB + ABS |
 | **Counted via dunder** (no patch needed — do not expect these in the patch list) | `math.floor` / `math.ceil` / `math.trunc` → F2I through `__floor__`/`__ceil__`/`__trunc__`; the builtins `abs()` → ABS and `round()` → RND/F2I likewise count through their dunders |
 | **Not instrumented** (returns a plain, uncounted `float`) | exactly the float-representation helpers — `frexp`, `ldexp`, `modf`, `nextafter`, `ulp` |
@@ -85,12 +85,18 @@ While a context is open, the reduction patches (`fsum`, `prod`, `sumprod`,
 computing the result — a space-behavior divergence from the streaming stdlib
 versions; see [Known limitations](known_limitations.md).
 
-The float-classification calls (`isnan`, `isinf`, `isfinite`, `isclose`) return a
-`bool`, so contagion does not apply to them — but they count all the same: a
-compiled port emits real compare machinery for each, the same work the operator
-spellings (`x != x`, `x != 0.0`) have always counted. The one comparison left
-uncounted is truthiness (`bool(x)`, `if x:`), a labeled exception — the
-interpreter inserts it implicitly, with no opt-out — documented with the
+The float-classification calls (`isnan`, `isinf`, `isfinite`, `isnormal`,
+`issubnormal`, `signbit`, `isclose`) return a `bool`, so contagion does not apply
+to them — but they count all the same: a compiled port emits real compare
+machinery for each, and each is priced as the FP-canonical form of the question it
+asks. For `isnan` that form *is* an operator spelling a reader could have written
+(`x != x`) and the counts coincide; where the form is a range test the price is
+fixed per call while the Python spelling short-circuits, so `isnormal` and
+`issubnormal` charge more than the hand-written chain does on zeros, subnormals and
+NaN — a stated gap, listed with them in
+[the decomposed operations](cost_model.md#decomposed-operations). The one
+comparison left uncounted is truthiness (`bool(x)`, `if x:`), a labeled exception —
+the interpreter inserts it implicitly, with no opt-out — documented with the
 [`COMP` type](flop_types.md#flop-comp).
 
 Rather than checking this table against your code by hand, you can have a counting

--- a/scripts/generate_docs_content.py
+++ b/scripts/generate_docs_content.py
@@ -278,20 +278,32 @@ def generate_builtin_data_table() -> str:
 # instrumented buckets, so patching something new breaks this generator until its row is decided --
 # which is what keeps the table from drifting behind the code.
 #
-# The two arity-parametric and two version-gated entries carry a note; the rest render bare.
+# The arity-parametric, version-gated and decomposed-into-more-than-one-type entries carry a note;
+# the rest render bare.
 _MATH_INSTRUMENTED_ORDER = [
     "sqrt", "cbrt", "exp", "exp2", "expm1", "log", "log2", "log10", "log1p", "pow",
     "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "sinh", "cosh", "tanh",
     "asinh", "acosh", "atanh", "hypot", "dist", "fmod", "remainder", "gamma", "lgamma",
-    "erf", "erfc", "fabs", "copysign", "isnan", "isinf", "isfinite", "isclose", "fma",
-    "sumprod",
+    "erf", "erfc", "fabs", "copysign", "fmax", "fmin", "isnan", "isinf", "isfinite",
+    "isnormal", "issubnormal", "signbit", "isclose", "fma", "sumprod",
 ]  # fmt: skip
 _MATH_INSTRUMENTED_NOTES = {
     "hypot": "(+ `HYPOT_XARG` per coordinate beyond the second)",
     "dist": "(+ `DIST_XARG` likewise)",
+    "fmax": "(Python 3.15+; COMP — the compare-and-select a port emits)",
+    "fmin": "(Python 3.15+; COMP likewise)",
     "isnan": "(COMP — the self-compare a port emits)",
     "isinf": "(ABS + COMP)",
     "isfinite": "(ABS + COMP)",
+    "isnormal": (
+        "(Python 3.15+; ABS + 2 COMP — the FP-canonical `DBL_MIN ≤ |x| ≤ DBL_MAX`; the Python "
+        "spelling's short-circuit on zeros, subnormals and NaN is a stated gap)"
+    ),
+    "issubnormal": "(Python 3.15+; ABS + 2 COMP — likewise, for `0 < |x| < DBL_MIN`)",
+    "signbit": (
+        "(Python 3.15+; COMP — the float-domain exit alone: the copysign its faithful float "
+        "spelling needs is machinery of the spelling, not work the operation does)"
+    ),
     "isclose": (
         "(SUB + 3 ABS + MUL + 3 COMP — the transcription of its documented formula; the guards, "
         "short-circuit savings and the implementation's respelling are a stated gap)"
@@ -312,7 +324,7 @@ _MATH_DECOMPOSED_CELL = (
 )
 # registered conditionally by the patch table, so they are absent from it on an older interpreter
 # while still belonging in the committed table -- the note on each says from which version
-_MATH_VERSION_GATED = {"fma", "sumprod"}
+_MATH_VERSION_GATED = {"fma", "sumprod", "fmax", "fmin", "isnormal", "issubnormal", "signbit"}
 
 
 def _math_names_by_reason(reason: str) -> list[str]:

--- a/scripts/generate_machine_code_docs.py
+++ b/scripts/generate_machine_code_docs.py
@@ -228,7 +228,12 @@ PAGES: list[MachineCodePage] = [
         extended_probe="f_lte_addsub",
         rationale=(
             "the subtrahend is the ADD/SUB average, and the branchy source compiles branchless -- the weight prices "
-            "compare-and-select machinery, matching what float comparisons cost in optimized code"
+            "compare-and-select machinery, matching what float comparisons cost in optimized code. "
+            "`math.fmax`/`fmin` reuse this weight: their port -- the IEEE max/min instruction (ARM's "
+            "`fmaxnm`/`fminnm`) -- is one instruction of the same compare-select class, the same reuse as "
+            "`math.fabs` -> ABS. They stay a different value function from the builtin `min`/`max` (NaN-quieting "
+            "selection vs a comparison chain returning whichever operand survives, order-dependent under NaN): "
+            "shared machinery, and so a shared price, not shared semantics"
         ),
     ),
     MachineCodePage("copysign", kind=KIND_HARDWARE, base_probe="f_add", extended_probe="f_add_copysign"),

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -799,11 +799,12 @@ def math_copysign(x: float, y: float) -> float | CountedFloat:
 def math_fmax(x: float, y: float, /) -> float | CountedFloat:
     """Patch math.fmax: stdlib contract (NaN-quieting maximum), counted as one COMP.
 
-    A port selects the larger operand, which is the compare-and-select machinery the COMP
-    weight measures -- the price the model gives `min`/`max` everywhere. The two are different
-    value functions all the same: `math.fmax` returns the non-NaN operand where the builtin
-    `max` propagates the NaN, and they merely share the price. Stated gap: that NaN-quieting
-    clause is a guard, and guards go unpriced, so one COMP is charged on every regime.
+    A port emits the IEEE max instruction (ARM's `fmaxnm`) -- one instruction of the same
+    compare-select class the COMP weight measures, so the weight is reused, as `math.fabs`
+    reuses ABS. The builtin `max` shares that price while being a different value function:
+    a comparison chain returning whichever operand survives, order-dependent under NaN,
+    where fmax is the NaN-quieting selection. Stated gap: the NaN-quieting clause is a
+    guard, and guards go unpriced, so one COMP is charged on every regime.
 
     No constant fold applies at any operand value. The candidates all fail the sign- and
     nan-exactness test: `fmax(x, -inf)` is `x` for every x except a NaN, where it is `-inf`,

--- a/src/counted_float/_core/counting/_math_patching.py
+++ b/src/counted_float/_core/counting/_math_patching.py
@@ -58,7 +58,7 @@ from __future__ import annotations
 import math
 import threading
 from math import copysign as _copysign  # the raw builtin: math.copysign is patched inside contexts
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Never
 
 from ._counted_float import CountedFloat, count_pow_with_constant_base, count_pow_with_constant_exponent
 from ._thread_counter import _TLS, _create_thread_state, thread_is_reporting
@@ -70,25 +70,37 @@ if TYPE_CHECKING:
     from ._thread_counter import CountsTarget
 
 
-def _math_fma_unavailable(x: float, y: float, z: float) -> float:
-    """Stand-in for `math.fma` on interpreters predating it (below 3.13).
+def _unavailable_stand_in(name: str, minimum_version: str) -> Callable[..., Never]:
+    """Build the stand-in for a `math` function the running interpreter predates.
 
-    Never called: the counting replacement is registered only where `math.fma` exists (see
-    _PATCHES). It exists so the `original_math_fma` reference is callable on every supported
-    interpreter rather than `None`, which would make the patch's own call sites unsound.
+    None of these is ever called: a counting replacement is registered only where its `math`
+    function exists (see _PATCHES). They exist so every `original_math_*` reference is callable
+    on every supported interpreter rather than `None`, which would make the patches' own call
+    sites unsound. Returning `Never` is what lets one builder serve them all: the delegating
+    patches declare `float` and `bool` return types, and a call that cannot return satisfies
+    either.
+
+    Args:
+        name: Name of the `math` function that is missing here.
+        minimum_version: First Python version providing it, for the raised message.
+
+    Returns:
+        A replacement that raises `NotImplementedError` whatever it is passed.
     """
-    raise NotImplementedError("math.fma requires Python 3.13 or newer")
+
+    def stand_in(*args: object, **kwargs: object) -> Never:
+        raise NotImplementedError(f"math.{name} requires Python {minimum_version} or newer")
+
+    return stand_in
 
 
-def _math_sumprod_unavailable(p: Iterable[float], q: Iterable[float], /) -> float:
-    """Stand-in for `math.sumprod` on interpreters predating it (below 3.12).
-
-    Never called: the replacement is registered only where `math.sumprod` exists (see
-    _PATCHES). It exists so the `original_math_sumprod` reference is callable on every
-    supported interpreter rather than `None`, which would make the patch's own call sites
-    unsound.
-    """
-    raise NotImplementedError("math.sumprod requires Python 3.12 or newer")
+_math_sumprod_unavailable = _unavailable_stand_in("sumprod", "3.12")
+_math_fma_unavailable = _unavailable_stand_in("fma", "3.13")
+_math_fmax_unavailable = _unavailable_stand_in("fmax", "3.15")
+_math_fmin_unavailable = _unavailable_stand_in("fmin", "3.15")
+_math_isnormal_unavailable = _unavailable_stand_in("isnormal", "3.15")
+_math_issubnormal_unavailable = _unavailable_stand_in("issubnormal", "3.15")
+_math_signbit_unavailable = _unavailable_stand_in("signbit", "3.15")
 
 
 # -------------------------------------------------------------------------
@@ -148,6 +160,11 @@ original_math_erf = math.erf
 original_math_erfc = math.erfc
 original_math_remainder = math.remainder
 original_math_sumprod = getattr(math, "sumprod", _math_sumprod_unavailable)
+original_math_fmax = getattr(math, "fmax", _math_fmax_unavailable)
+original_math_fmin = getattr(math, "fmin", _math_fmin_unavailable)
+original_math_isnormal = getattr(math, "isnormal", _math_isnormal_unavailable)
+original_math_issubnormal = getattr(math, "issubnormal", _math_issubnormal_unavailable)
+original_math_signbit = getattr(math, "signbit", _math_signbit_unavailable)
 
 # sentinel for math_log's optional base argument; the stdlib signature is math.log(x[, base]),
 # where omitting base is not the same as passing any real value (and None is rejected)
@@ -779,6 +796,45 @@ def math_copysign(x: float, y: float) -> float | CountedFloat:
     return original_math_copysign(x, y)
 
 
+def math_fmax(x: float, y: float, /) -> float | CountedFloat:
+    """Patch math.fmax: stdlib contract (NaN-quieting maximum), counted as one COMP.
+
+    A port selects the larger operand, which is the compare-and-select machinery the COMP
+    weight measures -- the price the model gives `min`/`max` everywhere. The two are different
+    value functions all the same: `math.fmax` returns the non-NaN operand where the builtin
+    `max` propagates the NaN, and they merely share the price. Stated gap: that NaN-quieting
+    clause is a guard, and guards go unpriced, so one COMP is charged on every regime.
+
+    No constant fold applies at any operand value. The candidates all fail the sign- and
+    nan-exactness test: `fmax(x, -inf)` is `x` for every x except a NaN, where it is `-inf`,
+    and `fmax(x, nan)` leaves a signaling NaN quieted rather than untouched.
+    """
+    if isinstance(x, CountedFloat) or isinstance(y, CountedFloat):
+        result = original_math_fmax(x, y)
+        try:
+            _TLS.flop_counts.COMP += 1
+        except AttributeError:  # first counted op on this thread
+            _create_thread_state().COMP += 1
+        return float.__new__(CountedFloat, result)
+    return original_math_fmax(x, y)
+
+
+def math_fmin(x: float, y: float, /) -> float | CountedFloat:
+    """Patch math.fmin: stdlib contract (NaN-quieting minimum), counted as one COMP.
+
+    The mirror of math_fmax in every respect -- same canonical compare-and-select, same
+    unpriced NaN guard, same absence of folds.
+    """
+    if isinstance(x, CountedFloat) or isinstance(y, CountedFloat):
+        result = original_math_fmin(x, y)
+        try:
+            _TLS.flop_counts.COMP += 1
+        except AttributeError:  # first counted op on this thread
+            _create_thread_state().COMP += 1
+        return float.__new__(CountedFloat, result)
+    return original_math_fmin(x, y)
+
+
 def math_isnan(x: float) -> bool:
     """Patch math.isnan: counted as the one FP self-compare a port emits.
 
@@ -862,6 +918,67 @@ def math_isclose(a: float, b: float, **kwargs: float) -> bool:
         cnt.MUL += 1
         cnt.COMP += 3
     return result
+
+
+def math_isnormal(x: float, /) -> bool:
+    """Patch math.isnormal: counted ABS + 2 COMP, the FP-canonical `DBL_MIN <= fabs(x) <= DBL_MAX`.
+
+    Same pricing stance as isinf and isfinite: the FP-canonical instruction stream, whatever
+    integer-domain lowering a particular compiler picks. The upper bound is isfinite's own
+    test, so isnormal prices as isfinite plus the one comparison that separates normals from
+    subnormals, with the magnitude taken once. Stated gap: the price is fixed per call because
+    the port is branchless, so it over-charges the Python spelling on every input where the
+    chained comparison short-circuits (zeros, subnormals and NaN stop after one compare).
+    """
+    if isinstance(x, CountedFloat):
+        result = original_math_isnormal(x)
+        try:
+            cnt: CountsTarget = _TLS.flop_counts
+        except AttributeError:  # first counted op on this thread
+            cnt: CountsTarget = _create_thread_state()
+        cnt.ABS += 1
+        cnt.COMP += 2
+        return result
+    return original_math_isnormal(x)
+
+
+def math_issubnormal(x: float, /) -> bool:
+    """Patch math.issubnormal: counted ABS + 2 COMP, the FP-canonical `0.0 < fabs(x) < DBL_MIN`.
+
+    The mirror of isnormal on the other side of the same boundary: one magnitude and two
+    bounds, the lower one excluding zero (which is neither normal nor subnormal). Its stated
+    gap is isnormal's -- fixed per call against a spelling that short-circuits on zeros and NaN.
+    """
+    if isinstance(x, CountedFloat):
+        result = original_math_issubnormal(x)
+        try:
+            cnt: CountsTarget = _TLS.flop_counts
+        except AttributeError:  # first counted op on this thread
+            cnt: CountsTarget = _create_thread_state()
+        cnt.ABS += 1
+        cnt.COMP += 2
+        return result
+    return original_math_issubnormal(x)
+
+
+def math_signbit(x: float, /) -> bool:
+    """Patch math.signbit: counted as one COMP, the price of reading one bool off one float.
+
+    Alone among the classifiers this one has no FP decomposition to transcribe. `x < 0.0` is
+    not it -- `signbit(-0.0)` is True where the comparison is False -- and the only faithful
+    float spelling, `copysign(1.0, x) < 0.0`, needs its copysign solely to make the sign
+    visible to a comparison. That copysign is machinery the spelling needs, not work the
+    operation does, so it is not priced; what remains is the float-domain exit every classifier
+    pays for materializing its bool.
+    """
+    if isinstance(x, CountedFloat):
+        result = original_math_signbit(x)
+        try:
+            _TLS.flop_counts.COMP += 1
+        except AttributeError:  # first counted op on this thread
+            _create_thread_state().COMP += 1
+        return result
+    return original_math_signbit(x)
 
 
 # -------------------------------------------------------------------------
@@ -973,6 +1090,19 @@ if hasattr(math, "fma"):
 if hasattr(math, "sumprod"):
     # Python 3.12+ only; same conditional-registration reasoning as math.fma above.
     _PATCHES["sumprod"] = math_sumprod
+# The 3.15 additions, gated one by one on the same reasoning: a partition that is exact on
+# every interpreter needs each name registered where that name exists, not where its release
+# did.
+if hasattr(math, "fmax"):
+    _PATCHES["fmax"] = math_fmax
+if hasattr(math, "fmin"):
+    _PATCHES["fmin"] = math_fmin
+if hasattr(math, "isnormal"):
+    _PATCHES["isnormal"] = math_isnormal
+if hasattr(math, "issubnormal"):
+    _PATCHES["issubnormal"] = math_issubnormal
+if hasattr(math, "signbit"):
+    _PATCHES["signbit"] = math_signbit
 
 # Why each remaining public `math` callable needs no replacement of either kind.  Between this,
 # _PATCHES and _UNCOUNTED_MATH the whole module surface is accounted for, and a test holds them to

--- a/tests/counting/test_fresh_thread_first_op.py
+++ b/tests/counting/test_fresh_thread_first_op.py
@@ -150,7 +150,8 @@ def test_operator_first_op_on_fresh_thread(op_id: str, call: Callable[[], object
 #  Patched math.* functions
 # =================================================================================================
 # one in-domain call per registered patch, with CountedFloat args so counting actually fires;
-# fma/sumprod are listed unconditionally but only exercised where _PATCHES registers them
+# the version-gated entries are listed unconditionally but only exercised where _PATCHES
+# registers them
 _PATCH_ARGS: dict[str, tuple[object, ...]] = {
     "sqrt": (CF(2.0),),
     "cbrt": (CF(2.0),),
@@ -195,6 +196,11 @@ _PATCH_ARGS: dict[str, tuple[object, ...]] = {
     "isclose": (CF(2.0), CF(2.5)),
     "fma": (CF(2.0), CF(3.0), CF(4.0)),
     "sumprod": ([CF(2.0)], [CF(3.0)]),
+    "fmax": (CF(2.0), CF(3.0)),
+    "fmin": (CF(2.0), CF(3.0)),
+    "isnormal": (CF(2.0),),
+    "issubnormal": (CF(5e-324),),
+    "signbit": (CF(-2.0),),
 }
 
 

--- a/tests/counting/test_math_patching.py
+++ b/tests/counting/test_math_patching.py
@@ -140,17 +140,16 @@ def test_capture_originals_keeps_both_original_tables_in_sync():
 # =================================================================================================
 #  Version-gated stand-ins and teardown guard
 # =================================================================================================
-def test_fma_unavailable_stand_in_raises() -> None:
-    # the stand-in exists so original_math_fma is callable pre-3.13; calling it must raise
-    # --- act / assert ------------------------------------
-    with pytest.raises(NotImplementedError, match=r"math\.fma"):
-        _math_patching._math_fma_unavailable(1.0, 2.0, 3.0)
+@pytest.mark.parametrize("fname", ["sumprod", "fma", "fmax", "fmin", "isnormal", "issubnormal", "signbit"])
+def test_version_gated_stand_in_raises(fname: str) -> None:
+    # the stand-ins exist so every original_math_* is callable on an interpreter predating its
+    # function; calling one must raise rather than silently return a value
+    # --- arrange -----------------------------------------
+    stand_in = getattr(_math_patching, f"_math_{fname}_unavailable")
 
-
-def test_sumprod_unavailable_stand_in_raises() -> None:
     # --- act / assert ------------------------------------
-    with pytest.raises(NotImplementedError, match=r"math\.sumprod"):
-        _math_patching._math_sumprod_unavailable([1.0], [2.0])
+    with pytest.raises(NotImplementedError, match=rf"math\.{fname}"):
+        stand_in(1.0, 2.0, 3.0)
 
 
 def test_remove_uncounted_math_patches_is_a_noop_when_none_installed() -> None:

--- a/tests/counting/test_math_patching_counting.py
+++ b/tests/counting/test_math_patching_counting.py
@@ -1,4 +1,5 @@
 import math
+import sys
 
 import pytest
 
@@ -1036,6 +1037,144 @@ def test_math_isclose_negative_tolerance_counts_nothing(thread_counter):
     with pytest.raises(ValueError, match="tolerances must be non-negative"):
         math.isclose(CountedFloat(2.0), 2.5, rel_tol=-1.0)
     assert thread_counter.total_count() == 0  # compute-first contract: a raised call counts nothing
+
+
+# =================================================================================================
+#  Patched math functions - the Python 3.15 additions
+# =================================================================================================
+needs_py315_math = pytest.mark.skipif(
+    not hasattr(math, "fmax"),
+    reason="fmax/fmin/isnormal/issubnormal/signbit require Python 3.15+",
+)
+
+_PY315_NAMES = ["fmax", "fmin", "isnormal", "issubnormal", "signbit"]
+
+
+@pytest.mark.parametrize("fname", _PY315_NAMES)
+def test_py315_math_functions_registered_only_where_available(fname):
+    """Each 3.15 callable is patched exactly on the interpreters that have it, and never elsewhere."""
+    # --- act & assert ------------------------------------
+    assert (fname in _math_patching._PATCHES) == hasattr(math, fname)
+
+
+@needs_py315_math
+@pytest.mark.parametrize("fname", ["fmax", "fmin"])
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        (CountedFloat(2.0), CountedFloat(3.0)),
+        (CountedFloat(2.0), 3.0),
+        (2.0, CountedFloat(3.0)),
+        (CountedFloat(2.0), 3),
+        (CountedFloat(math.nan), 1.0),  # the NaN-quieting guard is unpriced: the same charge
+        (CountedFloat(0.0), -0.0),  # signed zeros likewise
+        (CountedFloat(-math.inf), 2.0),  # an infinite constant does not fold the selection away
+    ],
+    ids=repr,
+)
+def test_math_fmax_and_fmin_count_one_comp(thread_counter, fname, arguments):
+    # --- arrange -----------------------------------------
+    selector = getattr(math, fname)  # resolved inside the context, where the patch is installed
+
+    # --- act ---------------------------------------------
+    result = selector(*arguments)
+
+    # --- assert ------------------------------------------
+    assert isinstance(result, CountedFloat)  # contagion survives even when the plain operand wins
+    assert float(result) == STDLIB_MATH_FUNCTIONS[fname](*(float(a) for a in arguments))
+    assert thread_counter.COMP == 1  # compare-and-select, charged on every regime
+    assert thread_counter.total_count() == 1
+
+
+@needs_py315_math
+@pytest.mark.parametrize("fname", ["fmax", "fmin"])
+def test_math_fmax_and_fmin_without_counted_operands_count_nothing(thread_counter, fname):
+    # --- act ---------------------------------------------
+    result = getattr(math, fname)(2.0, 3.0)
+
+    # --- assert ------------------------------------------
+    assert type(result) is float  # delegated whole: neither wrapped nor counted
+    assert result == STDLIB_MATH_FUNCTIONS[fname](2.0, 3.0)
+    assert thread_counter.total_count() == 0
+
+
+@needs_py315_math
+@pytest.mark.parametrize("classifier_name", ["isnormal", "issubnormal"])
+@pytest.mark.parametrize(
+    "value",
+    [1.0, 0.0, -0.0, 5e-324, sys.float_info.min, math.inf, math.nan],
+    ids=repr,
+)
+def test_math_isnormal_and_issubnormal_count_abs_and_two_comps(thread_counter, classifier_name, value):
+    # --- arrange -----------------------------------------
+    classifier = getattr(math, classifier_name)
+
+    # --- act ---------------------------------------------
+    result = classifier(CountedFloat(value))
+
+    # --- assert ------------------------------------------
+    assert result is STDLIB_MATH_FUNCTIONS[classifier_name](value)
+    assert type(result) is bool
+    # the FP-canonical magnitude and two bounds, charged identically on every regime -- where the
+    # Python spelling short-circuits (zeros, subnormals, NaN) it counts less, the stated gap
+    assert thread_counter.ABS == 1
+    assert thread_counter.COMP == 2
+    assert thread_counter.total_count() == 3
+
+
+@needs_py315_math
+@pytest.mark.parametrize("value", [1.0, -1.0, 0.0, -0.0, math.inf, -math.inf, math.nan], ids=repr)
+def test_math_signbit_counts_one_comp(thread_counter, value):
+    # --- act ---------------------------------------------
+    result = math.signbit(CountedFloat(value))
+
+    # --- assert ------------------------------------------
+    assert result is STDLIB_MATH_FUNCTIONS["signbit"](value)
+    assert type(result) is bool
+    # the float-domain exit every classifier pays: the copysign of the faithful float spelling is
+    # machinery that spelling needs, not work signbit does, so it is charged nothing
+    assert thread_counter.COMP == 1
+    assert thread_counter.total_count() == 1
+
+
+@needs_py315_math
+@pytest.mark.parametrize("fname", ["isnormal", "issubnormal", "signbit"])
+def test_py315_predicates_without_counted_operands_count_nothing(thread_counter, fname):
+    # --- act ---------------------------------------------
+    result = getattr(math, fname)(2.0)
+
+    # --- assert ------------------------------------------
+    assert result is STDLIB_MATH_FUNCTIONS[fname](2.0)
+    assert thread_counter.total_count() == 0
+
+
+# these cannot join _ACCUMULATING_MATH_OPS: that table is built unconditionally, and its calls
+# would not resolve below 3.15
+_PY315_ACCUMULATING_OPS = [
+    ("fmax", lambda: math.fmax(CountedFloat(2.0), 3.0), {"COMP": 1}),
+    ("fmin", lambda: math.fmin(CountedFloat(2.0), 3.0), {"COMP": 1}),
+    ("isnormal", lambda: math.isnormal(CountedFloat(2.0)), {"ABS": 1, "COMP": 2}),
+    ("issubnormal", lambda: math.issubnormal(CountedFloat(5e-324)), {"ABS": 1, "COMP": 2}),
+    ("signbit", lambda: math.signbit(CountedFloat(-2.0)), {"COMP": 1}),
+]
+
+
+@needs_py315_math
+@pytest.mark.parametrize("n_calls", [1, 2, 5])
+@pytest.mark.parametrize(
+    ("op", "per_call"),
+    [(op, counts) for _, op, counts in _PY315_ACCUMULATING_OPS],
+    ids=[i for i, _, _ in _PY315_ACCUMULATING_OPS],
+)
+def test_repeated_py315_math_ops_accumulate_their_counts(thread_counter, op, per_call: dict[str, int], n_calls: int):
+    # --- act ---------------------------------------------
+    for _ in range(n_calls):
+        op()
+
+    # --- assert ------------------------------------------
+    for field, count in per_call.items():
+        assert getattr(thread_counter, field) == n_calls * count
+    assert thread_counter.total_count() == n_calls * sum(per_call.values())
 
 
 # =================================================================================================

--- a/tests/counting/test_math_patching_property.py
+++ b/tests/counting/test_math_patching_property.py
@@ -27,6 +27,8 @@ _ARITY = {
     "copysign": 2,
     "remainder": 2,
     "isclose": 2,
+    "fmax": 2,
+    "fmin": 2,
 }  # others take one operand
 # the sequence-taking functions get a two-element sequence per argument instead of bare scalars
 _SEQUENCE_ARGS = {


### PR DESCRIPTION
**TL;DR**: Python 3.15 adds `fmax`, `fmin`, `isnormal`, `issubnormal` and `signbit` to `math`. All five are now instrumented, and the cost model gains the rule that settles how they are priced.

## Description

### Problem addressed

The **patching partition must stay exhaustive**: every public `math` callable belongs to exactly one of the three classification tables, and a test holds the code to that — precisely so a function a future CPython adds cannot become a silently uncounted hole. CPython 3.15 adds five, so that test fails there today.

Left unclassified, each one would break counting in its own way: `fmax`/`fmin` return a plain `float`, ending countedness mid-algorithm, and the three predicates would ask a question about a counted value and charge nothing for it.

### Implementation

Five counting replacements, registered per name behind a `hasattr` gate so the tables stay exact on every supported interpreter and the capture/restore lifecycle keeps working unchanged.

The tallies, each derived from the FP-canonical form of what the operation does:

- **`fmax` / `fmin` → COMP.** A port selects the larger operand, which is the compare-and-select machinery the COMP weight is measured on. They share that price with the builtin `min`/`max` while being a *different value function* — they return the non-NaN operand where the builtins propagate the NaN — so the cost model now says so explicitly. Unlike the builtins they also keep countedness alive, since the patch wraps a freshly built result whichever operand wins.
- **`isnormal` / `issubnormal` → ABS + 2 COMP**, the magnitude and the two bounds of `DBL_MIN ≤ |x| ≤ DBL_MAX` and `0 < |x| < DBL_MIN`.
- **`signbit` → COMP.** Its question has no FP form to decompose, so only the exit every classifier pays for its `bool` remains.

That last one is what the **cost-model amendment** exists for: one sentence drawing the boundary *within* the priced domain — priced is the work an operation does, never machinery a float-only spelling of it would need. The classifier family also joins the decomposed-operations inventory, which had listed none of it.

One CI change travels with the code rather than separately: **the pre-release leg now feeds the coverage combine**. Version-gated code whose only home is that interpreter has no other leg to be covered from, and the cumulative 100% floor admits no exceptions — so the upload has to arrive with the code it covers, or the floor is missed by exactly these five patches.

## Attention points

- **`signbit`'s price is the one genuinely contested call.** An earlier draft priced it COPYSIGN + COMP, transcribed from its only faithful float spelling `copysign(1.0, x) < 0.0`. That lands at 2.14 against `isinf`/`isfinite` at 1.68 — the model's dearest classifier for what is, in hardware, the cheapest of them (a two-instruction bit test). The inversion is what exposed the error: that copysign exists to make `-0.0`'s sign visible to a comparison, and is not work `signbit` performs.
- **`isnormal`/`issubnormal` charge a fixed price where the Python spelling short-circuits**, so they count more than a hand-written chained comparison does on zeros, subnormals and NaN. Documented as a stated gap in the same mold as `math.isclose`'s guards.
- **No constant folds, deliberately.** Every candidate fails the bit-level exactness test the model applies: `fmax(x, ±inf)` is not an identity for a signaling NaN operand, which comes back quieted rather than untouched.
- **The pre-release leg is still non-blocking here**, so its result reads as a passing check either way — it uploads coverage without yet gating on its own outcome. The suite was run against 3.15.0b4 directly instead; see below.
- **Nothing pins implementation-defined behavior.** NaN result signs, signaling-NaN payloads and `±0.0` outcomes diverge across platforms, so no test asserts one.

## Tests / Spikes

- **SPIKE:** measured all five on CPython 3.15.0b4 at the bit level — NaN quieting in both operand orders, signed-zero order-independence, signaling-NaN payloads, int coercion, keyword rejection. This is what rules the folds out and fixes each canonical form.
- **SPIKE:** compiled each canonical form with clang for arm64 and x86-64. `fmax` is one `fmaxnm` on ARM but an eight-instruction blend on x86-64, since SSE2's `maxsd` has the wrong NaN and signed-zero behavior — which is why the price rests on the canonical stream rather than on an instruction count.
- **TEST:** full suite green on 3.13 (2330 passed) and on a 3.15.0b4 base install (2225 passed, and the partition test now passes there).
- **TEST:** CI proved the coverage point rather than the argument doing it — without the pre-release leg's upload, the combined report came to 98.61% against the 100% floor, the shortfall being exactly these five patches.
- **87 test cases added** across six parametrized functions: registration parity per callable, per-regime tallies including NaN and both zeros, plain-operand delegation, accumulation across repeated calls, and the version-gated stand-ins — that last test generalized from two hand-written cases to all seven.

## Changelog entry

Under `### Added`:

```
- on Python 3.15, the new `math` callables are counted: `fmax`/`fmin` (COMP each), `isnormal`/`issubnormal` (ABS + 2 COMP each) and `signbit` (COMP)
```

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

