### PR TITLE
fix: build release artifacts with the uv cache disabled

### DIFF
--- a/.github/workflows/_package_check.yml
+++ b/.github/workflows/_package_check.yml
@@ -23,6 +23,10 @@ jobs:
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          # On release runs this job's `uv build` output is what gets published; the default `auto`
+          # setting would restore a main-scoped cache that any push-to-main run can write into.
+          enable-cache: false
 
       - name: Build sdist + wheel
         run: uv build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- the published release artifacts are no longer built from a CI cache that other pushes to `main` can write into, closing a supply-chain path
+
 ## 2.5.0 (2026-08-10)
 
 ### Added


### PR DESCRIPTION
**Problem**: The reusable `build` job in `_package_check.yml` produces the exact artifact the release path publishes, yet its setup-uv used the default `auto` cache — which on hosted runners restores a `main`-scoped cache that any push-to-`main` run can write into.

**Solution**: Set `enable-cache: false` on that job's setup-uv, so the published bytes never build from a cache other runs can poison. Scoped to the `build` job (the one whose output ships); the install/test job is unaffected.

- **Attention:** The reusable workflow also runs on PRs, where the build output is discarded — so PR builds lose uv caching too, a negligible cost for a job that only runs `uv build`.
- **TEST:** `make lint` clean (actionlint, zizmor, and workflow validation all pass); no code changed, so the Python test suite is unaffected.

**Changelog** (Security):
```
- the published release artifacts are no longer built from a CI cache that other pushes to `main` can write into, closing a supply-chain path
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
