### PR TITLE
chore: have Dependabot bump pre-commit hook versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
     # long enough for upstream compromises to surface before they can land.
     # (semver-specific cooldowns are not supported for github-actions.)
     cooldown:
-      default-days: 7  # zizmor's dependabot-cooldown floor; ~no-op at weekly cadence anyway
+      default-days: 7  # zizmor's dependabot-cooldown floor; a fresh release still waits this long
 
   - package-ecosystem: "uv"
     # Refreshes uv.lock for the runtime + dev/lint/type tooling the lockfile
@@ -40,5 +40,19 @@ updates:
       python:  # one batched PR for all Python-dependency bumps
         patterns: ["*"]
     cooldown:
-      default-days: 7  # zizmor's dependabot-cooldown floor; ~no-op at weekly cadence anyway
+      default-days: 7  # zizmor's dependabot-cooldown floor; a fresh release still waits this long
       semver-major-days: 14
+
+  - package-ecosystem: "pre-commit"
+    # Bumps the pinned `rev` of each hook in .pre-commit-config.yaml — the hook tooling rots
+    # without these bumps.
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+    groups:
+      pre-commit:  # one batched PR for all hook bumps
+        patterns: ["*"]
+    cooldown:
+      default-days: 7  # zizmor's dependabot-cooldown floor; a fresh release still waits this long


### PR DESCRIPTION
**Problem**: Dependabot watches only the `github-actions` and `uv` ecosystems, so the pinned hook `rev`s in `.pre-commit-config.yaml` (zizmor, …) never get bumped and drift out of date.

**Solution**: Add a `pre-commit` package-ecosystem to `dependabot.yml`, mirroring the existing blocks (weekly, `chore` prefix, grouped, cooldown). Dependabot gained native pre-commit support, so it now parses the config and bumps each hook's `rev`.

- **Attention:** The auto-merge workflow is **unchanged** and already covers these PRs — it keys on `dependabot[bot]` (any ecosystem), so patch/minor hook bumps auto-merge after the `CI gate` and majors wait for review. No manual toil.
- **Attention:** Also corrects a wrong comment on the three `cooldown` blocks — the 7-day floor was labeled "~no-op at weekly cadence," but a release published days before a run still waits the full 7 days, so the floor genuinely bites.
- **TEST:** `make lint` clean — the `Validate Dependabot Config (v2)` and yaml hooks pass on the new block.

**Changelog** (none): None — CI/tooling hygiene with no user-facing effect; `chore/` branch, so no `CHANGELOG.md` entry is required.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
