### PR TITLE
chore: retire make format; make lint now fixes as it goes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         pass_filenames: true
       - id: ruff
         name: ruff check
-        # --fix lets pre-commit be run to fix; it still blocks, since it detects rewritten files.
+        # --fix lets pre-commit be run to fix; it still blocks, since pre-commit detects rewritten files.
         entry: uv run ruff check --fix
         language: system
         types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,8 @@ repos:
         pass_filenames: true
       - id: ruff
         name: ruff check
-        entry: uv run ruff check
+        # --fix lets pre-commit be run to fix; it still blocks, since it detects rewritten files.
+        entry: uv run ruff check --fix
         language: system
         types: [python]
         files: ^(src|tests|scripts)/|^\.github/scripts/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,7 @@ installs pre-commit hooks.
 
 ```bash
 make test     # Run the test suite (pytest)
-make lint     # Run all pre-commit checks (format, ruff, ty, hygiene)
-make format   # Format and auto-fix with ruff
+make lint     # Run all pre-commit checks (format, ruff, ty, hygiene); formats and applies ruff fixes as it goes
 ```
 
 ## Development workflow

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-file_path=
-
 # Comments sit above their target rather than inside the recipe: CI runs the test targets on
 # Windows too, where make drives cmd.exe, which does not understand `#`.
 

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,10 @@ help:
 	@echo ''
 	@echo '  test		                    Run pytest unit tests.'
 	@echo '  test-collect-ids               List the collected test node-ids (CI unions these across matrix legs).'
-	@echo '  lint		                    Run all pre-commit hooks on all files.'
+	@echo '  lint		                    Run all pre-commit hooks on all files. Formats and applies ruff fixes as it goes.'
 	@echo '  mutation		                Run local mutation testing (mutmut). MODULE=<substr> scopes it.'
 	@echo '  mutation-results	            List the surviving mutants from the last mutation run.'
 	@echo '  mutation-stats	                Export the last mutation run'"'"'s tallies as JSON (used by the release badge).'
-	@echo '  format		                    Format source code using ruff.'
-	@echo '  format-single-file             Format single file using ruff. Useful in e.g. PyCharm to automatically trigger formatting on file save.'
 	@echo ''
 	@echo '  precompute-weights            Regenerate the shipped consensus flop weights from the built-in source data.'
 	@echo '  regen-docs                    Regenerate the dataset-derived docs content (marked text blocks + screenshots).'
@@ -43,7 +41,6 @@ help:
 	@echo ''
 	@echo 'Options:'
 	@echo ''
-	@echo '  format-single-file             - accepts `file_path=<path>` to pass the relative path of the file to be formatted.'
 	@echo '  test, test-collect-ids         - accept PYTHON=<x.y>, RESOLUTION=highest|lowest-direct, ALL_EXTRAS=true|false, PYTEST_ARGS=<args>.'
 	@echo '  lint                           - accepts PRE_COMMIT_ARGS=<args>.'
 
@@ -65,14 +62,6 @@ test-collect-ids:
 lint:
 	uv sync --locked --all-extras
 	uv run pre-commit run --all-files $(PRE_COMMIT_ARGS)
-
-format:
-	uv run ruff format .;
-	uv run ruff check --fix .;
-
-format-single-file:
-	uv run ruff format ${file_path};
-	uv run ruff check --fix ${file_path};
 
 # local mutation testing over _core (config in [tool.mutmut]); MODULE=<substr> scopes to matching mutants
 mutation:


### PR DESCRIPTION
**Problem**: Ruff 0.16 added `*.md` to its default include, so the repo-wide `ruff format` behind `make format` started rewriting the Python snippets in the README and the docs pages — aligned result comments collapse, spacing around `**` disappears. Those snippets are written for a reader and verified by the docs drift tests, not by ruff.

**Solution**: remove the repo-wide entry point instead of excluding markdown. The `format` and `format-single-file` targets go; the ruff check pre-commit hook gains `--fix`, so `make lint` formats and applies fixes as it goes — and still blocks when it rewrote anything. Both ruff hooks are filename-scoped to Python under `src`, `tests` and `scripts`, so markdown structurally never reaches ruff, whatever ruff's own defaults do.

- **Attention:** `make lint` is now the one formatting entry point; there is no fix-without-gating command anymore.
- **TEST:** a scratch file with an unsorted import, run through the ruff hook: fixed in place, hook still fails the run. `make lint` and the full suite green on a clean tree.

**Changelog** (none): tooling-only change, no user-facing effect.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
