### PR TITLE
fix: actionable error when from_system runs without the benchmarking extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `SystemInfo.from_system()` without the `benchmarking` extra now fails with an actionable "install the extra" message instead of a bare `ModuleNotFoundError`
+
 ### Security
 
 ## 2.5.0 (2026-08-10)

--- a/src/counted_float/_core/micro_benchmarking/_micro_benchmark.py
+++ b/src/counted_float/_core/micro_benchmarking/_micro_benchmark.py
@@ -76,10 +76,12 @@ class MicroBenchmark(ABC):
                 console.print(".", end="")
                 benchmark_runs.append(single_run_result)
 
-            # --- adjust n_ops ---
-            n_ops_min = max(1, int(n_executions / self.MAX_N_EXECUTIONS_FACTOR))
-            n_ops_max = min(int(n_executions * self.MAX_N_EXECUTIONS_FACTOR), self.MAX_N_EXECUTIONS)
-            n_executions = max(n_ops_min, min(n_ops_max, int(n_executions * n_seconds_per_run_target / t_tot_seconds)))
+            # --- adjust n_executions ---
+            n_executions_min = max(1, int(n_executions / self.MAX_N_EXECUTIONS_FACTOR))
+            n_executions_max = min(int(n_executions * self.MAX_N_EXECUTIONS_FACTOR), self.MAX_N_EXECUTIONS)
+            n_executions = max(
+                n_executions_min, min(n_executions_max, int(n_executions * n_seconds_per_run_target / t_tot_seconds))
+            )
 
         # final results
         benchmark_result = MicroBenchmarkResult(

--- a/src/counted_float/_core/models/_flop_counts.py
+++ b/src/counted_float/_core/models/_flop_counts.py
@@ -101,6 +101,9 @@ class FlopCounts:
         When omitted, the currently configured weights (see Config class) will be used.
         """
         if weights is None:
+            # get_active_flop_weights is imported lazily here, an accepted upward dependency
+            # (models -> counting.config) confined to the None-weights fallback. Pass `weights`
+            # explicitly, as show() does, to keep the call independent of global config.
             from counted_float._core.counting.config import get_active_flop_weights
 
             weights = get_active_flop_weights()

--- a/src/counted_float/_core/models/_flops_benchmark_meta_data.py
+++ b/src/counted_float/_core/models/_flops_benchmark_meta_data.py
@@ -60,18 +60,22 @@ class ProcessorInfo(JsonReprModel):
     @classmethod
     def from_system(cls) -> ProcessorInfo:
         """Describe the running machine's processor, as stamped onto a benchmark result."""
-        # psutil, cpuinfo and the _cpu_freq helpers all sit behind the `benchmarking` extra, and
-        # this is the only method that touches them. The import is deferred so that loading the
-        # model to parse shipped data never needs the extra -- a base install ships SystemInfo
-        # (public API) without it. The models -> benchmarking dependency this creates points "up"
-        # the package tree; it is accepted because from_system runs only while benchmarking.
-        import cpuinfo
-        import psutil
+        # psutil, cpuinfo and the _cpu_freq helpers sit behind the `benchmarking` extra, which only
+        # ProcessorInfo.from_system needs. The required() guard gives a base install -- which ships
+        # SystemInfo as public API but not the extra -- an actionable message rather than a bare
+        # ModuleNotFoundError; the imports stay deferred so that loading the model to parse shipped
+        # data never pulls the extra in. The resulting upward models -> benchmarking dependency is
+        # accepted, since from_system runs only while benchmarking.
+        from counted_float._core.compatibility import Capability
 
-        from counted_float._core.benchmarking.flops._cpu_freq import (
-            get_cpu_frequency_mhz_max,
-            get_cpu_frequency_mhz_min,
-        )
+        with Capability.FLOPS_BENCHMARKING.required():
+            import cpuinfo
+            import psutil
+
+            from counted_float._core.benchmarking.flops._cpu_freq import (
+                get_cpu_frequency_mhz_max,
+                get_cpu_frequency_mhz_min,
+            )
 
         cpu_info_dict = cpuinfo.get_cpu_info()
         return ProcessorInfo(

--- a/src/counted_float/_core/models/_flops_benchmark_meta_data.py
+++ b/src/counted_float/_core/models/_flops_benchmark_meta_data.py
@@ -60,8 +60,11 @@ class ProcessorInfo(JsonReprModel):
     @classmethod
     def from_system(cls) -> ProcessorInfo:
         """Describe the running machine's processor, as stamped onto a benchmark result."""
-        # both imported here rather than at module level: this is the only place either is used, and
-        # it runs while benchmarking -- whereas the model itself is loaded to parse the shipped data
+        # psutil, cpuinfo and the _cpu_freq helpers all sit behind the `benchmarking` extra, and
+        # this is the only method that touches them. The import is deferred so that loading the
+        # model to parse shipped data never needs the extra -- a base install ships SystemInfo
+        # (public API) without it. The models -> benchmarking dependency this creates points "up"
+        # the package tree; it is accepted because from_system runs only while benchmarking.
         import cpuinfo
         import psutil
 

--- a/src/counted_float/_core/utils/_rounding.py
+++ b/src/counted_float/_core/utils/_rounding.py
@@ -59,7 +59,7 @@ def round_number(value: float, mode: Literal["nearest_int", "10%"] | None) -> fl
             return value
 
 
-def _round_to_log_nearest(value: float, candidate_value: list[float]) -> float:
-    """Return candidate_value that is log-closest to value, assuming all are >0."""
+def _round_to_log_nearest(value: float, candidate_values: list[float]) -> float:
+    """Return the candidate value that is log-closest to value, assuming all are >0."""
     log_value = math.log(value)
-    return min(candidate_value, key=lambda cand: abs(math.log(cand) - log_value))
+    return min(candidate_values, key=lambda cand: abs(math.log(cand) - log_value))

--- a/tests/benchmarking/test_flops_guard.py
+++ b/tests/benchmarking/test_flops_guard.py
@@ -18,6 +18,7 @@ import pytest
 
 from counted_float._core import benchmarking
 from counted_float._core.compatibility import Capability, MissingCapabilityError
+from counted_float._core.models._flops_benchmark_meta_data import ProcessorInfo
 from tests._capabilities import needs
 
 _BLOCK_BENCHMARKING_MODULES = """
@@ -132,6 +133,14 @@ def test_the_guard_refuses_before_importing_anything(extra_not_installed, monkey
         benchmarking.run_flops_benchmark()
 
     assert "counted_float._core.benchmarking.flops" not in sys.modules
+
+
+def test_stamping_the_running_machine_names_the_extra_that_installs_it(extra_not_installed):
+    # ProcessorInfo.from_system reaches the benchmarking-only cpu probes; without the extra the call
+    # must name what to install rather than surface a bare ModuleNotFoundError
+    # --- act / assert ------------------------------------
+    with pytest.raises(MissingCapabilityError, match=re.escape(f"counted-float[{Capability.FLOPS_BENCHMARKING}]")):
+        ProcessorInfo.from_system()
 
 
 # =================================================================================================


### PR DESCRIPTION
**TL;DR**: A no-extras install now gets an actionable error when it reaches the benchmarking-only `from_system`; alongside, two accepted upward imports are documented and two names aligned.

## Description

### Problem addressed

`SystemInfo.from_system()` is public API shipped in the base install, but it reaches benchmarking-only code (`cpuinfo`, `psutil`, `_cpu_freq`). A plain install calling it hit a bare `ModuleNotFoundError`, saying nothing about the `benchmarking` extra. Separately, two `models` modules reach "up" into `counting.config` and `benchmarking` via deferred imports with no note that the upward dependency is deliberate, and two identifiers named themselves against what they hold (`candidate_value` for a list, `n_ops_*` for execution counts).

### Implementation

Guard the extra-only imports in `ProcessorInfo.from_system` with the existing `Capability.FLOPS_BENCHMARKING.required()` context manager, which raises a `MissingCapabilityError` (an `ImportError` subclass) naming the extra to install. Comment each deferred upward import as an accepted, gated exception. Rename the mislabeled list parameter and the `run_many` bounds to match each site's own vocabulary.

## Attention points

- **Only one behavior change** — the clearer error. It stays an `ImportError` subclass, so any existing `except ImportError` still catches it. The rest is comments plus local-variable and parameter renames.
- **`models → compatibility`** is a new (deferred) import — a stdlib-only leaf, so it adds no cycle.

## Tests / Spikes

- **TEST:** full suite green with and without extras — 4866 passed (extras) / 4660 passed (no extras); `make lint` clean.
- **1 unit test added** — asserts `ProcessorInfo.from_system()` names the `benchmarking` extra when it is absent. This path was previously untested: the existing `from_system` tests `importorskip` on the very modules the guard checks for, so they skip in exactly the no-extras run where the guard fires.

## Changelog entry

Under **Fixed**:
```
- `SystemInfo.from_system()` without the `benchmarking` extra now fails with an actionable "install the extra" message instead of a bare `ModuleNotFoundError`
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
