### PR TITLE
docs: publish what is pending removal

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,0 +1,72 @@
+# Deprecations
+
+What is scheduled to be removed, and what to use instead.
+
+Everything listed here still works today. Each entry keeps working for the rest
+of the `2.x` series and is removed at **the next major release** — that is the
+whole of the commitment: no date is promised, and no other removal is planned.
+When this page is empty, nothing is pending.
+
+This is the live inventory. The [changelog](changelog.md) records *when* each
+name was deprecated; this page records what is *still* deprecated, and shrinks
+as entries are removed.
+
+## Pending removal at the next major
+
+All three were deprecated in **2.1.0**, and are renames rather than withdrawals
+— the functionality stays, under a name that says what it does. Each measures
+this library's own overhead, which the old names described as benchmarking a
+machine.
+
+### The `numba` extra → `benchmarking`
+
+```
+pip install counted-float[numba]         # deprecated
+pip install counted-float[benchmarking]  # use this
+```
+
+The old extra resolves to exactly the same dependency set, so nothing about an
+existing install changes until it is removed.
+
+**This is the one entry you cannot be warned about at runtime.** An extra is
+packaging metadata, not code, so nothing runs and nothing can print a notice —
+an install string left unchanged simply stops resolving at the next major.
+Anything pinning `counted-float[numba]` is worth updating now.
+
+### The `benchmark-counted-float` command → `evaluate-overhead`
+
+```bash
+counted_float benchmark-counted-float   # deprecated
+counted_float evaluate-overhead         # use this
+```
+
+The old name still runs and delegates to the new one, printing a notice to
+stderr. It is hidden from `--help`, since it exists for command lines already
+written rather than for new ones. See the
+[CLI reference](cli.md) for what the command does.
+
+### `run_counted_float_benchmark` → `evaluate_counting_overhead`
+
+```python
+from counted_float.benchmarking import run_counted_float_benchmark  # deprecated
+from counted_float.evaluation import evaluate_counting_overhead     # use this
+```
+
+The old name still resolves from `counted_float.benchmarking` and raises a
+`DeprecationWarning` once per process. The function itself is unchanged — it
+moved to `counted_float.evaluation`, alongside the rest of the library's
+self-measurement.
+
+Note that `DeprecationWarning` is silent by default in Python. To see it, run
+with warnings enabled:
+
+```bash
+python -W default::DeprecationWarning your_script.py
+```
+
+## What is not on this list
+
+**Nothing else is scheduled for removal.** The public API is deliberately small
+and is not expected to shed anything beyond the three names above. Behavior that
+falls outside the counting model is not a deprecation — it is documented, and
+stays documented, under [known limitations](known_limitations.md).

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,72 +1,33 @@
 # Deprecations
 
-What is scheduled to be removed, and what to use instead.
+Everything below still works today, and is removed in **3.0.0** (no timeline
+pinned). Nothing else is scheduled for removal.
 
-Everything listed here still works today. Each entry keeps working for the rest
-of the `2.x` series and is removed at **the next major release** — that is the
-whole of the commitment: no date is promised, and no other removal is planned.
-When this page is empty, nothing is pending.
-
-This is the live inventory. The [changelog](changelog.md) records *when* each
-name was deprecated; this page records what is *still* deprecated, and shrinks
-as entries are removed.
-
-## Pending removal at the next major
-
-All three were deprecated in **2.1.0**, and are renames rather than withdrawals
-— the functionality stays, under a name that says what it does. Each measures
-this library's own overhead, which the old names described as benchmarking a
-machine.
-
-### The `numba` extra → `benchmarking`
+## The `numba` extra → `benchmarking`
 
 ```
-pip install counted-float[numba]         # deprecated
-pip install counted-float[benchmarking]  # use this
+pip install counted-float[benchmarking]   # replaces counted-float[numba]
 ```
 
-The old extra resolves to exactly the same dependency set, so nothing about an
-existing install changes until it is removed.
+Same dependency set. The one entry that cannot warn: an extra is packaging
+metadata, no code runs — an unchanged install string simply stops resolving in
+3.0.0, so update pins now.
 
