### PR TITLE
feat: compact rendering for FlopCounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `FlopCounts` now renders compactly: `str()` and `show()` list only nonzero counts (`show(weights=...)` adds a weighted-cost column), and `as_dict(nonzero_only=True)` filters zero entries
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `FlopCounts` now renders compactly: `str()` and `show()` list only nonzero counts (`show(weights=...)` adds a weighted-cost column), and `as_dict(nonzero_only=True)` filters zero entries
+- `FlopCounts` now renders compactly: `str()` and `show()` list only nonzero counts, with `show(weights=...)` adding a weighted-cost column
+- `FlopCounts.as_dict(nonzero_only=True)` returns only the nonzero counts
 
 ### Changed
 

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -273,6 +273,35 @@ counts = ctx.flop_counts()   # {FlopType.MUL: 1, FlopType.SUB: 1}
 counts.total_count()         # 2
 ```
 
+**Example 5**: _inspecting the counts_
+
+The dataclass `repr` of a `FlopCounts` object lists every flop type, zeros included; the
+renderings below show only what was actually counted.
+
+```python
+from counted_float import CountedFloat, FlopCountingContext
+
+cf1 = CountedFloat(1.73)
+cf2 = CountedFloat(2.94)
+
+with FlopCountingContext() as ctx:
+    _ = cf1 * cf2 + cf1
+
+counts = ctx.flop_counts()
+str(counts)                        # 'FlopCounts(ADD=1, MUL=1)'
+counts.as_dict(nonzero_only=True)  # {FlopType.ADD: 1, FlopType.MUL: 1}
+
+counts.show()
+# {
+#     FlopType.ADD            [x+y]             :      1
+#     FlopType.MUL            [x*y]             :      1
+#     total                                     :      2
+# }
+```
+
+Passing weights (`counts.show(weights=...)`) appends a weighted-cost column per row and a
+weighted total, using the same NaN-for-missing convention as `total_weighted_cost()`.
+
 ### Watching what gets counted
 
 A flop counting context can also report as it goes, instead of only counting. Two
@@ -283,7 +312,7 @@ levels:
 
 Both write to `stderr`, and `INFO` includes the `WARNING` lines.
 
-**Example 5**: _verbose counting_
+**Example 6**: _verbose counting_
 
 <!-- BEGIN generated: snippet-verbosity-info -->
 ```python
@@ -321,7 +350,7 @@ snippet. Three things worth knowing:
   operations logs a million lines: `INFO` is a microscope for small snippets, not
   a profiler for a whole run.
 
-**Example 6**: _reporting what could not be counted_
+**Example 7**: _reporting what could not be counted_
 
 <!-- BEGIN generated: snippet-verbosity-warning -->
 ```python
@@ -366,7 +395,7 @@ there either.
     `CountedFloat` throughout is what makes a count trustworthy; this level only
     catches the boundaries that are visible.
 
-**Example 7**: _both sides in one stream_
+**Example 8**: _both sides in one stream_
 
 `INFO` includes the `WARNING` lines, so a single run shows what was counted and
 what was lost, interleaved in the order it happened:

--- a/docs/counting_flops.md
+++ b/docs/counting_flops.md
@@ -300,7 +300,7 @@ counts.show()
 ```
 
 Passing weights (`counts.show(weights=...)`) appends a weighted-cost column per row and a
-weighted total, using the same NaN-for-missing convention as `total_weighted_cost()`.
+weighted total (NaN when a counted flop type has no weight, matching `total_weighted_cost()`).
 
 ### Watching what gets counted
 

--- a/src/counted_float/_core/models/_flop_counts.py
+++ b/src/counted_float/_core/models/_flop_counts.py
@@ -79,9 +79,16 @@ class FlopCounts:
         return FlopCounts(**{attr: getattr(self, attr) - getattr(other, attr) for attr in _FIELD_NAMES})
 
     # --- extract info ------------------------------------
-    def as_dict(self) -> dict[FlopType, int]:
-        """Return the flop counts as a dictionary with FlopType keys."""
-        return {flop_type: getattr(self, flop_type.name) for flop_type in FlopType}
+    def as_dict(self, nonzero_only: bool = False) -> dict[FlopType, int]:
+        """Return the flop counts as a dictionary with FlopType keys.
+
+        Args:
+            nonzero_only: When True, omit flop types whose count is zero.
+        """
+        counts = {flop_type: getattr(self, flop_type.name) for flop_type in FlopType}
+        if nonzero_only:
+            return {flop_type: count for flop_type, count in counts.items() if count}
+        return counts
 
     def total_count(self) -> int:
         """Sum of all flop counts."""
@@ -103,6 +110,45 @@ class FlopCounts:
         return sum(
             count * weights.weights[flop_type] for flop_type in FlopType if (count := getattr(self, flop_type.name))
         )
