### PR TITLE
chore: harden the release build and tidy packaging config

### DIFF
--- a/.github/workflows/_package_check.yml
+++ b/.github/workflows/_package_check.yml
@@ -23,6 +23,10 @@ jobs:
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          # On release runs, this job's `uv build` output gets published; the default `auto` setting
+          # would restore a main-scoped cache that any push-to-main run can write into.
+          enable-cache: false
 
       - name: Build sdist + wheel
         run: uv build

--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,7 @@ Thumbs.db
 .idea
 .vscode
 
-# AI agent working files (also in the maintainer's global gitignore; kept here too so any
-# checkout on a machine without that global ignore is still covered)
+# AI agent working files
 CLAUDE.md
 .claude/
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,11 @@ Thumbs.db
 .idea
 .vscode
 
+# AI agent working files (also in the maintainer's global gitignore; kept here too so any
+# checkout on a machine without that global ignore is still covered)
+CLAUDE.md
+.claude/
+
 # other local files
 .local
 # Only working_docs/README.md is committed; everything else here stays out of git.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,11 @@ description = "Count floating-point operations in Python code & benchmark relati
 # vX.Y.Z builds as exactly X.Y.Z, an untagged commit as the PEP 440 dev version
 # X.Y.(Z+1).devN+g<sha> — so dev builds self-report their provenance (config below).
 dynamic = ["readme", "version"]
+authors = [
+    { name = "Bert Pluymers" }
+]
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.11"
 # Counting only. Everything the flops benchmark suite needs -- which is everything that describes or
 # measures a machine -- sits behind the `benchmarking` extra instead, since counting numpy arrays is
@@ -26,7 +31,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     # Python versions kept in sync with .python-versions (release.py enforces this)
     "Programming Language :: Python :: 3.11",
@@ -36,6 +40,7 @@ classifiers = [
     # counting state is per-thread, so nothing is shared to race on a free-threaded build
     "Programming Language :: Python :: Free Threading :: 3 - Stable",
     "Topic :: Scientific/Engineering",
+    "Typing :: Typed",
 ]
 
 [project.scripts]
@@ -44,6 +49,7 @@ classifiers = [
 counted_float = "counted_float._core.cli_main:main"
 
 [project.urls]
+Documentation = "https://counted-float.readthedocs.io/"
 Source = "https://github.com/bertpl/counted-float"
 ChangeLog = "https://github.com/bertpl/counted-float/blob/main/CHANGELOG.md"
 Issues = "https://github.com/bertpl/counted-float/issues"


### PR DESCRIPTION
**TL;DR**: Four low-blast CI/packaging hygiene fixes, no library code:
- the release build no longer restores a poisonable uv cache
- the license is declared as an SPDX expression, dropping the deprecated trove classifier
- packaging metadata gains the `Typing :: Typed` classifier, an author, and a Documentation URL
- `.gitignore` covers the maintainer's local agent config files

## Description

### Problem addressed

Four independent CI/packaging defects, none touching library code. The package-check `build` job — whose `uv build` output the release path publishes — left setup-uv at the default `auto` cache, so it restores a `main`-scoped cache any push-to-`main` run can write into. The package declares its license only via the deprecated `License ::` trove classifier (no SPDX expression), omits the `Typing :: Typed` classifier despite shipping `py.typed`, and carries no author or Documentation URL. And `.gitignore` doesn't cover the local agent config files, relying solely on the maintainer's global ignore.

### Implementation

- **Release-build cache** — `enable-cache: false` on the `build` job's setup-uv, so the published bytes never restore from a cache.
- **License** — `license = "Apache-2.0"` + `license-files`, and the `License ::` classifier removed (Metadata 2.4 forbids an expression alongside a license classifier).
- **Metadata** — added the `Typing :: Typed` classifier, a name-only author, and the `Documentation` URL.
- **gitignore** — added the local agent config files as a second layer over the maintainer's global ignore, so any checkout that lacks it stays covered.

## Attention points

- **No user-facing change**, so no changelog entry — and a `chore/` branch, which CI does not gate on a changelog.
- **Author is name-only** (no email): closes the "no authors" gap without publishing a contact address — contact routes through the existing Issues / Source URLs.

## Tests / Spikes

- **TEST:** built the wheel and inspected its METADATA — `License-Expression: Apache-2.0`, `License-File: LICENSE`, the Typing classifier, the Documentation URL, and `Author: Bert Pluymers` with no `Author-email`.
- **TEST:** full suite green (4866 passed) and `make lint` clean (ruff, ty, toml/yaml, actionlint, zizmor).

## Changelog entry

None — CI/packaging hygiene with no user-facing effect; `chore/` branch, so no `CHANGELOG.md` entry is required.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
