### PR TITLE
chore: gate the CI test matrix against .python-versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,13 @@ repos:
         language: system
         files: ^(pyproject\.toml|uv\.lock)$
         pass_filenames: false
+      - id: python-matrix-coverage
+        name: python matrix covers .python-versions
+        entry: uv run --no-project python scripts/check_python_matrix.py
+        language: system
+        # A version added to .python-versions but not to the CI test matrix would ship untested.
+        files: ^(\.python-versions|\.github/workflows/_unit_tests\.yml)$
+        pass_filenames: false
 
   # ----------------------------------------------------------------------------
   #  Managed: file hygiene

--- a/scripts/check_python_matrix.py
+++ b/scripts/check_python_matrix.py
@@ -1,0 +1,66 @@
+"""Check that the CI test matrix covers every Python in `.python-versions`.
+
+`.python-versions` is the declared set of supported Python minors, and `scripts/release.py` ties it
+to the trove classifiers. Nothing ties `.python-versions` to what CI runs.
+
+The test matrix in `.github/workflows/_unit_tests.yml` is separate and hand-curated (each Python
+paired with resolution and extras axes, plus a free-threaded leg and a pre-release leg),
+so a version can sit in `.python-versions` and the classifiers, pass the release check, and reach PyPI
+with no test leg running on it.
+
+This check fails when a declared version has no matrix leg. It is one-directional: extra matrix legs
+(the free-threaded and pre-release legs, deliberately absent from `.python-versions`) are fine; only
+an uncovered declared version is an error.
+
+Usage:
+
+    python scripts/check_python_matrix.py    # exits non-zero if a declared version is untested
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYTHON_VERSIONS_FILE = REPO_ROOT / ".python-versions"
+UNIT_TESTS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "_unit_tests.yml"
+
+# Matrix legs quote their Python as `python: "3.11"`. The setup step's `python_version:` key and the
+# `${{ ... }}` references carry no `python:`-quoted literal, so this matches the matrix versions and
+# nothing else.
+_MATRIX_PYTHON = re.compile(r'\bpython:\s*"([^"]+)"')
+
+
+def read_declared_versions(path: Path = PYTHON_VERSIONS_FILE) -> set[str]:
+    """Return the Python minors declared in `.python-versions` (one per non-empty line)."""
+    return {line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()}
+
+
+def read_tested_versions(path: Path = UNIT_TESTS_WORKFLOW) -> set[str]:
+    """Return the Python value of every leg in the workflow's test matrix."""
+    return set(_MATRIX_PYTHON.findall(path.read_text(encoding="utf-8")))
+
+
+def uncovered_versions(declared: set[str], tested: set[str]) -> set[str]:
+    """Return declared versions with no matching matrix leg; extra tested legs are allowed."""
+    return declared - tested
+
+
+def main() -> int:
+    """Report any declared Python version the CI matrix does not test; return 1 if any."""
+    declared = read_declared_versions()
+    tested = read_tested_versions()
+    missing = uncovered_versions(declared, tested)
+    if missing:
+        print(
+            f".python-versions declares {sorted(missing)} with no matching leg in the "
+            f"{UNIT_TESTS_WORKFLOW.relative_to(REPO_ROOT)} test matrix (matrix tests {sorted(tested)}).",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"CI matrix covers all {len(declared)} declared Python versions: {sorted(declared)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/shared/test_python_matrix.py
+++ b/tests/shared/test_python_matrix.py
@@ -1,0 +1,52 @@
+"""Guards for the CI-matrix coverage check (scripts/check_python_matrix.py)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check_python_matrix.py"
+
+
+def _load_module():
+    """Import the check by path -- scripts/ is maintainer tooling, not an importable package."""
+    spec = importlib.util.spec_from_file_location("check_python_matrix", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load_module()
+
+
+def test_reads_only_quoted_matrix_python_values(tmp_path):
+    """The parser picks up quoted `python:` matrix legs and ignores every `python_version:` key."""
+    # --- arrange -----------------------------------------
+    workflow = tmp_path / "wf.yml"
+    workflow.write_text(
+        "        include:\n"
+        '          - { os: ubuntu-latest, python: "3.11", resolution: highest }\n'
+        '          - { os: ubuntu-latest, python: "3.14t", resolution: highest }\n'
+        "          python_version: ${{ matrix.python }}\n"
+        '          python_version: "3.15.0rc1"\n',
+        encoding="utf-8",
+    )
+
+    # --- act ---------------------------------------------
+    tested = _mod.read_tested_versions(workflow)
+
+    # --- assert ------------------------------------------
+    assert tested == {"3.11", "3.14t"}
+
+
+def test_uncovered_versions_flags_declared_gap_only():
+    """A declared version absent from the matrix is uncovered; an extra matrix leg is not."""
+    # --- act / assert ------------------------------------
+    assert _mod.uncovered_versions(declared={"3.11", "3.15"}, tested={"3.11", "3.14t"}) == {"3.15"}
+
+
+def test_repo_matrix_covers_declared_versions():
+    """The live repo satisfies the invariant: every declared version has a matrix leg."""
+    # --- act / assert ------------------------------------
+    assert _mod.main() == 0


### PR DESCRIPTION
**TL;DR**: A CI check fails when a Python in `.python-versions` has no test-matrix leg — closing the gap where a version could be declared, classified, and shipped to PyPI untested.

## Description

### Problem addressed

`.python-versions` is the declared set of supported Python minors, and `release.py` already ties it to the trove classifiers. But nothing tied it to what CI actually *tests*: the `_unit_tests.yml` matrix is hand-curated and independent, so a version could be added to `.python-versions` and the classifiers, pass the release check, and reach PyPI with no test leg running on it. The matrix happens to be in sync today — this closes the latent gap, not an active one.

### Implementation

`scripts/check_python_matrix.py` (stdlib-only) parses the matrix's quoted `python:` legs and the declared versions, and fails if any declared version is uncovered. It's one-directional — extra legs (free-threaded, pre-release) are fine. A `python-matrix-coverage` pre-commit hook runs it, so it fires in `make lint` and the CI `pre-commit` job whenever either file changes, completing on the CI side the `.python-versions`-to-classifiers check `release.py` already does.

## Attention points

- **Latent, not active** — the matrix covers all four declared versions today; this is prevention.
- **The parser reads only matrix `python: "X"` legs** — the `python_version:` setup key (including the quoted pre-release pin) is deliberately ignored, and a test pins that.

## Tests / Spikes

- **TEST:** 3 unit tests added — the leg parser (ignores `python_version:` keys), the one-directional gap detection, and a live-repo smoke test that the invariant holds. Full suite 4869 passed.
- **TEST:** `make lint` clean; the new hook fires and passes.

## Changelog entry

None — CI hardening with no user-facing effect; `chore/` branch, so no `CHANGELOG.md` entry is required.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
