### PR TITLE
chore: gate the docs build in CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -125,6 +125,21 @@ jobs:
           # ignore-vulns: |
           #   GHSA-xxxx-xxxx-xxxx  # why accepted
 
+  # Docs must build cleanly at PR time. A dead cross-link, bad nav entry, or stale reference is only a
+  # warning, which a non-strict build publishes silently — Read the Docs then serves the last good
+  # build and never signals GitHub. The strict `make docs` fails this check on any such warning.
+  docs:
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Build docs (strict)
+        run: make docs
+
   ci-gate:
     name: CI gate
     # The single stable required check on main: branch protection requires only
@@ -132,7 +147,7 @@ jobs:
     # `always()` is load-bearing — without it the gate is skipped when an
     # upstream job fails, and GitHub treats a skipped required check as passing.
     if: always()
-    needs: [preflight, pre-commit, test, package, pip-audit, codeql]
+    needs: [preflight, pre-commit, test, package, pip-audit, codeql, docs]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job did not succeed

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,14 @@ mutation-stats:
 precompute-weights:
 	uv run python scripts/generate_precomputed_weights.py
 
+# A strict build fails on any warning -- a dead link, a bad nav entry -- instead of shipping it
+# silently. It uses docs-only deps and no project, because the docs build runs no plugin that imports
+# the package, matching the Read the Docs install. The target is declared .PHONY because the `docs/`
+# source directory would otherwise mark the docs target up to date and skip it.
+.PHONY: docs
+docs:
+	uv run --only-group docs mkdocs build --strict
+
 regen-docs:
 	uv run python scripts/generate_docs_content.py
 


### PR DESCRIPTION
**Problem**: Nothing built the docs at PR time, and Read the Docs isn't strict — so a warning-level break (a dead cross-link, a bad nav entry, a stale reference) published silently: RTD serves the last good build and never signals GitHub.

**Solution**: A new `make docs` runs `mkdocs build --strict`, and a gated `docs` CI job runs it on every PR (wired into `ci-gate`), failing on any warning. The strict build also exercises the previously-untested `docs_changelog_hook.py` build hook end-to-end.

- **Attention:** Scoped to what counted-float needs — its docs are search-plugin-only and already live in a `[dependency-groups] docs` with a group-based RTD install, so no metadata move or `.readthedocs.yaml` change is needed (those matter only when docs import the package, e.g. via mkdocstrings). The build is docs-only with no project install; the target is `.PHONY` since a `docs/` source dir would otherwise skip it.
- **Attention:** No standalone unit test for the hook — mkdocs's `File.generated` needs build-time plugin state a unit test can only fake by poking internals; the strict CI build covers the hook in its real context instead.
- **TEST:** `make docs` builds strict-clean locally (exit 0, no warning backlog); `make lint` clean (actionlint, zizmor, workflow validation); full suite 4866 passed.

**Changelog** (none): None — CI hardening with no user-facing effect; `chore/` branch, so no `CHANGELOG.md` entry is required.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