+
+    # --- rendering ---------------------------------------
+    def __str__(self) -> str:
+        """Render only the nonzero counts, as the constructor call that would rebuild them.
+
+        The dataclass `repr` (all fields, zeros included) stays available for debugging.
+        """
+        nonzero = ", ".join(
+            f"{flop_type.name}={count}" for flop_type in FlopType if (count := getattr(self, flop_type.name))
+        )
+        return f"FlopCounts({nonzero})"
+
+    def show(self, weights: FlopWeights | None = None) -> None:
+        """Print the nonzero counts in FlopType order, followed by a total row.
+
+        Args:
+            weights: When given, each row appends `x <weight> = <weighted cost>` and the total
+                row ends with the weighted total (NaN when a used flop type has a missing
+                weight, matching `total_weighted_cost`). When omitted, only counts are shown —
+                the active config weights are deliberately not pulled in, so plain `show()`
+                never depends on global state.
+        """
+        # same padding rule as FlopWeights.show(), so the two renderings line up when read together
+        name_pad = 4 + max(len(flop_type.long_name()) for flop_type in FlopType) + 2
+        print("{")
+        for flop_type in FlopType:
+            count = getattr(self, flop_type.name)
+            if not count:
+                continue
+            line = f"    {flop_type.long_name()}".ljust(name_pad) + f": {count:>6}"
+            if weights is not None:
+                weight = weights.weights[flop_type]
+                line += f"  x {weight:8.3f}  = {count * weight:10.3f}"
+            print(line)
+        total_line = f"    {'total'}".ljust(name_pad) + f": {self.total_count():>6}"
+        if weights is not None:
+            total_line += f"  {'':10}  = {self.total_weighted_cost(weights):10.3f}"
+        print(total_line)
+        print("}")
 
     # --- increment-target contract -----------------------
     def note(self, rationale: str) -> None:

--- a/src/counted_float/_core/models/_flop_counts.py
+++ b/src/counted_float/_core/models/_flop_counts.py
@@ -126,13 +126,13 @@ class FlopCounts:
         """Print the nonzero counts in FlopType order, followed by a total row.
 
         Args:
-            weights: When given, each row appends `x <weight> = <weighted cost>` and the total
-                row ends with the weighted total (NaN when a used flop type has a missing
-                weight, matching `total_weighted_cost`). When omitted, only counts are shown —
+            weights: When given, each row gains a weighted-cost column and the total row a
+                weighted total (NaN when a used flop type has a missing weight, matching
+                `total_weighted_cost`). When omitted, only counts are shown —
                 the active config weights are deliberately not pulled in, so plain `show()`
                 never depends on global state.
         """
-        # same padding rule as FlopWeights.show(), so the two renderings line up when read together
+        # The padding matches FlopWeights.show(), so the two renderings line up when read together.
         name_pad = 4 + max(len(flop_type.long_name()) for flop_type in FlopType) + 2
         print("{")
         for flop_type in FlopType:

--- a/tests/models/test_flop_counts.py
+++ b/tests/models/test_flop_counts.py
@@ -114,10 +114,8 @@ def test_flop_counts_as_dict_nonzero_only():
     # --- arrange -----------------------------------------
     flop_counts = FlopCounts(MUL=3, ADD=2)
 
-    # --- act ---------------------------------------------
+    # --- act / assert ------------------------------------
     nonzero = flop_counts.as_dict(nonzero_only=True)
-
-    # --- assert ------------------------------------------
     assert nonzero == {FlopType.ADD: 2, FlopType.MUL: 3}
     assert list(nonzero) == [FlopType.ADD, FlopType.MUL]
     assert FlopCounts().as_dict(nonzero_only=True) == {}

--- a/tests/models/test_flop_counts.py
+++ b/tests/models/test_flop_counts.py
@@ -135,6 +135,7 @@ def test_flop_counts_str_lists_only_nonzero_counts():
 
 
 def test_flop_counts_show_prints_nonzero_rows_and_total(capsys):
+    """show() prints one row per nonzero count plus a total row, wrapped in braces."""
     # --- arrange -----------------------------------------
     flop_counts = FlopCounts(MUL=3, ADD=2)
 
@@ -155,6 +156,7 @@ def test_flop_counts_show_prints_nonzero_rows_and_total(capsys):
 
 
 def test_flop_counts_show_with_weights_appends_cost_column(capsys):
+    """show(weights=...) appends count-times-weight per row and a weighted total."""
     # --- arrange -----------------------------------------
     flop_counts = FlopCounts(MUL=3, ADD=2)
     weights = FlopWeights(weights=dict.fromkeys(FlopType, 2.0))

--- a/tests/models/test_flop_counts.py
+++ b/tests/models/test_flop_counts.py
@@ -109,6 +109,68 @@ def test_flop_counts_as_dict():
     assert counts_as_dict == orig_data
 
 
