### PR TITLE
chore: move the pre-release pin to 3.15.0rc1

### DIFF
--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -72,10 +72,10 @@ jobs:
       # uv never auto-downloads a pre-release for a bare version request, so the shared action
       # below can only resolve this interpreter once it is already installed
       - name: Install the pinned pre-release interpreter
-        run: uv python install 3.15.0b4
+        run: uv python install 3.15.0rc1
       - uses: ./.github/actions/unit_test
         with:
-          python_version: "3.15.0b4"
+          python_version: "3.15.0rc1"
           include_all_extra_deps: "false"
           coverage: "true"
 


### PR DESCRIPTION
**Problem**: The gating pre-release leg is pinned to 3.15.0b4, and 3.15.0rc1 is out. The pin exists precisely so this bump happens as a deliberate commit — this is that commit, previously blocked because no released uv carried an interpreter index containing the rc build.

**Solution**: Move the pin (install step + test-action input) to `3.15.0rc1`. Nothing else changes; the leg's comment already documents the cadence.

- **TEST:** full suite run locally on 3.15.0rc1 — 2225 passed, 22 skipped, including the math-surface partition test, so the feature-frozen surface is confirmed unchanged.
- **TEST:** verified `uv python install 3.15.0rc1` resolves under uv 0.12.2, and that a per-operation counting sweep produces bit-identical results on rc1 and b4.

**Changelog**: none — CI configuration, no user-facing effect.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