-**This is the one entry you cannot be warned about at runtime.** An extra is
-packaging metadata, not code, so nothing runs and nothing can print a notice —
-an install string left unchanged simply stops resolving at the next major.
-Anything pinning `counted-float[numba]` is worth updating now.
-
-### The `benchmark-counted-float` command → `evaluate-overhead`
+## The `benchmark-counted-float` command → `evaluate-overhead`
 
 ```bash
-counted_float benchmark-counted-float   # deprecated
-counted_float evaluate-overhead         # use this
+counted_float evaluate-overhead   # replaces benchmark-counted-float
 ```
 
-The old name still runs and delegates to the new one, printing a notice to
-stderr. It is hidden from `--help`, since it exists for command lines already
-written rather than for new ones. See the
-[CLI reference](cli.md) for what the command does.
+The old name still runs, delegates, and prints a notice to stderr; it is hidden
+from `--help`.
 
-### `run_counted_float_benchmark` → `evaluate_counting_overhead`
+## `run_counted_float_benchmark` → `evaluate_counting_overhead`
 
 ```python
-from counted_float.benchmarking import run_counted_float_benchmark  # deprecated
-from counted_float.evaluation import evaluate_counting_overhead     # use this
+from counted_float.evaluation import evaluate_counting_overhead
+# replaces: from counted_float.benchmarking import run_counted_float_benchmark
 ```
 
-The old name still resolves from `counted_float.benchmarking` and raises a
-`DeprecationWarning` once per process. The function itself is unchanged — it
-moved to `counted_float.evaluation`, alongside the rest of the library's
-self-measurement.
-
-Note that `DeprecationWarning` is silent by default in Python. To see it, run
-with warnings enabled:
-
-```bash
-python -W default::DeprecationWarning your_script.py
-```
-
-## What is not on this list
-
-**Nothing else is scheduled for removal.** The public API is deliberately small
-and is not expected to shed anything beyond the three names above. Behavior that
-falls outside the counting model is not a deprecation — it is documented, and
-stays documented, under [known limitations](known_limitations.md).
+The old import still resolves and raises a `DeprecationWarning` (silent by
+default — `python -W default::DeprecationWarning ...` shows it).

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,3 +52,5 @@ Extras compose, so `counted-float[benchmarking,cli]` gets you everything.
   command-line tool.
 - [Known limitations](known_limitations.md) — what falls outside the counting
   model.
+- [Deprecations](deprecations.md) — the names scheduled for removal at the next
+  major, and what replaces them.

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,5 +52,5 @@ Extras compose, so `counted-float[benchmarking,cli]` gets you everything.
   command-line tool.
 - [Known limitations](known_limitations.md) — what falls outside the counting
   model.
-- [Deprecations](deprecations.md) — the names scheduled for removal at the next
-  major, and what replaces them.
+- [Deprecations](deprecations.md) — the names scheduled for removal in 3.0.0,
+  and what replaces them.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Benchmarking: benchmarking.md
   - CLI reference: cli.md
   - Known limitations: known_limitations.md
+  - Deprecations: deprecations.md
   - Reference:
       - FLOP types: flop_types.md
       - Built-in data: builtin_data.md


### PR DESCRIPTION
**Problem**: Three names have been deprecated since 2.1.0, and each announces itself only where it is implemented — a packaging comment, a hidden command's stderr line, a module shim's warning. A user cannot see the set whole.

**Solution**: One page, `Deprecations`, in the nav after Known limitations and linked from the index. Each entry gives the old name, its replacement, and how it signals today. It complements the changelog rather than repeating it: the changelog records *when* each was deprecated, this page is the live inventory of what is still pending, and it empties when the major lands.

- **Attention:** the `numba` extra is the entry that most needs this. An extra is packaging metadata, so no code runs and **no warning is possible** — an unchanged install string gives no signal at all until it stops resolving. That is called out explicitly on the page.
- **Attention:** hand-written, with no generated block and no drift test. The set has been stable since 2.1.0 and empties at the next major, so the machinery would outlive what it guards. The cost is accepted: nothing fails if a future deprecation is added and not listed here.
- **TEST:** verified every claim against the package rather than from the source comments — the CLI alias runs, warns on stderr and is absent from `--help`; the Python alias warns and is the identical function object; the old extra still resolves. This caught the invocation being spelled `counted-float` where the console script is `counted_float`.
- **TEST:** strict `mkdocs build` passes (no broken links or anchors), and the page was read back rendered to check the nav placement and section order.

**Changelog**: none — documentation only, no user-facing behavior change.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