+def test_flop_counts_as_dict_nonzero_only():
+    """nonzero_only drops exactly the zero-count entries and keeps FlopType order."""
+    # --- arrange -----------------------------------------
+    flop_counts = FlopCounts(MUL=3, ADD=2)
+
+    # --- act ---------------------------------------------
+    nonzero = flop_counts.as_dict(nonzero_only=True)
+
+    # --- assert ------------------------------------------
+    assert nonzero == {FlopType.ADD: 2, FlopType.MUL: 3}
+    assert list(nonzero) == [FlopType.ADD, FlopType.MUL]
+    assert FlopCounts().as_dict(nonzero_only=True) == {}
+
+
+def test_flop_counts_str_lists_only_nonzero_counts():
+    """str() renders the constructor call rebuilding the counts; repr keeps every field."""
+    # --- arrange -----------------------------------------
+    flop_counts = FlopCounts(MUL=3, ADD=2)
+
+    # --- act / assert ------------------------------------
+    assert str(flop_counts) == "FlopCounts(ADD=2, MUL=3)"
+    assert str(FlopCounts()) == "FlopCounts()"
+    assert "COPYSIGN=0" in repr(flop_counts)
+
+
+def test_flop_counts_show_prints_nonzero_rows_and_total(capsys):
+    # --- arrange -----------------------------------------
+    flop_counts = FlopCounts(MUL=3, ADD=2)
+
+    # --- act ---------------------------------------------
+    flop_counts.show()
+    lines = capsys.readouterr().out.splitlines()
+
+    # --- assert ------------------------------------------
+    assert lines[0] == "{"
+    assert lines[-1] == "}"
+    assert len(lines) == 5  # braces + ADD + MUL + total
+    assert "ADD" in lines[1]
+    assert lines[1].rstrip().endswith("2")
+    assert "MUL" in lines[2]
+    assert lines[2].rstrip().endswith("3")
+    assert "total" in lines[3]
+    assert lines[3].rstrip().endswith("5")
+
+
+def test_flop_counts_show_with_weights_appends_cost_column(capsys):
+    # --- arrange -----------------------------------------
+    flop_counts = FlopCounts(MUL=3, ADD=2)
+    weights = FlopWeights(weights=dict.fromkeys(FlopType, 2.0))
+
+    # --- act ---------------------------------------------
+    flop_counts.show(weights=weights)
+    lines = capsys.readouterr().out.splitlines()
+
+    # --- assert ------------------------------------------
+    assert "x" in lines[1]
+    assert lines[1].rstrip().endswith("4.000")  # 2 x 2.0
+    assert lines[2].rstrip().endswith("6.000")  # 3 x 2.0
+    assert "total" in lines[3]
+    assert lines[3].rstrip().endswith("10.000")
+
+
 def test_flop_counts_total_count():
     # --- arrange -----------------------------------------
     flop_counts = FlopCounts()


### PR DESCRIPTION
**TL;DR**: `FlopCounts` gains human-readable renderings — `str()`, `show()` (optionally weighted), and a nonzero-only `as_dict` filter — replacing the 51-field dataclass dump as the way to look at counts.

## Description

### Problem addressed

Reading counts back was the API's **worst ergonomic moment**: `repr(ctx.flop_counts())` prints a ~423-character dataclass dump of 51 fields, almost all zeros, and there was no built-in way to see just what was counted.

### Implementation

Three cold-path additions to `FlopCounts`, no counting site touched:

- **`str(counts)`** renders the constructor call that would rebuild the counts — `FlopCounts(ADD=2, MUL=3)` — listing nonzero fields only; the full dataclass `repr` stays for debugging.
- **`counts.show()`** prints the nonzero counts aligned in `FlopType` order plus a total row, matching the `FlopWeights.show()` layout so the two renderings read together. An optional `weights=` argument appends a weighted-cost column and weighted total, with NaN propagation matching `total_weighted_cost()`.
- **`as_dict(nonzero_only=True)`** filters the zero entries.

One design decision worth naming: plain `show()` deliberately does **not** fall back to the active config weights the way `total_weighted_cost()` does — rendering without an explicit `weights=` argument never depends on global state.

## Attention points

- The docs example numbering in `counting_flops.md` shifted by one (a new Example 5 slots in before the verbosity examples); the generated snippet blocks themselves are untouched.

## Tests / Spikes

- **TEST:** full suite and lint green; the doc example's hand-written output was verified byte-for-byte against the real rendering.
- 4 unit tests added (`str`, both `show` variants, the `as_dict` filter).

## Changelog entry

Added:

```
- `FlopCounts` now renders compactly: `str()` and `show()` list only nonzero counts, with `show(weights=...)` adding a weighted-cost column
- `FlopCounts.as_dict(nonzero_only=True)` returns only the nonzero counts
```


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
