### PR TITLE
chore: harden the release PyPI check and note the changelog CI gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,8 @@ The body (optional) explains *why*, not *what*. Wrap at ~72 characters.
 ## Changelog
 
 Add an entry under the appropriate category in the `## Unreleased` section of
-[`CHANGELOG.md`](CHANGELOG.md) as part of your PR.
+[`CHANGELOG.md`](CHANGELOG.md) as part of your PR. CI requires an entry for
+`feat/` and `fix/` branches.
 
 Changelog entries are **user-facing** — write them for someone deciding whether
 to upgrade, not for someone reviewing the implementation.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -159,6 +159,10 @@ def step_5_check_pypi_doesnt_have(version: str) -> None:
     except urllib.error.HTTPError as e:
         if e.code != 404:
             fail_with_message(f"PyPI check returned HTTP {e.code}")
+    except urllib.error.URLError as e:
+        # a transport failure (DNS, connection reset, timeout) has no HTTP response to inspect, so the
+        # check can't run -- fail with a message rather than abort the release with a raw traceback
+        fail_with_message(f"could not reach PyPI to check {version}: {e.reason}")
 
 
 def step_6_check_classifiers_match() -> None:


### PR DESCRIPTION
**Problem**: Two gaps, no library code: `release.py`'s PyPI precheck caught only `HTTPError` (a network drop → raw traceback on `make release`), and `CONTRIBUTING` didn't note that CI *enforces* the changelog entry on `feat/`/`fix/` branches, so the rule read as advisory.

**Solution**: A `URLError` arm now fails with a message on a transport failure instead. And one sentence in `CONTRIBUTING`'s Changelog section states the CI enforcement.

- **Attention:** The `URLError` arm sits *after* the `HTTPError` arm deliberately — `HTTPError` subclasses `URLError`, so order matters. `release.py` isn't unit-tested (maintainer tooling), so this is verified by lint + inspection.
- **TEST:** `make lint` clean (ruff, ty, codespell); no package code changed.

**Changelog** (none): None — maintainer-tooling and contributor-doc hygiene, no user-facing effect; `chore/` branch, so no `CHANGELOG.md` entry is required.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
